### PR TITLE
fix(auth): handle expired Google tokens and fix encryption

### DIFF
--- a/backend/src/controllers/sourceController.js
+++ b/backend/src/controllers/sourceController.js
@@ -1,3 +1,4 @@
+import { TokenExpiredError } from "../integrations/base/driveConnector.js";
 import SourceService from "../services/sourceService.js";
 
 const sourceService = new SourceService();
@@ -172,6 +173,13 @@ class SourceController {
       });
     } catch (error) {
       console.error("Error in testCredentials:", error);
+      if (error instanceof TokenExpiredError) {
+        return res.status(401).json({
+          success: false,
+          code: "TOKEN_EXPIRED",
+          message: "Votre session Google a expiré, veuillez vous reconnecter",
+        });
+      }
       res.status(500).json({
         success: false,
         message: "Credentials test failed",
@@ -192,6 +200,13 @@ class SourceController {
       });
     } catch (error) {
       console.error("Error in testConnection:", error);
+      if (error instanceof TokenExpiredError) {
+        return res.status(401).json({
+          success: false,
+          code: "TOKEN_EXPIRED",
+          message: "Votre session Google a expiré, veuillez vous reconnecter",
+        });
+      }
       res.status(500).json({
         success: false,
         message: "Connection test failed",
@@ -263,6 +278,13 @@ class SourceController {
       });
     } catch (error) {
       console.error("Error in getGoogleDriveFolders:", error);
+      if (error instanceof TokenExpiredError) {
+        return res.status(401).json({
+          success: false,
+          code: "TOKEN_EXPIRED",
+          message: "Votre session Google a expiré, veuillez vous reconnecter",
+        });
+      }
       res.status(500).json({
         success: false,
         message: "Failed to fetch Google Drive folders",
@@ -299,6 +321,13 @@ class SourceController {
       });
     } catch (error) {
       console.error("Error in previewGoogleDriveFiles:", error);
+      if (error instanceof TokenExpiredError) {
+        return res.status(401).json({
+          success: false,
+          code: "TOKEN_EXPIRED",
+          message: "Votre session Google a expiré, veuillez vous reconnecter",
+        });
+      }
       res.status(500).json({
         success: false,
         message: "Failed to preview Google Drive files",

--- a/backend/src/integrations/base/driveConnector.js
+++ b/backend/src/integrations/base/driveConnector.js
@@ -1,4 +1,16 @@
 /**
+ * Error thrown when OAuth credentials are expired or revoked.
+ * Controllers should catch this to return 401 instead of 500.
+ */
+export class TokenExpiredError extends Error {
+  constructor(message = "Refresh token expired or revoked") {
+    super(message);
+    this.name = "TokenExpiredError";
+    this.code = "TOKEN_EXPIRED";
+  }
+}
+
+/**
  * Interface de base pour tous les connecteurs de drives
  * Tous les connecteurs doivent hériter de cette classe
  */
@@ -106,6 +118,17 @@ class DriveConnector {
    */
   handleApiError(error, operation) {
     console.error(`${this.constructor.name} ${operation} failed:`, error);
+
+    // Detect expired/revoked OAuth tokens
+    const responseData = error.response?.data;
+    if (
+      responseData?.error === "invalid_grant" ||
+      error.response?.status === 401
+    ) {
+      throw new TokenExpiredError(
+        `${operation} failed: ${responseData?.error_description || "Refresh token expired or revoked"}`,
+      );
+    }
 
     // Enrichir l'erreur avec des informations contextuelles
     const enrichedError = new Error(`${operation} failed: ${error.message}`);

--- a/backend/src/utils/encryption.js
+++ b/backend/src/utils/encryption.js
@@ -20,7 +20,7 @@ export function encryptCredentials(data) {
     const iv = crypto.randomBytes(IV_LENGTH);
 
     // Créer le cipher
-    const cipher = crypto.createCipher(ALGORITHM, config.encryptionKey, iv);
+    const cipher = crypto.createCipheriv(ALGORITHM, config.encryptionKey, iv);
 
     // Chiffrer les données
     let encrypted = cipher.update(text, "utf8", ENCODING);
@@ -65,7 +65,7 @@ export function decryptCredentials(encryptedData) {
       .toString(ENCODING);
 
     // Créer le decipher
-    const decipher = crypto.createDecipher(ALGORITHM, config.encryptionKey, iv);
+    const decipher = crypto.createDecipheriv(ALGORITHM, config.encryptionKey, iv);
     decipher.setAuthTag(tag);
 
     // Déchiffrer

--- a/frontend/src/components/forms/FilePreview.tsx
+++ b/frontend/src/components/forms/FilePreview.tsx
@@ -10,6 +10,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { FileText, Loader2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
+import { sourcesApi } from "../../services/api";
 
 interface FilePreviewItem {
   id: string;
@@ -52,31 +53,12 @@ export function FilePreview({
 
     setLoading(true);
     try {
-      const response = await fetch("/api/sources/google-drive/preview-files", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          folder_id: folderId,
-          credentials,
-          extensions,
-        }),
-      });
-
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-
-      const result = await response.json();
-
-      if (result.success) {
-        setPreviewData(result.data);
-      } else {
-        throw new Error(
-          result.message || "Erreur lors du chargement des fichiers",
-        );
-      }
+      const data = await sourcesApi.previewGoogleDriveFiles(
+        folderId,
+        credentials,
+        extensions,
+      );
+      setPreviewData(data);
     } catch (error) {
       console.error("Error fetching file preview:", error);
       toast.error("Erreur lors du chargement de la prévisualisation");

--- a/frontend/src/components/forms/GoogleDriveFolderPicker.tsx
+++ b/frontend/src/components/forms/GoogleDriveFolderPicker.tsx
@@ -11,6 +11,7 @@ import { Separator } from "@/components/ui/separator";
 import { ChevronRight, Folder, FolderOpen, Loader2 } from "lucide-react";
 import React, { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
+import { sourcesApi } from "../../services/api";
 
 interface GoogleDriveFolder {
   id: string;
@@ -59,32 +60,11 @@ export function GoogleDriveFolderPicker({
 
       setLoading(true);
       try {
-        const response = await fetch(
-          `/api/sources/google-drive/folders?parent_id=${folderId}`,
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              credentials,
-            }),
-          },
+        const folders = await sourcesApi.getGoogleDriveFolders(
+          folderId,
+          credentials,
         );
-
-        if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
-        }
-
-        const result = await response.json();
-
-        if (result.success) {
-          setFolders(result.data);
-        } else {
-          throw new Error(
-            result.message || "Erreur lors du chargement des dossiers",
-          );
-        }
+        setFolders(folders);
       } catch (error) {
         console.error("Error fetching folders:", error);
         toast.error("Erreur lors du chargement des dossiers Google Drive");

--- a/frontend/src/hooks/useGoogleAuth.ts
+++ b/frontend/src/hooks/useGoogleAuth.ts
@@ -1,4 +1,5 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { GOOGLE_TOKEN_EXPIRED_EVENT } from "../services/api";
 import { TokenStorage } from "../services/tokenStorage";
 
 interface GoogleUser {
@@ -76,6 +77,26 @@ export function useGoogleAuth(): UseGoogleAuthReturn {
     checkAuthData();
   }, []);
 
+  const disconnect = useCallback((): void => {
+    setUser(null);
+    setError(null);
+    TokenStorage.clearCredentials();
+  }, []);
+
+  // Auto-disconnect when backend reports expired token
+  useEffect(() => {
+    const handleTokenExpired = () => {
+      console.warn("Google token expired, disconnecting...");
+      disconnect();
+      setError("Votre session Google a expiré, veuillez vous reconnecter");
+    };
+
+    window.addEventListener(GOOGLE_TOKEN_EXPIRED_EVENT, handleTokenExpired);
+    return () => {
+      window.removeEventListener(GOOGLE_TOKEN_EXPIRED_EVENT, handleTokenExpired);
+    };
+  }, [disconnect]);
+
   const connect = async (): Promise<void> => {
     setIsConnecting(true);
     setError(null);
@@ -100,12 +121,6 @@ export function useGoogleAuth(): UseGoogleAuthReturn {
       setError(err instanceof Error ? err.message : "Erreur inconnue");
       setIsConnecting(false);
     }
-  };
-
-  const disconnect = (): void => {
-    setUser(null);
-    setError(null);
-    TokenStorage.clearCredentials(); // Nettoyer les credentials persistés
   };
 
   return {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -16,6 +16,9 @@ import type {
 const API_BASE_URL = import.meta.env.VITE_API_URL;
 console.log("API_BASE_URL: ", API_BASE_URL);
 
+/** Custom event dispatched when Google OAuth token is expired/revoked */
+export const GOOGLE_TOKEN_EXPIRED_EVENT = "google-auth-expired";
+
 class ApiError extends Error {
   public status?: number;
   public data?: any;
@@ -57,6 +60,11 @@ async function fetchApi<T>(
     console.log("fetchApi: Response data:", data);
 
     if (!response.ok) {
+      // Detect expired Google token and notify the app
+      if (response.status === 401 && data.code === "TOKEN_EXPIRED") {
+        window.dispatchEvent(new CustomEvent(GOOGLE_TOKEN_EXPIRED_EVENT));
+      }
+
       throw new ApiError(
         data.message || "Une erreur est survenue",
         response.status,
@@ -165,6 +173,36 @@ export const sourcesApi = {
   // Récupérer les statistiques des sources
   getStats: async (): Promise<SourceStats> => {
     const response = await fetchApi<ApiResponse<SourceStats>>("/sources/stats");
+    return response.data;
+  },
+
+  // Lister les dossiers Google Drive
+  getGoogleDriveFolders: async (
+    parentId: string,
+    credentials: { clientId: string; clientSecret: string; refreshToken: string },
+  ): Promise<any[]> => {
+    const response = await fetchApi<ApiResponse<any[]>>(
+      `/sources/google-drive/folders?parent_id=${encodeURIComponent(parentId)}`,
+      {
+        method: "POST",
+        body: JSON.stringify({ credentials }),
+      },
+    );
+    return response.data;
+  },
+
+  // Prévisualiser les fichiers Google Drive
+  previewGoogleDriveFiles: async (
+    folderId: string,
+    credentials: { clientId: string; clientSecret: string; refreshToken: string },
+    extensions: string[],
+  ): Promise<{ totalFiles: number; convertibleFiles: number; files: any[] }> => {
+    const response = await fetchApi<
+      ApiResponse<{ totalFiles: number; convertibleFiles: number; files: any[] }>
+    >("/sources/google-drive/preview-files", {
+      method: "POST",
+      body: JSON.stringify({ folder_id: folderId, credentials, extensions }),
+    });
     return response.data;
   },
 };


### PR DESCRIPTION
## Summary
- **Backend**: Detect `invalid_grant` errors from Google OAuth and return 401 with `TOKEN_EXPIRED` code instead of generic 500 errors. Added `TokenExpiredError` class in base drive connector.
- **Frontend**: Auto-disconnect user when backend reports an expired token via a custom event system (`google-auth-expired`). Centralized Google Drive API calls (folders/preview) into `sourcesApi`, removing duplicated raw `fetch` logic from `GoogleDriveFolderPicker` and `FilePreview`.
- **Fix**: `crypto.createCipher` → `crypto.createCipheriv` in encryption utility (removed API in modern Node.js), which was blocking source creation entirely.

## Test plan
- [ ] Start app, connect Google account, browse folders, preview files — should work normally
- [ ] Manually expire/revoke the Google refresh token, then try to browse folders — should auto-disconnect and show "session expired" message instead of empty folder list
- [ ] Create a new source after re-authenticating — should succeed (encryption fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)