### PR TITLE
fix(sync): fix manual sync crash and Google Docs filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist/
 .idea/
 .cursor/
 docs/
+
+./exports

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -18,6 +18,9 @@ import fs from "fs-extra";
 
 const app = express();
 
+// Trust le premier proxy (nginx dans Docker)
+app.set("trust proxy", 1);
+
 /**
  * Configuration de l'application Express
  */

--- a/backend/src/services/monitoringService.js
+++ b/backend/src/services/monitoringService.js
@@ -12,8 +12,25 @@ class MonitoringService {
   constructor() {
     this.isRunning = false;
     this.activeMonitors = new Map();
+    this.syncInProgress = new Set();
     this.conversionService = new ConversionService();
     this.cronJob = null;
+  }
+
+  _parseAndDecryptConfig(source) {
+    const parsedConfig =
+      typeof source.config === "string"
+        ? JSON.parse(source.config)
+        : source.config;
+
+    const decryptedConfig = {
+      ...parsedConfig,
+      credentials: parsedConfig.credentials
+        ? decryptCredentials(parsedConfig.credentials)
+        : null,
+    };
+
+    return { parsedConfig, decryptedConfig };
   }
 
   async start() {
@@ -95,19 +112,7 @@ class MonitoringService {
     try {
       console.log(`🔍 Starting monitoring for: ${source.name}`);
 
-      // Parser le config JSON (Prisma SQLite retourne une string)
-      const parsedConfig =
-        typeof source.config === "string"
-          ? JSON.parse(source.config)
-          : source.config;
-
-      // Déchiffrer les credentials
-      const decryptedConfig = {
-        ...parsedConfig,
-        credentials: parsedConfig.credentials
-          ? decryptCredentials(parsedConfig.credentials)
-          : null,
-      };
+      const { decryptedConfig } = this._parseAndDecryptConfig(source);
 
       // Créer le connecteur
       const connector = DriveConnectorFactory.createConnector(
@@ -202,78 +207,92 @@ class MonitoringService {
   }
 
   async syncSource(sourceId) {
+    // Guard against concurrent syncs on the same source
+    if (this.syncInProgress.has(sourceId)) {
+      console.log(`⚠️ Sync already in progress for source: ${sourceId}`);
+      return;
+    }
+
+    this.syncInProgress.add(sourceId);
+
     try {
       const monitor = this.activeMonitors.get(sourceId);
-      let source, connector;
 
-      if (!monitor) {
+      // Always fetch fresh source data from DB
+      const source = await prisma.source.findUnique({
+        where: { id: sourceId },
+      });
+
+      if (!source) {
+        throw new Error("Source not found");
+      }
+
+      if (source.status !== "active") {
+        throw new Error("Source must be active to sync");
+      }
+
+      let connector;
+
+      if (monitor) {
+        // Sync automatique : utiliser le connecteur existant, mais rafraîchir les données source
+        connector = monitor.connector;
+        monitor.source = source;
+      } else {
         // Sync manuelle : créer un connecteur temporaire
         console.log(`🔄 Manual sync for source: ${sourceId}`);
 
-        source = await prisma.source.findUnique({
-          where: { id: sourceId },
-        });
+        const { decryptedConfig } = this._parseAndDecryptConfig(source);
 
-        if (!source) {
-          throw new Error("Source not found");
-        }
-
-        if (source.status !== "active") {
-          throw new Error("Source must be active to sync");
-        }
-
-        // Parser et déchiffrer le config
-        const parsedConfig =
-          typeof source.config === "string"
-            ? JSON.parse(source.config)
-            : source.config;
-
-        const decryptedConfig = {
-          ...parsedConfig,
-          credentials: parsedConfig.credentials
-            ? decryptCredentials(parsedConfig.credentials)
-            : null,
-        };
-
-        // Créer et authentifier le connecteur temporaire
         connector = DriveConnectorFactory.createConnector(
           source.platform,
           decryptedConfig,
         );
         await connector.authenticate();
-      } else {
-        // Sync automatique : utiliser le connecteur du monitor
-        source = monitor.source;
-        connector = monitor.connector;
       }
 
       console.log(`🔄 Syncing source: ${source.name}`);
 
-      // Parser le config si nécessaire
-      const config =
-        typeof source.config === "string"
-          ? JSON.parse(source.config)
-          : source.config;
+      // Parser le config une seule fois pour les filtres et le chemin
+      const { parsedConfig } = this._parseAndDecryptConfig(source);
 
       // Obtenir la liste des fichiers du drive
-      const sourcePath = config.sourcePath || "/";
+      const sourcePath = parsedConfig.sourcePath || "/";
       const files = await connector.listFiles(sourcePath);
 
-      // Filtrer les fichiers selon la configuration
-      const supportedExtensions = Array.isArray(config.filters?.extensions)
-        ? config.filters.extensions
-        : [".docx", ".pdf", ".doc"];
-      const excludePatterns = Array.isArray(config.filters?.excludePatterns)
-        ? config.filters.excludePatterns
-        : [];
+      // Normaliser les filtres (peuvent être des objets {"0":".docx",...} au lieu de tableaux)
+      const rawExtensions = parsedConfig.filters?.extensions;
+      const supportedExtensions = Array.isArray(rawExtensions)
+        ? rawExtensions
+        : rawExtensions && typeof rawExtensions === "object"
+          ? Object.values(rawExtensions)
+          : [".docx", ".pdf", ".doc"];
+
+      const rawExclude = parsedConfig.filters?.excludePatterns;
+      const excludePatterns = Array.isArray(rawExclude)
+        ? rawExclude
+        : rawExclude && typeof rawExclude === "object"
+          ? Object.values(rawExclude)
+          : [];
+
+      // Map Google Apps mimeTypes vers leurs extensions équivalentes
+      const googleMimeToExt = {
+        "application/vnd.google-apps.document": ".docx",
+        "application/vnd.google-apps.spreadsheet": ".xlsx",
+        "application/vnd.google-apps.presentation": ".pptx",
+      };
 
       const filteredFiles = files.filter((file) => {
-        // Vérifier l'extension
+        // Vérifier par extension du nom de fichier
         const hasValidExtension = supportedExtensions.some((ext) =>
           file.name.toLowerCase().endsWith(ext.toLowerCase()),
         );
 
-        if (!hasValidExtension) return false;
+        // Ou par mimeType Google Apps (ces fichiers n'ont pas d'extension dans leur nom)
+        const googleExt = googleMimeToExt[file.mimeType];
+        const matchesGoogleType = googleExt &&
+          supportedExtensions.some((ext) => ext.toLowerCase() === googleExt);
+
+        if (!hasValidExtension && !matchesGoogleType) return false;
 
         // Vérifier les patterns d'exclusion
         const isExcluded = excludePatterns.some((pattern) =>
@@ -285,7 +304,6 @@ class MonitoringService {
 
       console.log(`📁 Found ${filteredFiles.length} files to process`);
 
-      // Vérifier les fichiers modifiés ou nouveaux
       for (const file of filteredFiles) {
         await this.processFileChange(sourceId, file, connector);
       }
@@ -296,8 +314,10 @@ class MonitoringService {
         data: { lastSync: new Date() },
       });
 
-      // Mettre à jour le monitor
-      monitor.lastCheck = new Date();
+      // Mettre à jour le monitor si présent
+      if (monitor) {
+        monitor.lastCheck = new Date();
+      }
 
       // Log de succès
       await prisma.syncLog.create({
@@ -313,7 +333,6 @@ class MonitoringService {
       console.error(`❌ Sync failed for source ${sourceId}:`, error);
 
       try {
-        // Log d'erreur
         await prisma.syncLog.create({
           data: {
             sourceId,
@@ -328,6 +347,8 @@ class MonitoringService {
       }
 
       throw error;
+    } finally {
+      this.syncInProgress.delete(sourceId);
     }
   }
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,8 +1,5 @@
 #root {
-  max-width: 1280px;
   margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
 }
 
 .logo {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -95,23 +95,23 @@ function App() {
           <Alert className="mb-6">
             <AlertCircle className="h-4 w-4" />
             <AlertDescription>
-              Erreur lors du chargement: {sourcesError}
+              Erreur lors du chargement : {sourcesError}
             </AlertDescription>
           </Alert>
         )}
 
         {/* Stats Cards */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
-          <Card>
+          <Card className="text-center">
             <CardHeader>
-              <CardTitle className="flex items-center gap-2">
+              <CardTitle className="flex items-center justify-center gap-2">
                 <Cloud className="h-5 w-5 text-blue-500" />
-                Sources Connectées
+                Sources connectées
               </CardTitle>
             </CardHeader>
             <CardContent>
               {statsLoading ? (
-                <Skeleton className="h-8 w-16 mb-2" />
+                <Skeleton className="h-8 w-16 mb-2 mx-auto" />
               ) : (
                 <div className="text-3xl font-bold">
                   {sourceStats?.totalSources || sources.length}
@@ -128,38 +128,28 @@ function App() {
             </CardContent>
           </Card>
 
-          <Card>
+          <Card className="text-center">
             <CardHeader>
-              <CardTitle className="flex items-center gap-2">
+              <CardTitle className="flex items-center justify-center gap-2">
                 <Download className="h-5 w-5 text-green-500" />
-                Fichiers Convertis
+                Fichiers convertis
               </CardTitle>
             </CardHeader>
             <CardContent>
               <div className="text-3xl font-bold">
-                {conversionStats?.byStatus
-                  ? Object.values(conversionStats.byStatus).reduce(
-                      (a, b) => a + b,
-                      0,
-                    )
-                  : 0}
+                {conversionStats?.recent ?? 0}
               </div>
               <p className="text-sm text-muted-foreground">
-                Documents traités en Markdown
+                Dernières 24 heures
               </p>
-              {conversionStats?.recent && (
-                <p className="text-xs text-muted-foreground mt-1">
-                  {conversionStats.recent} dernières 24h
-                </p>
-              )}
             </CardContent>
           </Card>
 
-          <Card>
+          <Card className="text-center">
             <CardHeader>
-              <CardTitle className="flex items-center gap-2">
+              <CardTitle className="flex items-center justify-center gap-2">
                 <Activity className="h-5 w-5 text-orange-500" />
-                Statut Système
+                Statut système
               </CardTitle>
             </CardHeader>
             <CardContent>
@@ -174,14 +164,14 @@ function App() {
                   </Badge>
                   <p className="text-sm text-muted-foreground mt-2">
                     {monitoringStatus.isRunning
-                      ? `${monitoringStatus.activeMonitors} sources surveillées`
+                      ? `${monitoringStatus.totalActiveSources} sources surveillées`
                       : "Monitoring arrêté"}
                   </p>
                 </>
               ) : (
                 <>
-                  <Skeleton className="h-6 w-16 mb-2" />
-                  <Skeleton className="h-4 w-24" />
+                  <Skeleton className="h-6 w-16 mb-2 mx-auto" />
+                  <Skeleton className="h-4 w-24 mx-auto" />
                 </>
               )}
             </CardContent>
@@ -192,7 +182,7 @@ function App() {
         <div className="space-y-6">
           <div className="flex items-center justify-between">
             <div>
-              <h2 className="text-2xl font-semibold">Sources Documentaires</h2>
+              <h2 className="text-2xl font-semibold">Sources documentaires</h2>
               <p className="text-muted-foreground">
                 Configurez vos drives cloud et dépôts de documents
               </p>
@@ -200,7 +190,7 @@ function App() {
             <AddSourceDialog onSourceAdded={handleSourceAdded}>
               <Button>
                 <Plus className="h-4 w-4" />
-                Ajouter une Source
+                Ajouter une source
               </Button>
             </AddSourceDialog>
           </div>
@@ -236,7 +226,7 @@ function App() {
               <CardContent>
                 <Cloud className="h-16 w-16 text-muted-foreground mx-auto mb-4" />
                 <CardTitle className="mb-2">
-                  Aucune Source Documentaire
+                  Aucune source documentaire
                 </CardTitle>
                 <CardDescription className="mb-6 max-w-md mx-auto">
                   Commencez par connecter votre première source documentaire.
@@ -246,7 +236,7 @@ function App() {
                 <AddSourceDialog onSourceAdded={handleSourceAdded}>
                   <Button size="lg">
                     <Plus className="h-4 w-4" />
-                    Ajouter Votre Première Source
+                    Ajouter votre première source
                   </Button>
                 </AddSourceDialog>
               </CardContent>
@@ -274,8 +264,8 @@ function App() {
         <div className="container mx-auto px-6 py-4">
           <div className="flex items-center justify-between text-sm text-muted-foreground">
             <p>
-              Doc2AI - Convertisseur Automatique de Documentation pour
-              Développeurs
+              Doc2AI - Convertisseur automatique de documentation pour
+              développeurs
             </p>
             <div className="flex items-center gap-2">
               <p>Auto-hébergé • Sécurisé • Prêt IA</p>

--- a/frontend/src/components/dashboard/SourceCard.tsx
+++ b/frontend/src/components/dashboard/SourceCard.tsx
@@ -258,29 +258,29 @@ export function SourceCard({ source, onSync, onDelete }: SourceCardProps) {
           </div>
 
           {/* Extensions et filtres */}
-          {source.config.filters && (
-            <div className="space-y-2">
-              {source.config.filters.extensions &&
-                source.config.filters.extensions.length > 0 && (
-                  <div>
-                    <span className="text-xs text-muted-foreground">
-                      Extensions:
-                    </span>
-                    <div className="flex flex-wrap gap-1 mt-1">
-                      {source.config.filters.extensions.map((ext, index) => (
-                        <Badge
-                          key={index}
-                          variant="outline"
-                          className="text-xs"
-                        >
-                          {ext}
-                        </Badge>
-                      ))}
-                    </div>
-                  </div>
-                )}
-            </div>
-          )}
+          {source.config.filters?.extensions && (() => {
+            const exts = Array.isArray(source.config.filters.extensions)
+              ? source.config.filters.extensions
+              : Object.values(source.config.filters.extensions);
+            return exts.length > 0 ? (
+              <div>
+                <span className="text-xs text-muted-foreground">
+                  Extensions:
+                </span>
+                <div className="flex flex-wrap gap-1 mt-1">
+                  {exts.map((ext, index) => (
+                    <Badge
+                      key={index}
+                      variant="outline"
+                      className="text-xs"
+                    >
+                      {ext as string}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            ) : null;
+          })()}
 
           {/* Jobs récents */}
           {source.jobs && source.jobs.length > 0 && (


### PR DESCRIPTION
## Summary
- Fix crash on manual sync ("Cannot set properties of undefined (setting 'lastCheck')") — `monitor` is undefined for manual syncs but was accessed unconditionally
- Fix Google Docs files (native format, no file extension) being silently filtered out during sync by matching on mimeType
- Fix filters stored as objects `{"0":".docx",...}` instead of arrays not being recognized
- Add concurrent sync guard, fresh DB reads on every sync, `trust proxy` for express-rate-limit behind nginx
- Frontend: fix source count in status card, simplify conversion stats to last 24h, fix extensions display in SourceCard, normalize French casing, center stat cards

## Test plan
- [ ] Create a Google Drive source with native Google Docs files
- [ ] Click "Synchroniser maintenant" — should succeed without 500 error
- [ ] Verify files appear in the exports folder after conversion
- [ ] Check backend logs: no TypeError, no X-Forwarded-For warning
- [ ] Verify dashboard cards display correct source count and are centered