### PR TITLE
refactor(frontend): extract app layout and dashboard page

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -103,6 +103,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -3131,6 +3132,7 @@
       "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.10.0"
       }
@@ -3141,6 +3143,7 @@
       "integrity": "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3151,6 +3154,7 @@
       "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -3201,6 +3205,7 @@
       "integrity": "sha512-B7RIQiTsCBBmY+yW4+ILd6mF5h1FUwJsVvpqkrgpszYifetQ2Ke+Z4u6aZh0CblkUGIdR59iYVyXqqZGkZ3aBw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.43.0",
         "@typescript-eslint/types": "8.43.0",
@@ -3453,6 +3458,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3573,6 +3579,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001737",
         "electron-to-chromium": "^1.5.211",
@@ -3939,7 +3946,8 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -4046,6 +4054,7 @@
       "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5256,6 +5265,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5286,6 +5296,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -5298,6 +5309,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz",
       "integrity": "sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -5735,6 +5747,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5803,6 +5816,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5975,6 +5989,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.5.tgz",
       "integrity": "sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -6066,6 +6081,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,52 +1,14 @@
-import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Skeleton } from "@/components/ui/skeleton";
-import {
-  Activity,
-  AlertCircle,
-  Cloud,
-  Download,
-  Plus,
-  Settings,
-} from "lucide-react";
-import { useEffect, useState } from "react";
+import { Settings } from "lucide-react";
 import "./App.css";
 import Doc2aiLogoUrl from "./assets/doc2ai-full.svg";
-import { SourceCard } from "./components/dashboard/SourceCard";
-import { AddSourceDialog } from "./components/forms/AddSourceDialog";
-import { useConversionStats } from "./hooks/useConversions";
 import { useMonitoring } from "./hooks/useMonitoring";
-import { useSources, useSourceStats } from "./hooks/useSources";
 import AuthCallback from "./pages/AuthCallback";
+import Dashboard from "./pages/Dashboard";
 
 function App() {
-  const [refreshKey, setRefreshKey] = useState(0);
-
-  // Hooks pour les données - DOIVENT être appelés avant tout return conditionnel
-  const {
-    sources,
-    loading: sourcesLoading,
-    error: sourcesError,
-    refetch: refetchSources,
-  } = useSources();
-  const { stats: sourceStats, loading: statsLoading } = useSourceStats();
   const { status: monitoringStatus } = useMonitoring();
-  const { stats: conversionStats } = useConversionStats();
-
-  // Rafraîchir les données quand refreshKey change
-  useEffect(() => {
-    if (refreshKey > 0) {
-      refetchSources();
-    }
-  }, [refreshKey, refetchSources]);
 
   // Détecter si on est sur la page de callback OAuth
   const isAuthCallback =
@@ -54,25 +16,8 @@ function App() {
     window.location.search.includes("success=true") ||
     window.location.search.includes("data=");
 
-  // Si on est sur la page de callback, afficher seulement le composant AuthCallback
-  if (isAuthCallback) {
-    return <AuthCallback />;
-  }
-
-  const handleSourceAdded = () => {
-    setRefreshKey((prev) => prev + 1);
-  };
-
-  const handleSync = () => {
-    setRefreshKey((prev) => prev + 1);
-  };
-
-  const handleDelete = () => {
-    setRefreshKey((prev) => prev + 1);
-  };
-
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen bg-background flex flex-col">
       {/* Header */}
       <header className="border-b">
         <div className="container mx-auto px-6 py-4 flex items-center justify-between">
@@ -89,193 +34,24 @@ function App() {
       </header>
 
       {/* Main Content */}
-      <main className="container mx-auto px-6 py-8">
-        {/* Erreur globale */}
-        {sourcesError && (
-          <Alert className="mb-6">
-            <AlertCircle className="h-4 w-4" />
-            <AlertDescription>
-              Erreur lors du chargement : {sourcesError}
-            </AlertDescription>
-          </Alert>
-        )}
-
-        {/* Stats Cards */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
-          <Card className="text-center">
-            <CardHeader>
-              <CardTitle className="flex items-center justify-center gap-2">
-                <Cloud className="h-5 w-5 text-blue-500" />
-                Sources connectées
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              {statsLoading ? (
-                <Skeleton className="h-8 w-16 mb-2 mx-auto" />
-              ) : (
-                <div className="text-3xl font-bold">
-                  {sourceStats?.totalSources || sources.length}
-                </div>
-              )}
-              <p className="text-sm text-muted-foreground">
-                Sources documentaires configurées
-              </p>
-              {sourceStats && sourceStats.activeSources > 0 && (
-                <Badge variant="outline" className="mt-2">
-                  {sourceStats.activeSources} actives
-                </Badge>
-              )}
-            </CardContent>
-          </Card>
-
-          <Card className="text-center">
-            <CardHeader>
-              <CardTitle className="flex items-center justify-center gap-2">
-                <Download className="h-5 w-5 text-green-500" />
-                Fichiers convertis
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-3xl font-bold">
-                {conversionStats?.recent ?? 0}
-              </div>
-              <p className="text-sm text-muted-foreground">
-                Dernières 24 heures
-              </p>
-            </CardContent>
-          </Card>
-
-          <Card className="text-center">
-            <CardHeader>
-              <CardTitle className="flex items-center justify-center gap-2">
-                <Activity className="h-5 w-5 text-orange-500" />
-                Statut système
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              {monitoringStatus ? (
-                <>
-                  <Badge
-                    variant={
-                      monitoringStatus.isRunning ? "default" : "secondary"
-                    }
-                  >
-                    {monitoringStatus.isRunning ? "Actif" : "Inactif"}
-                  </Badge>
-                  <p className="text-sm text-muted-foreground mt-2">
-                    {monitoringStatus.isRunning
-                      ? `${monitoringStatus.totalActiveSources} sources surveillées`
-                      : "Monitoring arrêté"}
-                  </p>
-                </>
-              ) : (
-                <>
-                  <Skeleton className="h-6 w-16 mb-2 mx-auto" />
-                  <Skeleton className="h-4 w-24 mx-auto" />
-                </>
-              )}
-            </CardContent>
-          </Card>
-        </div>
-
-        {/* Document Sources Section */}
-        <div className="space-y-6">
-          <div className="flex items-center justify-between">
-            <div>
-              <h2 className="text-2xl font-semibold">Sources documentaires</h2>
-              <p className="text-muted-foreground">
-                Configurez vos drives cloud et dépôts de documents
-              </p>
-            </div>
-            <AddSourceDialog onSourceAdded={handleSourceAdded}>
-              <Button>
-                <Plus className="h-4 w-4" />
-                Ajouter une source
-              </Button>
-            </AddSourceDialog>
-          </div>
-
-          {/* Loading state */}
-          {sourcesLoading && (
-            <div className="grid gap-4">
-              {[1, 2, 3].map((i) => (
-                <Card key={i}>
-                  <CardHeader>
-                    <div className="flex items-center gap-3">
-                      <Skeleton className="h-5 w-5" />
-                      <div className="space-y-2">
-                        <Skeleton className="h-4 w-32" />
-                        <Skeleton className="h-3 w-24" />
-                      </div>
-                    </div>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="space-y-2">
-                      <Skeleton className="h-4 w-full" />
-                      <Skeleton className="h-4 w-3/4" />
-                    </div>
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
-          )}
-
-          {/* Empty State */}
-          {!sourcesLoading && sources.length === 0 && (
-            <Card className="p-12 text-center">
-              <CardContent>
-                <Cloud className="h-16 w-16 text-muted-foreground mx-auto mb-4" />
-                <CardTitle className="mb-2">
-                  Aucune source documentaire
-                </CardTitle>
-                <CardDescription className="mb-6 max-w-md mx-auto">
-                  Commencez par connecter votre première source documentaire.
-                  Support pour Microsoft SharePoint, Google Drive et autres
-                  plateformes de stockage cloud.
-                </CardDescription>
-                <AddSourceDialog onSourceAdded={handleSourceAdded}>
-                  <Button size="lg">
-                    <Plus className="h-4 w-4" />
-                    Ajouter votre première source
-                  </Button>
-                </AddSourceDialog>
-              </CardContent>
-            </Card>
-          )}
-
-          {/* Sources List */}
-          {!sourcesLoading && sources.length > 0 && (
-            <div className="grid gap-4">
-              {sources.map((source) => (
-                <SourceCard
-                  key={source.id}
-                  source={source}
-                  onSync={handleSync}
-                  onDelete={handleDelete}
-                />
-              ))}
-            </div>
-          )}
-        </div>
+      <main className="container mx-auto px-6 py-8 flex-1">
+        {isAuthCallback ? <AuthCallback /> : <Dashboard />}
       </main>
 
       {/* Footer */}
-      <footer className="border-t mt-16">
+      <footer className="border-t">
         <div className="container mx-auto px-6 py-4">
           <div className="flex items-center justify-between text-sm text-muted-foreground">
             <p>
               Doc2AI - Convertisseur automatique de documentation pour
               développeurs
             </p>
-            <div className="flex items-center gap-2">
-              <p>Auto-hébergé • Sécurisé • Prêt IA</p>
-              {monitoringStatus?.isRunning && (
-                <div className="flex items-center gap-1">
-                  <div className="h-2 w-2 bg-green-500 rounded-full animate-pulse" />
-                  <span className="text-xs">En ligne</span>
-                </div>
-              )}
-            </div>
+            {monitoringStatus?.isRunning && (
+              <div className="flex items-center gap-1">
+                <div className="h-2 w-2 bg-green-500 rounded-full animate-pulse" />
+                <span className="text-xs">En ligne</span>
+              </div>
+            )}
           </div>
         </div>
       </footer>

--- a/frontend/src/pages/AuthCallback.tsx
+++ b/frontend/src/pages/AuthCallback.tsx
@@ -1,6 +1,12 @@
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
-import { CheckCircle, Loader2, XCircle } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { ArrowLeft, CheckCircle, Loader2, XCircle } from "lucide-react";
 import React, { useEffect } from "react";
 
 const AuthCallback: React.FC = () => {
@@ -13,16 +19,11 @@ const AuthCallback: React.FC = () => {
         const error = urlParams.get("error");
 
         if (success === "true" && encodedData) {
-          // Décoder les données
           const jsonData = atob(encodedData);
           const authData = JSON.parse(jsonData);
 
-          console.log("Auth data received:", authData);
-
-          // Stocker les données dans localStorage temporairement
           localStorage.setItem("google_auth_data", JSON.stringify(authData));
 
-          // Envoyer un message à la fenêtre parent si c'est une popup
           if (window.opener) {
             window.opener.postMessage(
               {
@@ -33,7 +34,6 @@ const AuthCallback: React.FC = () => {
             );
             window.close();
           } else {
-            // Rediriger vers la page principale après un délai
             setTimeout(() => {
               window.location.href = "/";
             }, 2000);
@@ -81,60 +81,60 @@ const AuthCallback: React.FC = () => {
   const error = urlParams.get("error");
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background">
+    <div className="flex items-center justify-center flex-1">
       <Card className="w-full max-w-md">
-        <CardContent className="pt-6">
+        <CardHeader className="text-center">
           {success === "true" ? (
-            <div className="space-y-6 text-center">
-              <CheckCircle className="h-16 w-16 text-green-500 mx-auto" />
-              <div className="space-y-2">
-                <h2 className="text-2xl font-bold text-green-800">
-                  Authentification réussie !
-                </h2>
-                <p className="text-muted-foreground">
-                  Votre compte Google a été connecté avec succès.
-                </p>
+            <>
+              <div className="mx-auto mb-2">
+                <CheckCircle className="h-12 w-12 text-green-500" />
               </div>
-              <div className="flex items-center justify-center space-x-2 text-sm text-muted-foreground">
-                <Loader2 className="h-4 w-4 animate-spin" />
-                <span>Redirection automatique...</span>
-              </div>
-              <Button
-                variant="outline"
-                onClick={() => (window.location.href = "/")}
-                className="w-full"
-              >
-                Retourner à l'application
-              </Button>
-            </div>
+              <CardTitle>Authentification réussie</CardTitle>
+              <CardDescription>
+                Votre compte Google a été connecté avec succès.
+              </CardDescription>
+            </>
           ) : error ? (
-            <div className="space-y-6 text-center">
-              <XCircle className="h-16 w-16 text-destructive mx-auto" />
-              <div className="space-y-2">
-                <h2 className="text-2xl font-bold text-destructive">
-                  Erreur d'authentification
-                </h2>
-                <p className="text-muted-foreground">{error}</p>
+            <>
+              <div className="mx-auto mb-2">
+                <XCircle className="h-12 w-12 text-destructive" />
               </div>
-              <Button
-                variant="outline"
-                onClick={() => (window.location.href = "/")}
-                className="w-full"
-              >
-                Retourner à l'application
-              </Button>
-            </div>
+              <CardTitle className="text-destructive">
+                Erreur d'authentification
+              </CardTitle>
+              <CardDescription>{error}</CardDescription>
+            </>
           ) : (
-            <div className="space-y-6 text-center">
-              <Loader2 className="h-16 w-16 animate-spin text-primary mx-auto" />
-              <div className="space-y-2">
-                <h2 className="text-2xl font-bold">Traitement en cours...</h2>
-                <p className="text-muted-foreground">
-                  Veuillez patienter pendant que nous traitons votre
-                  authentification.
-                </p>
+            <>
+              <div className="mx-auto mb-2">
+                <Loader2 className="h-12 w-12 animate-spin text-primary" />
               </div>
+              <CardTitle>Traitement en cours...</CardTitle>
+              <CardDescription>
+                Veuillez patienter pendant que nous traitons votre
+                authentification.
+              </CardDescription>
+            </>
+          )}
+        </CardHeader>
+
+        <CardContent className="space-y-4">
+          {success === "true" && (
+            <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              <span>Redirection automatique...</span>
             </div>
+          )}
+
+          {(success === "true" || error) && (
+            <Button
+              variant="outline"
+              onClick={() => (window.location.href = "/")}
+              className="w-full"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Retourner à l'application
+            </Button>
           )}
         </CardContent>
       </Card>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,0 +1,228 @@
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Activity,
+  AlertCircle,
+  Cloud,
+  Download,
+  Plus,
+} from "lucide-react";
+import { useEffect, useState } from "react";
+import { SourceCard } from "../components/dashboard/SourceCard";
+import { AddSourceDialog } from "../components/forms/AddSourceDialog";
+import { useConversionStats } from "../hooks/useConversions";
+import { useMonitoring } from "../hooks/useMonitoring";
+import { useSources, useSourceStats } from "../hooks/useSources";
+
+export default function Dashboard() {
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const {
+    sources,
+    loading: sourcesLoading,
+    error: sourcesError,
+    refetch: refetchSources,
+  } = useSources();
+  const { stats: sourceStats, loading: statsLoading } = useSourceStats();
+  const { status: monitoringStatus } = useMonitoring();
+  const { stats: conversionStats } = useConversionStats();
+
+  useEffect(() => {
+    if (refreshKey > 0) {
+      refetchSources();
+    }
+  }, [refreshKey, refetchSources]);
+
+  const handleSourceAdded = () => {
+    setRefreshKey((prev) => prev + 1);
+  };
+
+  const handleSync = () => {
+    setRefreshKey((prev) => prev + 1);
+  };
+
+  const handleDelete = () => {
+    setRefreshKey((prev) => prev + 1);
+  };
+
+  return (
+    <>
+      {/* Erreur globale */}
+      {sourcesError && (
+        <Alert className="mb-6">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>
+            Erreur lors du chargement : {sourcesError}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {/* Stats Cards */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+        <Card className="text-center">
+          <CardHeader>
+            <CardTitle className="flex items-center justify-center gap-2">
+              <Cloud className="h-5 w-5 text-blue-500" />
+              Sources connectées
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {statsLoading ? (
+              <Skeleton className="h-8 w-16 mb-2 mx-auto" />
+            ) : (
+              <div className="text-3xl font-bold">
+                {sourceStats?.totalSources || sources.length}
+              </div>
+            )}
+            <p className="text-sm text-muted-foreground">
+              Sources documentaires configurées
+            </p>
+            {sourceStats && sourceStats.activeSources > 0 && (
+              <Badge variant="outline" className="mt-2">
+                {sourceStats.activeSources} actives
+              </Badge>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card className="text-center">
+          <CardHeader>
+            <CardTitle className="flex items-center justify-center gap-2">
+              <Download className="h-5 w-5 text-green-500" />
+              Fichiers convertis
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-3xl font-bold">
+              {conversionStats?.recent ?? 0}
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Dernières 24 heures
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card className="text-center">
+          <CardHeader>
+            <CardTitle className="flex items-center justify-center gap-2">
+              <Activity className="h-5 w-5 text-orange-500" />
+              Statut système
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {monitoringStatus ? (
+              <>
+                <Badge
+                  variant={
+                    monitoringStatus.isRunning ? "default" : "secondary"
+                  }
+                >
+                  {monitoringStatus.isRunning ? "Actif" : "Inactif"}
+                </Badge>
+                <p className="text-sm text-muted-foreground mt-2">
+                  {monitoringStatus.isRunning
+                    ? `${monitoringStatus.totalActiveSources} sources surveillées`
+                    : "Monitoring arrêté"}
+                </p>
+              </>
+            ) : (
+              <>
+                <Skeleton className="h-6 w-16 mb-2 mx-auto" />
+                <Skeleton className="h-4 w-24 mx-auto" />
+              </>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Document Sources Section */}
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-2xl font-semibold">Sources documentaires</h2>
+            <p className="text-muted-foreground">
+              Configurez vos drives cloud et dépôts de documents
+            </p>
+          </div>
+          <AddSourceDialog onSourceAdded={handleSourceAdded}>
+            <Button>
+              <Plus className="h-4 w-4" />
+              Ajouter une source
+            </Button>
+          </AddSourceDialog>
+        </div>
+
+        {/* Loading state */}
+        {sourcesLoading && (
+          <div className="grid gap-4">
+            {[1, 2, 3].map((i) => (
+              <Card key={i}>
+                <CardHeader>
+                  <div className="flex items-center gap-3">
+                    <Skeleton className="h-5 w-5" />
+                    <div className="space-y-2">
+                      <Skeleton className="h-4 w-32" />
+                      <Skeleton className="h-3 w-24" />
+                    </div>
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  <div className="space-y-2">
+                    <Skeleton className="h-4 w-full" />
+                    <Skeleton className="h-4 w-3/4" />
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+
+        {/* Empty State */}
+        {!sourcesLoading && sources.length === 0 && (
+          <Card className="p-12 text-center">
+            <CardContent>
+              <Cloud className="h-16 w-16 text-muted-foreground mx-auto mb-4" />
+              <CardTitle className="mb-2">
+                Aucune source documentaire
+              </CardTitle>
+              <CardDescription className="mb-6 max-w-md mx-auto">
+                Commencez par connecter votre première source documentaire.
+                Support pour Microsoft SharePoint, Google Drive et autres
+                plateformes de stockage cloud.
+              </CardDescription>
+              <AddSourceDialog onSourceAdded={handleSourceAdded}>
+                <Button size="lg">
+                  <Plus className="h-4 w-4" />
+                  Ajouter votre première source
+                </Button>
+              </AddSourceDialog>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Sources List */}
+        {!sourcesLoading && sources.length > 0 && (
+          <div className="grid gap-4">
+            {sources.map((source) => (
+              <SourceCard
+                key={source.id}
+                source={source}
+                onSync={handleSync}
+                onDelete={handleDelete}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

- **App.tsx** is now a pure layout shell (header + page content + footer), removing all dashboard logic
- **Dashboard.tsx** (new) contains the full dashboard extracted from App.tsx
- **AuthCallback.tsx** cleaned up to use shadcn Card components (CardHeader/CardTitle/CardDescription) and removed duplicated layout code — it now renders inside the shared layout
- Footer simplified: removed "Auto-hébergé - Sécurisé - Prêt IA" text, removed extra margin

## Test plan

- [ ] Verify dashboard renders correctly at `/`
- [ ] Verify auth callback page renders inside the shared layout at `/auth/callback`
- [ ] Verify footer is visible without scrolling on AuthCallback page
- [ ] Verify monitoring status indicator still shows in footer when active

🤖 Generated with [Claude Code](https://claude.com/claude-code)