### PR TITLE
refactor: translate codebase to English, clean comments and logs

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -18,21 +18,15 @@ import fs from "fs-extra";
 
 const app = express();
 
-// Trust le premier proxy (nginx dans Docker)
 app.set("trust proxy", 1);
 
-/**
- * Configuration de l'application Express
- */
 async function setupApp() {
-  console.log("🚀 Starting Doc2AI Backend...");
+  console.log("Starting Doc2AI Backend...");
 
-  // Créer les répertoires nécessaires
   await fs.ensureDir(config.storagePath);
   await fs.ensureDir(config.tempPath);
-  console.log("📁 Storage directories created");
+  console.log("Storage directories created");
 
-  // Middlewares de sécurité
   app.use(
     helmet({
       crossOriginEmbedderPolicy: false,
@@ -47,7 +41,6 @@ async function setupApp() {
     }),
   );
 
-  // CORS
   app.use(
     cors({
       origin: config.corsOrigin,
@@ -57,7 +50,6 @@ async function setupApp() {
     }),
   );
 
-  // Rate limiting
   const limiter = rateLimit({
     windowMs: config.rateLimit.windowMs,
     max: config.rateLimit.max,
@@ -71,24 +63,19 @@ async function setupApp() {
   });
   app.use("/api/", limiter);
 
-  // Parsing des requêtes
   app.use(express.json({ limit: "10mb" }));
   app.use(express.urlencoded({ extended: true, limit: "10mb" }));
 
-  // Middlewares custom
   app.use(sanitizeInput);
   app.use(extractUserInfo);
 
-  // Logging des requêtes
   app.use((req, res, next) => {
-    console.log(`📡 ${req.method} ${req.originalUrl} - ${req.ip}`);
+    console.log(`${req.method} ${req.originalUrl} - ${req.ip}`);
     next();
   });
 
-  // Routes API
   app.use("/api", apiRoutes);
 
-  // Route racine
   app.get("/", (req, res) => {
     res.json({
       name: "Doc2AI Backend",
@@ -104,7 +91,6 @@ async function setupApp() {
     });
   });
 
-  // Middleware d'erreur
   app.use(logError);
   app.use(notFoundHandler);
   app.use(errorHandler);
@@ -112,65 +98,50 @@ async function setupApp() {
   return app;
 }
 
-/**
- * Démarrage du serveur
- */
 async function startServer() {
   try {
-    // Initialiser la base de données
     await initializeDatabase();
-
-    // Configurer l'app
     await setupApp();
 
-    // Démarrer le serveur
     const server = app.listen(config.port, () => {
-      console.log(`✅ Doc2AI Backend running on port ${config.port}`);
-      console.log(`🌍 Environment: ${config.nodeEnv}`);
-      console.log(`📊 API available at: http://localhost:${config.port}/api`);
+      console.log(`Doc2AI Backend running on port ${config.port}`);
+      console.log(`Environment: ${config.nodeEnv}`);
+      console.log(`API available at: http://localhost:${config.port}/api`);
     });
 
-    // Démarrer le processeur de queue asynchrone
-    console.log("🚀 Starting queue processor...");
+    console.log("Starting queue processor...");
     try {
-      await queueService.startProcessing(3); // 3 conversions en parallèle
-      console.log("✅ Queue processor started successfully");
+      await queueService.startProcessing(3);
+      console.log("Queue processor started successfully");
     } catch (error) {
       console.error("❌ Queue processor failed to start:", error.message);
     }
 
-    // Démarrer le service de monitoring
-    console.log("🔄 Starting monitoring service...");
+    console.log("Starting monitoring service...");
     try {
       await monitoringService.start();
-      console.log("✅ Monitoring service started successfully");
+      console.log("Monitoring service started successfully");
     } catch (error) {
       console.warn("⚠️ Monitoring service failed to start:", error.message);
     }
 
-    // Gestion propre de l'arrêt
     const gracefulShutdown = async (signal) => {
-      console.log(`\n📤 Received ${signal}. Graceful shutdown...`);
+      console.log(`\nReceived ${signal}. Graceful shutdown...`);
 
-      // Arrêter le monitoring
       if (monitoringService.isRunning) {
         await monitoringService.stop();
       }
 
-      // Fermer la queue (attend que les jobs en cours se terminent)
       console.log("Closing queue...");
       await queueService.close();
 
-      // Fermer les connexions DB
       await closeDatabase();
 
-      // Fermer le serveur
       server.close(() => {
-        console.log("✅ Doc2AI Backend stopped gracefully");
+        console.log("Doc2AI Backend stopped gracefully");
         process.exit(0);
       });
 
-      // Force exit après 10 secondes
       setTimeout(() => {
         console.error(
           "❌ Could not close connections in time, forcefully shutting down",
@@ -179,11 +150,9 @@ async function startServer() {
       }, 10000);
     };
 
-    // Écouter les signaux de fermeture
     process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));
     process.on("SIGINT", () => gracefulShutdown("SIGINT"));
 
-    // Gestion des erreurs non capturées
     process.on("unhandledRejection", (reason, promise) => {
       console.error("❌ Unhandled Rejection at:", promise, "reason:", reason);
     });
@@ -200,7 +169,6 @@ async function startServer() {
   }
 }
 
-// Démarrer le serveur si ce fichier est exécuté directement
 if (import.meta.url === `file://${process.argv[1]}`) {
   await startServer();
 }

--- a/backend/src/config/database.js
+++ b/backend/src/config/database.js
@@ -3,7 +3,6 @@ import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3';
 
 let prisma
 
-// Singleton pattern pour la connexion Prisma
 function getPrismaClient() {
   if (!prisma) {
     const adapter = new PrismaBetterSqlite3({ url: process.env.DATABASE_URL });
@@ -15,16 +14,14 @@ function getPrismaClient() {
   return prisma
 }
 
-// Initialisation de la base de données
 export async function initializeDatabase() {
   try {
-    console.log('🔄 Initializing database...')
+    console.log('Initializing database...')
     
     const client = getPrismaClient()
     
-    // Test de connexion
     await client.$connect()
-    console.log('✅ Database connected successfully')
+    console.log('Database connected successfully')
     
     return client
   } catch (error) {
@@ -33,14 +30,12 @@ export async function initializeDatabase() {
   }
 }
 
-// Fermeture propre de la connexion
 export async function closeDatabase() {
   if (prisma) {
     await prisma.$disconnect()
-    console.log('🔌 Database disconnected')
+    console.log('Database disconnected')
   }
 }
 
-// Export du client
 export { getPrismaClient }
 export default getPrismaClient

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -1,10 +1,7 @@
 import dotenv from "dotenv";
 import path from "path";
 
-// Charge les variables d'environnement
 dotenv.config();
-
-// Validation des variables requises
 const requiredVars = ["JWT_SECRET", "ENCRYPTION_KEY", "DATABASE_URL"];
 
 for (const varName of requiredVars) {
@@ -15,19 +12,15 @@ for (const varName of requiredVars) {
 }
 
 const config = {
-  // Serveur
   port: parseInt(process.env.PORT) || 3000,
   nodeEnv: process.env.NODE_ENV || "development",
   corsOrigin: process.env.CORS_ORIGIN || "http://localhost:5173",
 
-  // Base de données
   databaseUrl: process.env.DATABASE_URL,
 
-  // Sécurité
   jwtSecret: process.env.JWT_SECRET,
   encryptionKey: process.env.ENCRYPTION_KEY,
 
-  // APIs externes
   microsoft: {
     clientId: process.env.MICROSOFT_CLIENT_ID,
     clientSecret: process.env.MICROSOFT_CLIENT_SECRET,
@@ -40,26 +33,21 @@ const config = {
     redirectUri: process.env.GOOGLE_REDIRECT_URI,
   },
 
-  // Redis pour les queues
   redisUrl: process.env.REDIS_URL,
 
-  // Stockage
   storagePath: path.resolve(process.env.STORAGE_PATH || "./storage"),
   tempPath: path.resolve(process.env.TEMP_PATH || "./temp"),
   exportPath: path.resolve(process.env.EXPORT_PATH || "./exports"),
 
-  // Monitoring
   logLevel: process.env.LOG_LEVEL || "info",
   syncIntervalMinutes: parseInt(process.env.SYNC_INTERVAL_MINUTES) || 15,
 
-  // Rate limiting
   rateLimit: {
     windowMs: 15 * 60 * 1000, // 15 minutes
     max: 1000, // requests per windowMs
   },
 };
 
-// Validation additionnelle
 if (config.encryptionKey.length !== 32) {
   console.error("❌ ENCRYPTION_KEY must be exactly 32 characters long");
   process.exit(1);

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -6,7 +6,6 @@ class AuthController {
     try {
       const { code, error } = req.query;
 
-      // Si l'utilisateur a refusé l'accès
       if (error) {
         return res.status(400).json({
           success: false,
@@ -15,7 +14,6 @@ class AuthController {
         });
       }
 
-      // Si pas de code d'autorisation
       if (!code) {
         return res.status(400).json({
           success: false,
@@ -24,7 +22,6 @@ class AuthController {
         });
       }
 
-      // Échanger le code contre un access token et refresh token
       const tokenResponse = await axios.post(
         "https://oauth2.googleapis.com/token",
         {
@@ -46,7 +43,6 @@ class AuthController {
       const { access_token, refresh_token, expires_in, scope } =
         tokenResponse.data;
 
-      // Vérifier que nous avons bien reçu un refresh token
       if (!refresh_token) {
         return res.status(400).json({
           success: false,
@@ -61,7 +57,6 @@ class AuthController {
         });
       }
 
-      // Optionnel : tester le token en récupérant les infos utilisateur
       try {
         const userInfoResponse = await axios.get(
           "https://www.googleapis.com/drive/v3/about?fields=user",
@@ -74,7 +69,6 @@ class AuthController {
 
         const userInfo = userInfoResponse.data.user;
 
-        // Rediriger vers le frontend avec les données encodées
         const successData = {
           refresh_token,
           access_token,
@@ -87,7 +81,6 @@ class AuthController {
           },
         };
 
-        // Encoder les données en base64 pour les passer dans l'URL
         const encodedData = Buffer.from(JSON.stringify(successData)).toString(
           "base64",
         );
@@ -99,7 +92,6 @@ class AuthController {
       } catch (userInfoError) {
         console.warn("Could not fetch user info:", userInfoError.message);
 
-        // Retourner les tokens même si on ne peut pas récupérer les infos utilisateur
         const fallbackData = {
           refresh_token,
           access_token,
@@ -107,7 +99,7 @@ class AuthController {
           scope,
           user: {
             email: "unknown@gmail.com",
-            name: "Utilisateur Google",
+            name: "Google User",
             photoLink: null,
           },
         };
@@ -127,7 +119,6 @@ class AuthController {
       let errorMessage = "OAuth callback failed";
       let errorDetails = error.message;
 
-      // Gestion des erreurs spécifiques de Google
       if (error.response?.data) {
         errorMessage =
           error.response.data.error_description ||
@@ -144,7 +135,7 @@ class AuthController {
     }
   }
 
-  // GET /api/auth/google - Générer l'URL d'autorisation
+  // GET /api/auth/google
   async getGoogleAuthUrl(req, res) {
     try {
       const baseUrl = "https://accounts.google.com/o/oauth2/v2/auth";
@@ -156,7 +147,7 @@ class AuthController {
         response_type: "code",
         scope: "https://www.googleapis.com/auth/drive",
         access_type: "offline",
-        prompt: "consent", // Force l'affichage du consentement pour obtenir un refresh token
+        prompt: "consent",
       });
 
       const authUrl = `${baseUrl}?${params.toString()}`;

--- a/backend/src/controllers/conversionController.js
+++ b/backend/src/controllers/conversionController.js
@@ -70,10 +70,9 @@ class ConversionController {
 
       const job = await conversionService.createJob(sourceId, fileName, filePath, fileSize)
       
-      // Traiter le job immédiatement (en arrière-plan)
       conversionService.processJob(job.id)
         .then(() => {
-          console.log(`✅ Job ${job.id} completed`)
+          console.log(`Job ${job.id} completed`)
         })
         .catch((error) => {
           console.error(`❌ Job ${job.id} failed:`, error)
@@ -195,7 +194,6 @@ class ConversionController {
         })
       }
 
-      // Réinitialiser le job
       const updatedJob = await conversionService.createJob(
         job.sourceId,
         job.fileName,
@@ -203,10 +201,9 @@ class ConversionController {
         job.fileSize
       )
 
-      // Traiter le nouveau job
       conversionService.processJob(updatedJob.id)
         .then(() => {
-          console.log(`✅ Retry job ${updatedJob.id} completed`)
+          console.log(`Retry job ${updatedJob.id} completed`)
         })
         .catch((error) => {
           console.error(`❌ Retry job ${updatedJob.id} failed:`, error)

--- a/backend/src/controllers/monitoringController.js
+++ b/backend/src/controllers/monitoringController.js
@@ -155,17 +155,13 @@ class MonitoringController {
   // POST /api/monitoring/restart
   async restartMonitoring(req, res) {
     try {
-      console.log('🔄 Restarting monitoring service...')
+      console.log('Restarting monitoring service...')
       
-      // Arrêter le service s'il tourne
       if (monitoringService.isRunning) {
         await monitoringService.stop()
       }
       
-      // Attendre un peu avant de redémarrer
       await new Promise(resolve => setTimeout(resolve, 1000))
-      
-      // Redémarrer
       await monitoringService.start()
       
       res.json({

--- a/backend/src/controllers/sourceController.js
+++ b/backend/src/controllers/sourceController.js
@@ -55,7 +55,6 @@ class SourceController {
     try {
       const { name, platform, config } = req.body;
 
-      // Validation basique
       if (!name || !platform || !config) {
         return res.status(400).json({
           success: false,
@@ -63,7 +62,6 @@ class SourceController {
         });
       }
 
-      // Validation du platform
       const supportedPlatforms = ["sharepoint", "googledrive", "onedrive"];
       if (!supportedPlatforms.includes(platform)) {
         return res.status(400).json({
@@ -143,7 +141,6 @@ class SourceController {
     try {
       const { platform, credentials, sourcePath, siteUrl } = req.body;
 
-      // Validation basique
       if (!platform || !credentials) {
         return res.status(400).json({
           success: false,
@@ -151,7 +148,6 @@ class SourceController {
         });
       }
 
-      // Validation du platform
       const supportedPlatforms = ["sharepoint", "googledrive", "onedrive"];
       if (!supportedPlatforms.includes(platform)) {
         return res.status(400).json({
@@ -177,7 +173,7 @@ class SourceController {
         return res.status(401).json({
           success: false,
           code: "TOKEN_EXPIRED",
-          message: "Votre session Google a expiré, veuillez vous reconnecter",
+          message: "Your Google session has expired, please reconnect",
         });
       }
       res.status(500).json({
@@ -204,7 +200,7 @@ class SourceController {
         return res.status(401).json({
           success: false,
           code: "TOKEN_EXPIRED",
-          message: "Votre session Google a expiré, veuillez vous reconnecter",
+          message: "Your Google session has expired, please reconnect",
         });
       }
       res.status(500).json({
@@ -282,7 +278,7 @@ class SourceController {
         return res.status(401).json({
           success: false,
           code: "TOKEN_EXPIRED",
-          message: "Votre session Google a expiré, veuillez vous reconnecter",
+          message: "Your Google session has expired, please reconnect",
         });
       }
       res.status(500).json({
@@ -325,7 +321,7 @@ class SourceController {
         return res.status(401).json({
           success: false,
           code: "TOKEN_EXPIRED",
-          message: "Votre session Google a expiré, veuillez vous reconnecter",
+          message: "Your Google session has expired, please reconnect",
         });
       }
       res.status(500).json({

--- a/backend/src/converters/baseConverter.js
+++ b/backend/src/converters/baseConverter.js
@@ -2,31 +2,16 @@ import fs from "fs-extra";
 import path from "path";
 import { generateFileChecksum } from "../utils/encryption.js";
 
-/**
- * Classe de base pour tous les convertisseurs
- * Tous les convertisseurs doivent hériter de cette classe
- */
 class BaseConverter {
   constructor() {
     this.name = "Base Converter";
     this.supportedExtensions = [];
   }
 
-  /**
-   * Convertit un fichier vers Markdown
-   * @param {string} inputPath - Chemin du fichier source
-   * @param {string} outputPath - Chemin de sortie du fichier Markdown
-   * @returns {Promise<{success: boolean, message?: string, checksum?: string, error?: string}>}
-   */
   async convert(_inputPath, _outputPath) {
     throw new Error("convert() method must be implemented by subclass");
   }
 
-  /**
-   * Valide qu'un fichier d'entrée existe et est lisible
-   * @param {string} filePath - Chemin du fichier
-   * @returns {Promise<boolean>} - True si le fichier est valide
-   */
   async validateInputFile(filePath) {
     try {
       const exists = await fs.pathExists(filePath);
@@ -50,17 +35,10 @@ class BaseConverter {
     }
   }
 
-  /**
-   * Prépare le fichier de sortie
-   * @param {string} outputPath - Chemin de sortie
-   * @returns {Promise<void>}
-   */
   async prepareOutputFile(outputPath) {
     try {
-      // Créer le répertoire parent s'il n'existe pas
       await fs.ensureDir(path.dirname(outputPath));
 
-      // Si le fichier existe déjà, le supprimer
       if (await fs.pathExists(outputPath)) {
         await fs.remove(outputPath);
       }
@@ -70,24 +48,13 @@ class BaseConverter {
     }
   }
 
-  /**
-   * Nettoie le contenu Markdown généré
-   * @param {string} markdown - Contenu Markdown brut
-   * @returns {string} - Contenu Markdown nettoyé
-   */
   cleanMarkdown(markdown) {
     if (!markdown) return "";
 
-    // Supprimer les lignes vides excessives
     let cleaned = markdown.replace(/\n{3,}/g, "\n\n");
-
-    // Nettoyer les espaces en fin de ligne
     cleaned = cleaned.replace(/[ \t]+$/gm, "");
-
-    // Nettoyer les espaces en début/fin de document
     cleaned = cleaned.trim();
 
-    // Assurer qu'il y a une ligne vide à la fin
     if (cleaned && !cleaned.endsWith("\n")) {
       cleaned += "\n";
     }
@@ -95,12 +62,6 @@ class BaseConverter {
     return cleaned;
   }
 
-  /**
-   * Ajoute des métadonnées au début du fichier Markdown
-   * @param {string} markdown - Contenu Markdown
-   * @param {object} metadata - Métadonnées à ajouter
-   * @returns {string} - Markdown avec métadonnées
-   */
   addMetadata(markdown, metadata = {}) {
     const defaultMetadata = {
       generated_by: "Doc2AI",
@@ -121,12 +82,6 @@ class BaseConverter {
     return metadataLines.join("\n");
   }
 
-  /**
-   * Sauvegarde le contenu Markdown dans un fichier
-   * @param {string} markdown - Contenu Markdown
-   * @param {string} outputPath - Chemin de sortie
-   * @returns {Promise<string>} - Checksum du fichier sauvegardé
-   */
   async saveMarkdown(markdown, outputPath) {
     try {
       await this.prepareOutputFile(outputPath);
@@ -134,7 +89,6 @@ class BaseConverter {
       const cleanedMarkdown = this.cleanMarkdown(markdown);
       await fs.writeFile(outputPath, cleanedMarkdown, "utf8");
 
-      // Générer le checksum du fichier créé
       const checksum = await generateFileChecksum(outputPath);
 
       console.log(
@@ -148,22 +102,10 @@ class BaseConverter {
     }
   }
 
-  /**
-   * Log une opération du convertisseur
-   * @param {string} operation - Nom de l'opération
-   * @param {object} details - Détails de l'opération
-   */
   log(operation, details = {}) {
     console.log(`[${this.name}] ${operation}:`, details);
   }
 
-  /**
-   * Gère les erreurs de conversion
-   * @param {Error} error - Erreur à traiter
-   * @param {string} operation - Nom de l'opération qui a échoué
-   * @param {string} filePath - Chemin du fichier concerné
-   * @returns {object} - Résultat d'erreur formaté
-   */
   handleError(error, operation, filePath) {
     const errorMessage = `${operation} failed for ${filePath}: ${error.message}`;
     console.error(`[${this.name}] ${errorMessage}`, error);
@@ -181,11 +123,6 @@ class BaseConverter {
     };
   }
 
-  /**
-   * Obtient des informations sur le fichier d'entrée
-   * @param {string} filePath - Chemin du fichier
-   * @returns {Promise<object>} - Informations sur le fichier
-   */
   async getFileInfo(filePath) {
     try {
       const stats = await fs.stat(filePath);
@@ -205,11 +142,6 @@ class BaseConverter {
     }
   }
 
-  /**
-   * Méthode utilitaire pour la progression (peut être overridée)
-   * @param {number} progress - Progression 0-100
-   * @param {string} message - Message de progression
-   */
   updateProgress(progress, message) {
     console.log(`[${this.name}] ${progress}% - ${message}`);
   }

--- a/backend/src/converters/converterFactory.js
+++ b/backend/src/converters/converterFactory.js
@@ -1,15 +1,7 @@
 import DocxToMarkdownConverter from './docxToMarkdownConverter.js'
 import PdfToMarkdownConverter from './pdfToMarkdownConverter.js'
 
-/**
- * Factory pour créer les convertisseurs appropriés selon le type de fichier
- */
 class ConverterFactory {
-  /**
-   * Obtient le convertisseur approprié pour une extension de fichier
-   * @param {string} fileExtension - Extension du fichier (ex: '.docx', '.pdf')
-   * @returns {BaseConverter} - Instance du convertisseur approprié
-   */
   static getConverter(fileExtension) {
     if (!fileExtension) {
       throw new Error('File extension is required')
@@ -21,36 +13,23 @@ class ConverterFactory {
       case '.docx':
       case '.doc':
         return new DocxToMarkdownConverter()
-      
+
       case '.pdf':
         return new PdfToMarkdownConverter()
-      
+
       default:
         throw new Error(`Unsupported file format: ${fileExtension}. Supported formats: .docx, .doc, .pdf`)
     }
   }
 
-  /**
-   * Retourne la liste des extensions supportées
-   * @returns {Array<string>} - Liste des extensions
-   */
   static getSupportedExtensions() {
     return ['.docx', '.doc', '.pdf']
   }
 
-  /**
-   * Vérifie si une extension est supportée
-   * @param {string} fileExtension - Extension à vérifier
-   * @returns {boolean} - True si supportée
-   */
   static isExtensionSupported(fileExtension) {
     return this.getSupportedExtensions().includes(fileExtension.toLowerCase())
   }
 
-  /**
-   * Retourne des informations sur les convertisseurs disponibles
-   * @returns {object} - Informations sur les convertisseurs
-   */
   static getConverterInfo() {
     return {
       '.docx': {
@@ -76,11 +55,6 @@ class ConverterFactory {
     }
   }
 
-  /**
-   * Détermine le convertisseur à partir d'un nom de fichier
-   * @param {string} fileName - Nom du fichier
-   * @returns {BaseConverter} - Instance du convertisseur
-   */
   static getConverterFromFileName(fileName) {
     if (!fileName) {
       throw new Error('File name is required')
@@ -90,26 +64,21 @@ class ConverterFactory {
     return this.getConverter(extension)
   }
 
-  /**
-   * Valide qu'un fichier peut être converti
-   * @param {string} fileName - Nom du fichier
-   * @returns {object} - Résultat de validation { canConvert: boolean, reason?: string }
-   */
   static validateFile(fileName) {
     if (!fileName) {
       return { canConvert: false, reason: 'File name is required' }
     }
 
     const extension = fileName.substring(fileName.lastIndexOf('.')).toLowerCase()
-    
+
     if (!extension) {
       return { canConvert: false, reason: 'File has no extension' }
     }
 
     if (!this.isExtensionSupported(extension)) {
-      return { 
-        canConvert: false, 
-        reason: `Unsupported extension: ${extension}. Supported: ${this.getSupportedExtensions().join(', ')}` 
+      return {
+        canConvert: false,
+        reason: `Unsupported extension: ${extension}. Supported: ${this.getSupportedExtensions().join(', ')}`
       }
     }
 

--- a/backend/src/converters/docxToMarkdownConverter.js
+++ b/backend/src/converters/docxToMarkdownConverter.js
@@ -5,10 +5,6 @@ import path from "path";
 const require = createRequire(import.meta.url);
 const mammoth = require("mammoth");
 
-/**
- * Convertisseur de fichiers DOCX vers Markdown
- * Utilise mammoth.js pour l'extraction de contenu
- */
 class DocxToMarkdownConverter extends BaseConverter {
   constructor() {
     super();
@@ -16,18 +12,11 @@ class DocxToMarkdownConverter extends BaseConverter {
     this.supportedExtensions = [".docx", ".doc"];
   }
 
-  /**
-   * Convertit un fichier DOCX en Markdown
-   * @param {string} inputPath - Chemin du fichier DOCX
-   * @param {string} outputPath - Chemin de sortie du fichier Markdown
-   * @returns {Promise<{success: boolean, message?: string, checksum?: string, error?: string}>}
-   */
   async convert(inputPath, outputPath) {
     try {
       this.log("convert", { inputPath, outputPath });
       this.updateProgress(10, "Validating input file");
 
-      // Valider le fichier d'entrée
       await this.validateInputFile(inputPath);
 
       const fileInfo = await this.getFileInfo(inputPath);
@@ -37,10 +26,8 @@ class DocxToMarkdownConverter extends BaseConverter {
 
       this.updateProgress(20, "Reading DOCX file");
 
-      // Options de conversion Mammoth
       const options = {
         styleMap: [
-          // Mappings pour les styles Word vers Markdown
           "p[style-name='Heading 1'] => h1:fresh",
           "p[style-name='Heading 2'] => h2:fresh",
           "p[style-name='Heading 3'] => h3:fresh",
@@ -55,12 +42,9 @@ class DocxToMarkdownConverter extends BaseConverter {
           "p[style-name='List Paragraph'] => p:fresh",
         ],
         convertImage: mammoth.images.imgElement(async (image) => {
-          // Convertir les images en références Markdown
-          // En production, vous pourriez vouloir sauvegarder les images
           await image.read();
           const imageName = `image_${Date.now()}.${image.contentType.split("/")[1] || "png"}`;
 
-          // Pour l'instant, juste retourner une référence
           return {
             src: `./images/${imageName}`,
             alt: `Image ${imageName}`,
@@ -71,7 +55,6 @@ class DocxToMarkdownConverter extends BaseConverter {
 
       this.updateProgress(40, "Converting to Markdown");
 
-      // Convertir avec Mammoth
       const result = await mammoth.convertToMarkdown(
         { path: inputPath },
         options,
@@ -79,15 +62,11 @@ class DocxToMarkdownConverter extends BaseConverter {
 
       this.updateProgress(60, "Processing conversion result");
 
-      // Traiter le résultat
       let markdown = result.value;
-
-      // Nettoyer et améliorer le Markdown
       markdown = this.enhanceMarkdown(markdown);
 
       this.updateProgress(80, "Adding metadata and saving");
 
-      // Ajouter les métadonnées
       const metadata = {
         source_file: path.basename(inputPath),
         file_size: fileInfo.size,
@@ -97,10 +76,8 @@ class DocxToMarkdownConverter extends BaseConverter {
 
       markdown = this.addMetadata(markdown, metadata);
 
-      // Sauvegarder le fichier
       const checksum = await this.saveMarkdown(markdown, outputPath);
 
-      // Log des warnings de conversion s'il y en a
       if (result.messages.length > 0) {
         this.log("conversion_warnings", {
           count: result.messages.length,
@@ -129,68 +106,31 @@ class DocxToMarkdownConverter extends BaseConverter {
     }
   }
 
-  /**
-   * Améliore le Markdown généré par Mammoth
-   * @param {string} markdown - Markdown brut de Mammoth
-   * @returns {string} - Markdown amélioré
-   */
   enhanceMarkdown(markdown) {
     if (!markdown) return "";
 
     let enhanced = markdown;
 
-    // Corriger les titres mal formés
-    enhanced = enhanced.replace(/^#{7,}/gm, "######"); // Max 6 niveaux de titres
-
-    // Améliorer les listes
-    enhanced = enhanced.replace(/^\* /gm, "- "); // Uniformiser les puces
-
-    // Nettoyer les espaces autour des titres
+    enhanced = enhanced.replace(/^#{7,}/gm, "######");
+    enhanced = enhanced.replace(/^\* /gm, "- ");
     enhanced = enhanced.replace(/^(#{1,6})\s+(.+)$/gm, "$1 $2");
-
-    // Améliorer les liens
     enhanced = enhanced.replace(/\[([^\]]+)\]\(\s*([^)]+)\s*\)/g, "[$1]($2)");
-
-    // Corriger les tableaux mal formés
     enhanced = this.fixTables(enhanced);
-
-    // Améliorer les citations
     enhanced = enhanced.replace(/^>\s*/gm, "> ");
-
-    // Nettoyer les sauts de ligne excessifs
     enhanced = enhanced.replace(/\n{4,}/g, "\n\n\n");
 
     return enhanced;
   }
 
-  /**
-   * Corrige le formatage des tableaux
-   * @param {string} markdown - Markdown avec potentiels problèmes de tableaux
-   * @returns {string} - Markdown avec tableaux corrigés
-   */
   fixTables(markdown) {
-    // Cette méthode peut être étendue pour améliorer le traitement des tableaux
-    // Mammoth ne génère pas toujours des tableaux Markdown parfaits
-
-    // Pour l'instant, on fait un nettoyage basique
     let fixed = markdown;
-
-    // Assurer que les lignes de tableau ont bien des pipes de début/fin
     fixed = fixed.replace(/^([^|\n]*\|[^|\n]*\|[^|\n]*)$/gm, "|$1|");
-
     return fixed;
   }
 
-  /**
-   * Valide spécifiquement les fichiers DOCX/DOC
-   * @param {string} filePath - Chemin du fichier
-   * @returns {Promise<boolean>}
-   */
   async validateInputFile(filePath) {
-    // Validation de base
     await super.validateInputFile(filePath);
 
-    // Validation spécifique DOCX/DOC
     const extension = path.extname(filePath).toLowerCase();
 
     if (!this.supportedExtensions.includes(extension)) {
@@ -199,8 +139,7 @@ class DocxToMarkdownConverter extends BaseConverter {
       );
     }
 
-    // Vérifier que le fichier semble être un document Office valide
-    // (vérification basique sur les premiers bytes)
+    // Check file magic bytes for valid Office document
     const fs = require("fs");
     const buffer = Buffer.alloc(8);
     const fd = fs.openSync(filePath, "r");
@@ -208,8 +147,6 @@ class DocxToMarkdownConverter extends BaseConverter {
     try {
       fs.readSync(fd, buffer, 0, 8, 0);
 
-      // DOCX commence par 'PK' (ZIP signature)
-      // DOC a une signature différente
       if (
         extension === ".docx" &&
         !buffer.toString("ascii", 0, 2).includes("PK")

--- a/backend/src/converters/pdfToMarkdownConverter.js
+++ b/backend/src/converters/pdfToMarkdownConverter.js
@@ -3,10 +3,6 @@ import { PDFParse } from "pdf-parse";
 import fs from "fs-extra";
 import path from "path";
 
-/**
- * Convertisseur de fichiers PDF vers Markdown
- * Utilise pdf-parse v2 pour l'extraction de texte
- */
 class PdfToMarkdownConverter extends BaseConverter {
   constructor() {
     super();
@@ -14,12 +10,6 @@ class PdfToMarkdownConverter extends BaseConverter {
     this.supportedExtensions = [".pdf"];
   }
 
-  /**
-   * Convertit un fichier PDF en Markdown
-   * @param {string} inputPath - Chemin du fichier PDF
-   * @param {string} outputPath - Chemin de sortie du fichier Markdown
-   * @returns {Promise<{success: boolean, message?: string, checksum?: string, error?: string}>}
-   */
   async convert(inputPath, outputPath) {
     let parser = null;
 
@@ -27,7 +17,6 @@ class PdfToMarkdownConverter extends BaseConverter {
       this.log("convert", { inputPath, outputPath });
       this.updateProgress(10, "Validating input file");
 
-      // Valider le fichier d'entrée
       await this.validateInputFile(inputPath);
 
       const fileInfo = await this.getFileInfo(inputPath);
@@ -37,15 +26,12 @@ class PdfToMarkdownConverter extends BaseConverter {
 
       this.updateProgress(20, "Reading PDF file");
 
-      // Lire le fichier PDF
       const dataBuffer = await fs.readFile(inputPath);
 
       this.updateProgress(40, "Parsing PDF content");
 
-      // Créer le parser pdf-parse v2
       parser = new PDFParse({ data: dataBuffer });
 
-      // Extraire le texte et les métadonnées
       const [textResult, infoResult] = await Promise.all([
         parser.getText(),
         parser.getInfo(),
@@ -53,7 +39,6 @@ class PdfToMarkdownConverter extends BaseConverter {
 
       this.updateProgress(60, "Converting to Markdown");
 
-      // Convertir le texte en Markdown
       let markdown = this.convertTextToMarkdown(
         textResult.text,
         textResult.total,
@@ -61,7 +46,6 @@ class PdfToMarkdownConverter extends BaseConverter {
 
       this.updateProgress(80, "Adding metadata and saving");
 
-      // Ajouter les métadonnées
       const metadata = {
         source_file: path.basename(inputPath),
         file_size: fileInfo.size,
@@ -77,7 +61,6 @@ class PdfToMarkdownConverter extends BaseConverter {
 
       markdown = this.addMetadata(markdown, metadata);
 
-      // Sauvegarder le fichier
       const checksum = await this.saveMarkdown(markdown, outputPath);
 
       this.updateProgress(100, "Conversion completed");
@@ -96,28 +79,18 @@ class PdfToMarkdownConverter extends BaseConverter {
     } catch (error) {
       return this.handleError(error, "PDF conversion", inputPath);
     } finally {
-      // Toujours libérer les ressources du parser
       if (parser) {
         await parser.destroy();
       }
     }
   }
 
-  /**
-   * Convertit le texte brut extrait du PDF en Markdown
-   * @param {string} text - Texte brut du PDF
-   * @param {number} pageCount - Nombre de pages
-   * @returns {string} - Texte formaté en Markdown
-   */
   convertTextToMarkdown(text, pageCount) {
     if (!text) return "";
 
     let markdown = text;
 
-    // Nettoyer le texte initial
     markdown = this.cleanRawText(markdown);
-
-    // Détecter et convertir les structures
     markdown = this.detectHeaders(markdown);
     markdown = this.detectLists(markdown);
     markdown = this.detectParagraphs(markdown);
@@ -126,41 +99,22 @@ class PdfToMarkdownConverter extends BaseConverter {
     return markdown;
   }
 
-  /**
-   * Nettoie le texte brut extrait du PDF
-   * @param {string} text - Texte brut
-   * @returns {string} - Texte nettoyé
-   */
   cleanRawText(text) {
     let cleaned = text;
 
-    // Supprimer les caractères de contrôle étranges
     // eslint-disable-next-line no-control-regex
     cleaned = cleaned.replace(/[\x00-\x08\x0B-\x0C\x0E-\x1F\x7F]/g, "");
-
-    // Corriger les sauts de ligne
     cleaned = cleaned.replace(/\r\n/g, "\n");
     cleaned = cleaned.replace(/\r/g, "\n");
-
-    // Supprimer les espaces en fin de ligne
     cleaned = cleaned.replace(/[ \t]+$/gm, "");
-
-    // Corriger les mots coupés en fin de ligne (heuristique simple)
     cleaned = cleaned.replace(/([a-z])-\n([a-z])/g, "$1$2");
 
     return cleaned;
   }
 
-  /**
-   * Détecte et formate les en-têtes potentiels
-   * @param {string} text - Texte à analyser
-   * @returns {string} - Texte avec en-têtes formatés
-   */
   detectHeaders(text) {
     let formatted = text;
 
-    // Détecter les lignes qui pourraient être des titres
-    // (lignes courtes, en majuscules, ou suivies de lignes vides)
     const lines = formatted.split("\n");
     const processedLines = [];
 
@@ -169,27 +123,20 @@ class PdfToMarkdownConverter extends BaseConverter {
       const nextLine = i + 1 < lines.length ? lines[i + 1].trim() : "";
       const prevLine = i > 0 ? lines[i - 1].trim() : "";
 
-      // Heuristiques pour détecter les titres
       let isHeader = false;
       let headerLevel = 1;
 
       if (line.length > 0 && line.length < 80) {
-        // Ligne courte non vide
-
         if (line.toUpperCase() === line && line.length > 5) {
-          // Tout en majuscules
           isHeader = true;
           headerLevel = 1;
         } else if (nextLine === "" && prevLine === "" && line.length < 50) {
-          // Ligne isolée et courte
           isHeader = true;
           headerLevel = 2;
         } else if (/^\d+\./.test(line)) {
-          // Commence par un numéro (1. 2. etc.)
           isHeader = true;
           headerLevel = 2;
         } else if (/^[A-Z][A-Z\s]{10,}$/.test(line)) {
-          // Beaucoup de majuscules
           isHeader = true;
           headerLevel = 1;
         }
@@ -205,79 +152,45 @@ class PdfToMarkdownConverter extends BaseConverter {
     return processedLines.join("\n");
   }
 
-  /**
-   * Détecte et formate les listes
-   * @param {string} text - Texte à analyser
-   * @returns {string} - Texte avec listes formatées
-   */
   detectLists(text) {
     let formatted = text;
 
-    // Détecter les listes avec puces ou numéros
     formatted = formatted.replace(/^[\s]*[•·‣▪▫‪‬]\s+(.+)$/gm, "- $1");
     formatted = formatted.replace(/^[\s]*[*]\s+(.+)$/gm, "- $1");
     formatted = formatted.replace(/^[\s]*[-]\s+(.+)$/gm, "- $1");
-
-    // Listes numérotées
     formatted = formatted.replace(/^[\s]*(\d+)[.)]\s+(.+)$/gm, "$1. $2");
 
     return formatted;
   }
 
-  /**
-   * Améliore la structure des paragraphes
-   * @param {string} text - Texte à analyser
-   * @returns {string} - Texte avec paragraphes mieux structurés
-   */
   detectParagraphs(text) {
     let formatted = text;
 
-    // Assurer qu'il y a des espaces entre les paragraphes
     formatted = formatted.replace(/\n([^\n\s-#*\d])/g, "\n\n$1");
-
-    // Nettoyer les multiples sauts de ligne
     formatted = formatted.replace(/\n{3,}/g, "\n\n");
 
     return formatted;
   }
 
-  /**
-   * Ajoute des marqueurs de page
-   * @param {string} text - Texte à traiter
-   * @param {number} pageCount - Nombre de pages
-   * @returns {string} - Texte avec marqueurs de page
-   */
   addPageBreaks(text, pageCount) {
     if (pageCount <= 1) return text;
 
-    // Cette méthode est simplifiée - une implémentation plus avancée
-    // nécessiterait de traiter chaque page séparément lors du parsing
     let enhanced = text;
-
-    // Ajouter une note sur les pages
     enhanced =
-      `> Document extrait d'un PDF de ${pageCount} pages\n\n` + enhanced;
+      `> Extracted from a ${pageCount}-page PDF document\n\n` + enhanced;
 
     return enhanced;
   }
 
-  /**
-   * Valide spécifiquement les fichiers PDF
-   * @param {string} filePath - Chemin du fichier
-   * @returns {Promise<boolean>}
-   */
   async validateInputFile(filePath) {
-    // Validation de base
     await super.validateInputFile(filePath);
 
-    // Validation spécifique PDF
     const extension = path.extname(filePath).toLowerCase();
 
     if (extension !== ".pdf") {
       throw new Error(`Expected PDF file, got: ${extension}`);
     }
 
-    // Vérifier la signature PDF
     try {
       const buffer = await fs.readFile(filePath, { encoding: null });
       const header = buffer.subarray(0, 4).toString("ascii");
@@ -295,11 +208,6 @@ class PdfToMarkdownConverter extends BaseConverter {
     return true;
   }
 
-  /**
-   * Extrait les métadonnées du PDF
-   * @param {string} filePath - Chemin du fichier PDF
-   * @returns {Promise<object>} - Métadonnées du PDF
-   */
   async extractMetadata(filePath) {
     let parser = null;
 
@@ -311,7 +219,7 @@ class PdfToMarkdownConverter extends BaseConverter {
       return {
         pages: infoResult.total,
         info: infoResult.info || {},
-        textLength: 0, // Non disponible sans getText
+        textLength: 0,
       };
     } catch (error) {
       this.log("metadata_extraction_failed", { error: error.message });

--- a/backend/src/integrations/base/driveConnector.js
+++ b/backend/src/integrations/base/driveConnector.js
@@ -10,74 +10,36 @@ export class TokenExpiredError extends Error {
   }
 }
 
-/**
- * Interface de base pour tous les connecteurs de drives
- * Tous les connecteurs doivent hériter de cette classe
- */
 class DriveConnector {
   constructor(config) {
     this.config = config;
     this.isAuthenticated = false;
   }
 
-  /**
-   * Authentifie le connecteur avec les credentials fournis
-   * @returns {Promise<boolean>} - True si l'authentification réussit
-   */
   async authenticate() {
     throw new Error("authenticate() method must be implemented by subclass");
   }
 
-  /**
-   * Test de connexion au drive
-   * @returns {Promise<{success: boolean, message: string, details?: object}>}
-   */
   async testConnection() {
     throw new Error("testConnection() method must be implemented by subclass");
   }
 
-  /**
-   * Liste les fichiers dans un répertoire donné
-   * @param {string} path - Chemin du répertoire à lister
-   * @returns {Promise<Array<{id: string, name: string, path: string, size: number, modifiedTime: Date, checksum?: string}>>}
-   */
   async listFiles(_path = "/") {
     throw new Error("listFiles() method must be implemented by subclass");
   }
 
-  /**
-   * Télécharge un fichier vers un répertoire local
-   * @param {string} fileId - ID du fichier à télécharger
-   * @param {string} destinationPath - Chemin de destination local
-   * @returns {Promise<string>} - Chemin du fichier téléchargé
-   */
   async downloadFile(_fileId, _destinationPath) {
     throw new Error("downloadFile() method must be implemented by subclass");
   }
 
-  /**
-   * Surveille les changements dans un répertoire
-   * @param {string} path - Chemin à surveiller
-   * @param {Function} callback - Fonction appelée lors de changements
-   * @returns {Promise<void>}
-   */
   async watchForChanges(_path, _callback) {
     throw new Error("watchForChanges() method must be implemented by subclass");
   }
 
-  /**
-   * Nettoie les ressources utilisées
-   * @returns {Promise<void>}
-   */
   async cleanup() {
-    // Par défaut, rien à nettoyer
-    // Les sous-classes peuvent override si nécessaire
+    // No-op by default; subclasses can override
   }
 
-  /**
-   * Valide la configuration fournie
-   * @returns {boolean} - True si la configuration est valide
-   */
   validateConfig() {
     if (!this.config) {
       throw new Error("Configuration is required");
@@ -90,11 +52,6 @@ class DriveConnector {
     return true;
   }
 
-  /**
-   * Normalise les informations d'un fichier
-   * @param {object} rawFile - Données brutes du fichier depuis l'API
-   * @returns {object} - Fichier normalisé
-   */
   normalizeFileInfo(rawFile) {
     return {
       id: rawFile.id,
@@ -110,12 +67,6 @@ class DriveConnector {
     };
   }
 
-  /**
-   * Gère les erreurs d'API
-   * @param {Error} error - Erreur à traiter
-   * @param {string} operation - Nom de l'opération qui a échoué
-   * @throws {Error} - Erreur enrichie
-   */
   handleApiError(error, operation) {
     console.error(`${this.constructor.name} ${operation} failed:`, error);
 
@@ -130,7 +81,6 @@ class DriveConnector {
       );
     }
 
-    // Enrichir l'erreur avec des informations contextuelles
     const enrichedError = new Error(`${operation} failed: ${error.message}`);
     enrichedError.originalError = error;
     enrichedError.operation = operation;
@@ -139,11 +89,6 @@ class DriveConnector {
     throw enrichedError;
   }
 
-  /**
-   * Log une opération
-   * @param {string} operation - Nom de l'opération
-   * @param {object} details - Détails de l'opération
-   */
   log(operation, details = {}) {
     console.log(`[${this.constructor.name}] ${operation}:`, details);
   }

--- a/backend/src/integrations/base/driveConnectorFactory.js
+++ b/backend/src/integrations/base/driveConnectorFactory.js
@@ -1,16 +1,7 @@
 import SharePointConnector from '../sharepoint/sharepointConnector.js'
 import GoogleDriveConnector from '../googledrive/googledriveConnector.js'
 
-/**
- * Factory pour créer les connecteurs de drives appropriés
- */
 class DriveConnectorFactory {
-  /**
-   * Crée un connecteur basé sur la plateforme
-   * @param {string} platform - Type de plateforme ('sharepoint', 'googledrive', 'onedrive')
-   * @param {object} config - Configuration du connecteur
-   * @returns {DriveConnector} - Instance du connecteur approprié
-   */
   static createConnector(platform, config) {
     if (!platform) {
       throw new Error('Platform is required')
@@ -31,7 +22,7 @@ class DriveConnectorFactory {
         return new GoogleDriveConnector(config)
       
       case 'onedrive':
-        // OneDrive utilise la même API que SharePoint (Microsoft Graph)
+        // OneDrive uses the same Microsoft Graph API as SharePoint
         return new SharePointConnector({
           ...config,
           isOneDrive: true
@@ -42,28 +33,14 @@ class DriveConnectorFactory {
     }
   }
 
-  /**
-   * Retourne la liste des plateformes supportées
-   * @returns {Array<string>} - Liste des plateformes
-   */
   static getSupportedPlatforms() {
     return ['sharepoint', 'googledrive', 'onedrive']
   }
 
-  /**
-   * Valide qu'une plateforme est supportée
-   * @param {string} platform - Plateforme à valider
-   * @returns {boolean} - True si supportée
-   */
   static isPlatformSupported(platform) {
     return this.getSupportedPlatforms().includes(platform.toLowerCase())
   }
 
-  /**
-   * Retourne les champs de configuration requis pour une plateforme
-   * @param {string} platform - Plateforme
-   * @returns {object} - Schéma de configuration
-   */
   static getConfigSchema(platform) {
     const normalizedPlatform = platform.toLowerCase()
 
@@ -105,24 +82,16 @@ class DriveConnectorFactory {
     }
   }
 
-  /**
-   * Valide la configuration pour une plateforme donnée
-   * @param {string} platform - Plateforme
-   * @param {object} config - Configuration à valider
-   * @returns {object} - Résultat de validation { valid: boolean, errors: Array<string> }
-   */
   static validateConfig(platform, config) {
     try {
       const schema = this.getConfigSchema(platform)
       const errors = []
 
-      // Fonction récursive pour valider un objet contre un schéma
       function validateObject(obj, schemaObj, path = '') {
         for (const [key, schemaValue] of Object.entries(schemaObj)) {
           const currentPath = path ? `${path}.${key}` : key
           
           if (typeof schemaValue === 'object' && schemaValue.required !== undefined) {
-            // C'est une propriété avec des règles
             if (schemaValue.required && !obj[key]) {
               errors.push(`Missing required field: ${currentPath}`)
             } else if (obj[key] && schemaValue.type) {
@@ -132,7 +101,6 @@ class DriveConnectorFactory {
               }
             }
           } else if (typeof schemaValue === 'object') {
-            // C'est un objet imbriqué
             if (obj[key]) {
               validateObject(obj[key], schemaValue, currentPath)
             }

--- a/backend/src/integrations/googledrive/googledriveConnector.js
+++ b/backend/src/integrations/googledrive/googledriveConnector.js
@@ -3,10 +3,6 @@ import axios from "axios";
 import fs from "fs-extra";
 import path from "path";
 
-/**
- * Connecteur pour Google Drive
- * Utilise Google Drive API v3
- */
 class GoogleDriveConnector extends DriveConnector {
   constructor(config) {
     super(config);
@@ -15,16 +11,12 @@ class GoogleDriveConnector extends DriveConnector {
     this.baseUrl = "https://www.googleapis.com/drive/v3";
   }
 
-  /**
-   * Authentifie avec Google Drive API
-   */
   async authenticate() {
     try {
       this.validateConfig();
 
       const { clientId, clientSecret, refreshToken } = this.config.credentials;
 
-      // Obtenir un access token via refresh token
       const tokenUrl = "https://oauth2.googleapis.com/token";
 
       const params = {
@@ -56,14 +48,10 @@ class GoogleDriveConnector extends DriveConnector {
     }
   }
 
-  /**
-   * Test de connexion
-   */
   async testConnection() {
     try {
       await this.authenticate();
 
-      // Tester l'accès à l'API en récupérant les infos utilisateur
       const response = await this.makeAuthenticatedRequest(
         "https://www.googleapis.com/drive/v3/about?fields=user,storageQuota",
       );
@@ -92,9 +80,6 @@ class GoogleDriveConnector extends DriveConnector {
     }
   }
 
-  /**
-   * Liste les dossiers dans un répertoire
-   */
   async listFolders(folderId = "root") {
     try {
       await this.ensureAuthenticated();
@@ -127,14 +112,10 @@ class GoogleDriveConnector extends DriveConnector {
     }
   }
 
-  /**
-   * Liste les fichiers dans un dossier
-   */
   async listFiles(folderId = "root", limit = null) {
     try {
       await this.ensureAuthenticated();
 
-      // Construire la requête
       const params = {
         q: `'${folderId}' in parents and trashed=false and mimeType!='application/vnd.google-apps.folder'`,
         fields:
@@ -159,7 +140,7 @@ class GoogleDriveConnector extends DriveConnector {
         this.normalizeFileInfo({
           id: file.id,
           name: file.name,
-          path: `/${file.name}`, // Google Drive n'a pas de structure de path traditionnelle
+          path: `/${file.name}`,
           size: parseInt(file.size) || 0,
           modifiedTime: file.modifiedTime,
           checksum: file.md5Checksum,
@@ -173,9 +154,6 @@ class GoogleDriveConnector extends DriveConnector {
     }
   }
 
-  /**
-   * Recherche des fichiers par nom ou type
-   */
   async searchFiles(query, limit = 50) {
     try {
       await this.ensureAuthenticated();
@@ -201,29 +179,24 @@ class GoogleDriveConnector extends DriveConnector {
     }
   }
 
-  /**
-   * Télécharge un fichier
-   */
   async downloadFile(fileId, destinationDir) {
     try {
       await this.ensureAuthenticated();
 
       this.log("downloadFile", { fileId, destinationDir });
 
-      // Obtenir les métadonnées du fichier
       const fileInfoResponse = await this.makeAuthenticatedRequest(
         `${this.baseUrl}/files/${fileId}?fields=name,size,mimeType`,
       );
 
       const fileInfo = fileInfoResponse.data;
 
-      // Créer le répertoire de destination
       await fs.ensureDir(destinationDir);
 
       let downloadUrl = `${this.baseUrl}/files/${fileId}?alt=media`;
       let fileName = fileInfo.name;
 
-      // Gérer les formats Google Docs (conversion nécessaire)
+      // Handle Google Docs native formats (export required)
       if (fileInfo.mimeType.startsWith("application/vnd.google-apps.")) {
         const conversionMap = {
           "application/vnd.google-apps.document": {
@@ -254,7 +227,6 @@ class GoogleDriveConnector extends DriveConnector {
         }
       }
 
-      // Télécharger le fichier
       const response = await this.makeAuthenticatedRequest(downloadUrl, {
         responseType: "stream",
       });
@@ -279,17 +251,12 @@ class GoogleDriveConnector extends DriveConnector {
     }
   }
 
-  /**
-   * Surveillance des changements via Google Drive API changes
-   */
   async watchForChanges(folderId, callback) {
     this.log("watchForChanges", {
       folderId,
       note: "Using polling approach - push notifications require webhook setup",
     });
 
-    // Pour une implémentation simple, on utilise le polling des changements
-    // En production, il faudrait utiliser les push notifications
     let pageToken = null;
 
     const pollChanges = async () => {
@@ -311,7 +278,6 @@ class GoogleDriveConnector extends DriveConnector {
 
         const changes = response.data.changes || [];
 
-        // Filtrer les changements pour le dossier surveillé
         const relevantChanges = changes.filter((change) => {
           const file = change.file;
           return (
@@ -337,22 +303,16 @@ class GoogleDriveConnector extends DriveConnector {
       }
     };
 
-    // Polling initial
     await pollChanges();
 
-    // Polling périodique
-    const pollInterval = setInterval(pollChanges, 60000); // Poll toutes les minutes
+    const pollInterval = setInterval(pollChanges, 60000);
 
-    // Retourner une fonction de cleanup
     return () => {
       clearInterval(pollInterval);
       this.log("watchForChanges", { status: "stopped" });
     };
   }
 
-  /**
-   * Effectue une requête authentifiée
-   */
   async makeAuthenticatedRequest(url, config = {}) {
     await this.ensureAuthenticated();
 
@@ -366,19 +326,12 @@ class GoogleDriveConnector extends DriveConnector {
     });
   }
 
-  /**
-   * S'assure que l'authentication est valide
-   */
   async ensureAuthenticated() {
     if (!this.isAuthenticated || Date.now() >= this.tokenExpiry - 30000) {
-      // Re-authentifier si pas authentifié ou token expire dans 30s
       await this.authenticate();
     }
   }
 
-  /**
-   * Validation spécifique à Google Drive
-   */
   validateConfig() {
     super.validateConfig();
 
@@ -393,9 +346,6 @@ class GoogleDriveConnector extends DriveConnector {
     return true;
   }
 
-  /**
-   * Nettoyage des ressources
-   */
   async cleanup() {
     this.accessToken = null;
     this.tokenExpiry = null;

--- a/backend/src/integrations/sharepoint/sharepointConnector.js
+++ b/backend/src/integrations/sharepoint/sharepointConnector.js
@@ -3,10 +3,6 @@ import axios from 'axios'
 import fs from 'fs-extra'
 import path from 'path'
 
-/**
- * Connecteur pour Microsoft SharePoint et OneDrive
- * Utilise Microsoft Graph API
- */
 class SharePointConnector extends DriveConnector {
   constructor(config) {
     super(config)
@@ -17,18 +13,14 @@ class SharePointConnector extends DriveConnector {
     this.siteId = null
   }
 
-  /**
-   * Authentifie avec Microsoft Graph API
-   */
   async authenticate() {
     try {
       this.validateConfig()
 
       const { clientId, clientSecret, tenantId } = this.config.credentials
-      
-      // Obtenir un token d'accès via Client Credentials Flow
+
       const tokenUrl = `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`
-      
+
       const params = new URLSearchParams()
       params.append('client_id', clientId)
       params.append('client_secret', clientSecret)
@@ -47,7 +39,6 @@ class SharePointConnector extends DriveConnector {
       this.tokenExpiry = Date.now() + (response.data.expires_in * 1000)
       this.isAuthenticated = true
 
-      // Obtenir l'ID du site SharePoint si nécessaire
       if (!this.isOneDrive && this.config.siteUrl) {
         await this.getSiteId()
       }
@@ -60,9 +51,6 @@ class SharePointConnector extends DriveConnector {
     }
   }
 
-  /**
-   * Obtient l'ID du site SharePoint
-   */
   async getSiteId() {
     try {
       const siteUrl = new URL(this.config.siteUrl)
@@ -81,16 +69,12 @@ class SharePointConnector extends DriveConnector {
     }
   }
 
-  /**
-   * Test de connexion
-   */
   async testConnection() {
     try {
       await this.authenticate()
 
-      // Tester l'accès aux fichiers
-      const files = await this.listFiles('/', 1) // Lister seulement 1 fichier pour tester
-      
+      const files = await this.listFiles('/', 1)
+
       return {
         success: true,
         message: 'Connection successful',
@@ -112,30 +96,24 @@ class SharePointConnector extends DriveConnector {
     }
   }
 
-  /**
-   * Liste les fichiers
-   */
   async listFiles(folderPath = '/', limit = null) {
     try {
       await this.ensureAuthenticated()
 
       let endpoint
       if (this.isOneDrive) {
-        // OneDrive personnel
-        endpoint = folderPath === '/' 
+        endpoint = folderPath === '/'
           ? `${this.baseUrl}/me/drive/root/children`
           : `${this.baseUrl}/me/drive/root:${folderPath}:/children`
       } else {
-        // SharePoint
         endpoint = folderPath === '/'
           ? `${this.baseUrl}/sites/${this.siteId}/drive/root/children`
           : `${this.baseUrl}/sites/${this.siteId}/drive/root:${folderPath}:/children`
       }
 
-      // Ajouter des paramètres pour optimiser la requête
       const params = {
         '$select': 'id,name,size,lastModifiedDateTime,file,webUrl,@microsoft.graph.downloadUrl',
-        '$filter': 'file ne null' // Seulement les fichiers, pas les dossiers
+        '$filter': 'file ne null'
       }
 
       if (limit) {
@@ -162,14 +140,10 @@ class SharePointConnector extends DriveConnector {
     }
   }
 
-  /**
-   * Télécharge un fichier
-   */
   async downloadFile(fileId, destinationDir) {
     try {
       await this.ensureAuthenticated()
 
-      // Obtenir l'URL de téléchargement
       let endpoint
       if (this.isOneDrive) {
         endpoint = `${this.baseUrl}/me/drive/items/${fileId}`
@@ -187,10 +161,8 @@ class SharePointConnector extends DriveConnector {
         throw new Error('No download URL available for this file')
       }
 
-      // Créer le répertoire de destination
       await fs.ensureDir(destinationDir)
 
-      // Télécharger le fichier
       const response = await axios.get(downloadUrl, {
         responseType: 'stream'
       })
@@ -214,25 +186,19 @@ class SharePointConnector extends DriveConnector {
     }
   }
 
-  /**
-   * Surveillance des changements (polling basique)
-   */
   async watchForChanges(folderPath, callback) {
-    this.log('watchForChanges', { 
-      folderPath, 
-      note: 'Using polling approach - webhooks require additional setup' 
+    this.log('watchForChanges', {
+      folderPath,
+      note: 'Using polling approach - webhooks require additional setup'
     })
 
-    // Pour une implémentation simple, on utilise le polling
-    // En production, il faudrait utiliser les webhooks Microsoft Graph
     let lastCheck = new Date()
 
     const pollInterval = setInterval(async () => {
       try {
         const files = await this.listFiles(folderPath)
-        
-        // Filtrer les fichiers modifiés depuis la dernière vérification
-        const changedFiles = files.filter(file => 
+
+        const changedFiles = files.filter(file =>
           new Date(file.modifiedTime) > lastCheck
         )
 
@@ -246,18 +212,14 @@ class SharePointConnector extends DriveConnector {
       } catch (error) {
         console.error('Error in watchForChanges polling:', error)
       }
-    }, 60000) // Poll toutes les minutes
+    }, 60000)
 
-    // Retourner une fonction de cleanup
     return () => {
       clearInterval(pollInterval)
       this.log('watchForChanges', { status: 'stopped' })
     }
   }
 
-  /**
-   * Effectue une requête authentifiée
-   */
   async makeAuthenticatedRequest(url, config = {}) {
     await this.ensureAuthenticated()
 
@@ -271,19 +233,12 @@ class SharePointConnector extends DriveConnector {
     })
   }
 
-  /**
-   * S'assure que l'authentication est valide
-   */
   async ensureAuthenticated() {
     if (!this.isAuthenticated || Date.now() >= this.tokenExpiry - 30000) {
-      // Re-authentifier si pas authentifié ou token expire dans 30s
       await this.authenticate()
     }
   }
 
-  /**
-   * Validation spécifique à SharePoint
-   */
   validateConfig() {
     super.validateConfig()
 
@@ -300,9 +255,6 @@ class SharePointConnector extends DriveConnector {
     return true
   }
 
-  /**
-   * Nettoyage des ressources
-   */
   async cleanup() {
     this.accessToken = null
     this.tokenExpiry = null

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,25 +1,14 @@
-/**
- * Middleware d'authentification et d'autorisation
- * Note: Pour une version basique, l'auth est simplifiée
- * En production, vous devriez implémenter JWT + utilisateurs
- */
-
 import jwt from "jsonwebtoken";
 import config from "../config/env.js";
 
-/**
- * Middleware d'authentification JWT (optionnel pour la demo)
- * Actuellement désactivé car pas d'auth utilisateur implémentée
- */
 export function authenticateToken(req, res, next) {
-  // Pour l'instant, on skip l'auth en mode développement
   if (config.nodeEnv === "development") {
-    console.log("🔓 Authentication bypassed in development mode");
+    console.log("Authentication bypassed in development mode");
     return next();
   }
 
   const authHeader = req.headers["authorization"];
-  const token = authHeader && authHeader.split(" ")[1]; // Bearer TOKEN
+  const token = authHeader && authHeader.split(" ")[1];
 
   if (!token) {
     return res.status(401).json({
@@ -52,16 +41,11 @@ export function authenticateToken(req, res, next) {
   }
 }
 
-/**
- * Middleware optionnel d'authentification
- * Permet l'accès anonyme mais enrichit les infos si token présent
- */
 export function optionalAuth(req, res, next) {
   const authHeader = req.headers["authorization"];
   const token = authHeader && authHeader.split(" ")[1];
 
   if (!token) {
-    // Pas de token, mais on continue
     req.user = null;
     return next();
   }
@@ -70,7 +54,6 @@ export function optionalAuth(req, res, next) {
     const decoded = jwt.verify(token, config.jwtSecret);
     req.user = decoded;
   } catch {
-    // Token invalide, mais on continue quand même
     req.user = null;
     console.warn("Optional auth: invalid token provided");
   }
@@ -78,9 +61,6 @@ export function optionalAuth(req, res, next) {
   next();
 }
 
-/**
- * Génère un JWT pour les tests (fonction utilitaire)
- */
 const DEFAULT_TEST_PAYLOAD = { userId: "test-user", role: "admin" };
 
 export function generateTestToken(payload) {
@@ -92,12 +72,8 @@ export function generateTestToken(payload) {
   });
 }
 
-/**
- * Middleware de vérification des permissions (placeholder)
- */
 export function requirePermission(permission) {
   return (req, res, next) => {
-    // Pour l'instant, on accepte tout le monde en mode développement
     if (config.nodeEnv === "development") {
       return next();
     }
@@ -110,16 +86,13 @@ export function requirePermission(permission) {
       });
     }
 
-    // Vérification des permissions (à implémenter selon vos besoins)
     const userPermissions = req.user.permissions || [];
     const userRole = req.user.role || "user";
 
-    // Admin a tous les droits
     if (userRole === "admin") {
       return next();
     }
 
-    // Vérifier si l'utilisateur a la permission requise
     if (!userPermissions.includes(permission)) {
       return res.status(403).json({
         success: false,
@@ -132,9 +105,6 @@ export function requirePermission(permission) {
   };
 }
 
-/**
- * Middleware de limitation d'accès par rôle
- */
 export function requireRole(requiredRole) {
   return (req, res, next) => {
     if (config.nodeEnv === "development") {
@@ -170,21 +140,15 @@ export function requireRole(requiredRole) {
   };
 }
 
-/**
- * Middleware pour les opérations d'administration
- */
 export const requireAdmin = requireRole("admin");
 
-/**
- * Middleware pour logger les tentatives d'authentification
- */
 export function logAuthAttempts(req, res, next) {
   const authHeader = req.headers["authorization"];
   const hasToken = !!authHeader;
   const userAgent = req.get("User-Agent");
   const ip = req.ip || req.connection.remoteAddress;
 
-  console.log("🔐 Auth attempt:", {
+  console.log("Auth attempt:", {
     method: req.method,
     url: req.originalUrl,
     hasToken,
@@ -196,17 +160,10 @@ export function logAuthAttempts(req, res, next) {
   next();
 }
 
-/**
- * Middleware pour les routes publiques (pas d'auth requise)
- */
 export function publicRoute(req, res, next) {
-  // Simplement passer, ces routes sont accessibles à tous
   next();
 }
 
-/**
- * Middleware pour extraire les infos utilisateur du token sans validation stricte
- */
 export function extractUserInfo(req, res, next) {
   const authHeader = req.headers["authorization"];
   const token = authHeader && authHeader.split(" ")[1];
@@ -227,7 +184,6 @@ export function extractUserInfo(req, res, next) {
         ...decoded,
       };
     } catch (error) {
-      // Token invalide, mais on garde les valeurs par défaut
       console.warn("Token extraction failed:", error.message);
     }
   }

--- a/backend/src/middleware/errorHandler.js
+++ b/backend/src/middleware/errorHandler.js
@@ -1,16 +1,8 @@
-/**
- * Middleware de gestion des erreurs pour Express
- */
-
 import config from "../config/env.js";
 
-/**
- * Middleware principal de gestion d'erreur
- */
 export function errorHandler(error, req, res, _next) {
   console.error("❌ Unhandled error:", error);
 
-  // Erreur de validation Prisma
   if (error.code === "P2002") {
     return res.status(409).json({
       success: false,
@@ -19,7 +11,6 @@ export function errorHandler(error, req, res, _next) {
     });
   }
 
-  // Erreur de validation Prisma - Record not found
   if (error.code === "P2025") {
     return res.status(404).json({
       success: false,
@@ -28,7 +19,6 @@ export function errorHandler(error, req, res, _next) {
     });
   }
 
-  // Erreur JWT
   if (error.name === "JsonWebTokenError") {
     return res.status(401).json({
       success: false,
@@ -45,7 +35,6 @@ export function errorHandler(error, req, res, _next) {
     });
   }
 
-  // Erreur de validation des données (body parser, etc.)
   if (error.type === "entity.parse.failed") {
     return res.status(400).json({
       success: false,
@@ -54,7 +43,6 @@ export function errorHandler(error, req, res, _next) {
     });
   }
 
-  // Erreur de payload trop grand
   if (error.type === "entity.too.large") {
     return res.status(413).json({
       success: false,
@@ -63,7 +51,6 @@ export function errorHandler(error, req, res, _next) {
     });
   }
 
-  // Erreur de timeout
   if (error.code === "ETIMEDOUT" || error.code === "ECONNRESET") {
     return res.status(408).json({
       success: false,
@@ -72,7 +59,6 @@ export function errorHandler(error, req, res, _next) {
     });
   }
 
-  // Erreur de permission/accès
   if (error.code === "EACCES" || error.code === "EPERM") {
     return res.status(403).json({
       success: false,
@@ -81,7 +67,6 @@ export function errorHandler(error, req, res, _next) {
     });
   }
 
-  // Erreur de fichier non trouvé
   if (error.code === "ENOENT") {
     return res.status(404).json({
       success: false,
@@ -90,7 +75,6 @@ export function errorHandler(error, req, res, _next) {
     });
   }
 
-  // Erreur d'espace disque insuffisant
   if (error.code === "ENOSPC") {
     return res.status(507).json({
       success: false,
@@ -99,11 +83,9 @@ export function errorHandler(error, req, res, _next) {
     });
   }
 
-  // Erreur par défaut
   const statusCode = error.statusCode || error.status || 500;
   const message = error.message || "Internal server error";
 
-  // En développement, on expose plus de détails
   const errorResponse = {
     success: false,
     message: statusCode === 500 ? "Internal server error" : message,
@@ -113,7 +95,6 @@ export function errorHandler(error, req, res, _next) {
         : "An unexpected error occurred",
   };
 
-  // Ajouter la stack trace en développement
   if (config.nodeEnv === "development") {
     errorResponse.stack = error.stack;
     errorResponse.details = {
@@ -126,9 +107,6 @@ export function errorHandler(error, req, res, _next) {
   res.status(statusCode).json(errorResponse);
 }
 
-/**
- * Middleware pour gérer les routes non trouvées
- */
 export function notFoundHandler(req, res) {
   res.status(404).json({
     success: false,
@@ -144,27 +122,18 @@ export function notFoundHandler(req, res) {
   });
 }
 
-/**
- * Middleware pour capturer les erreurs async non gérées
- */
 export function asyncErrorHandler(fn) {
   return (req, res, next) => {
     Promise.resolve(fn(req, res, next)).catch(next);
   };
 }
 
-/**
- * Wrapper pour les routes async
- */
 export function wrapAsync(fn) {
   return function (req, res, next) {
     fn(req, res, next).catch(next);
   };
 }
 
-/**
- * Middleware de validation des erreurs de requête
- */
 export function validationErrorHandler(error, req, res, next) {
   if (error.name === "ValidationError") {
     return res.status(400).json({
@@ -177,11 +146,7 @@ export function validationErrorHandler(error, req, res, next) {
   next(error);
 }
 
-/**
- * Log des erreurs pour monitoring
- */
 export function logError(error, req, res, next) {
-  // Log détaillé de l'erreur
   console.error("Error details:", {
     message: error.message,
     stack: error.stack,

--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -1,39 +1,28 @@
-/**
- * Middleware de validation des données
- */
 import { validateDestinationPath } from "../utils/configParser.js";
 
-/**
- * Valide les données de création d'une source
- */
 export function validateSourceData(req, res, next) {
   const { name, platform, config } = req.body;
 
   const errors = [];
 
-  // Validation du nom
   if (!name || typeof name !== "string" || name.trim().length === 0) {
     errors.push("Name is required and must be a non-empty string");
   } else if (name.length > 100) {
     errors.push("Name must be less than 100 characters");
   }
 
-  // Validation de la plateforme
   const supportedPlatforms = ["sharepoint", "googledrive", "onedrive"];
   if (!platform || !supportedPlatforms.includes(platform.toLowerCase())) {
     errors.push(`Platform must be one of: ${supportedPlatforms.join(", ")}`);
   }
 
-  // Validation de la configuration
   if (!config || typeof config !== "object") {
     errors.push("Config is required and must be an object");
   } else {
-    // Validation des credentials
     if (!config.credentials || typeof config.credentials !== "object") {
       errors.push("Config.credentials is required and must be an object");
     }
 
-    // Validation spécifique par plateforme
     if (platform === "sharepoint" || platform === "onedrive") {
       const { clientId, clientSecret, tenantId } = config.credentials || {};
       if (!clientId) errors.push("Microsoft clientId is required");
@@ -51,7 +40,6 @@ export function validateSourceData(req, res, next) {
       if (!refreshToken) errors.push("Google refreshToken is required");
     }
 
-    // Validation de la destination avec sécurité
     if (config.destination) {
       if (typeof config.destination !== "string") {
         errors.push("Config.destination must be a string");
@@ -76,20 +64,15 @@ export function validateSourceData(req, res, next) {
   next();
 }
 
-/**
- * Valide les données de création d'un job de conversion
- */
 export function validateConversionJobData(req, res, next) {
   const { sourceId, fileName, filePath, fileSize } = req.body;
 
   const errors = [];
 
-  // Validation du sourceId
   if (!sourceId || typeof sourceId !== "string") {
     errors.push("sourceId is required and must be a string");
   }
 
-  // Validation du nom de fichier
   if (
     !fileName ||
     typeof fileName !== "string" ||
@@ -97,7 +80,6 @@ export function validateConversionJobData(req, res, next) {
   ) {
     errors.push("fileName is required and must be a non-empty string");
   } else {
-    // Vérifier l'extension
     const supportedExtensions = [".docx", ".doc", ".pdf"];
     const extension = fileName
       .substring(fileName.lastIndexOf("."))
@@ -109,7 +91,6 @@ export function validateConversionJobData(req, res, next) {
     }
   }
 
-  // Validation du chemin de fichier
   if (
     !filePath ||
     typeof filePath !== "string" ||
@@ -118,7 +99,6 @@ export function validateConversionJobData(req, res, next) {
     errors.push("filePath is required and must be a non-empty string");
   }
 
-  // Validation de la taille (optionnelle)
   if (
     fileSize !== undefined &&
     (typeof fileSize !== "number" || fileSize < 0)
@@ -137,9 +117,6 @@ export function validateConversionJobData(req, res, next) {
   next();
 }
 
-/**
- * Valide les paramètres de pagination
- */
 export function validatePagination(req, res, next) {
   const { page, limit } = req.query;
 
@@ -168,9 +145,6 @@ export function validatePagination(req, res, next) {
   next();
 }
 
-/**
- * Valide le format des IDs (CUID)
- */
 export function validateId(paramName = "id") {
   return (req, res, next) => {
     const id = req.params[paramName];
@@ -182,7 +156,7 @@ export function validateId(paramName = "id") {
       });
     }
 
-    // Validation basique du format CUID (commence par 'c' suivi de caractères alphanumériques)
+    // Basic CUID format validation (starts with 'c' followed by alphanumeric chars)
     if (!/^c[a-z0-9]{10,}$/i.test(id)) {
       return res.status(400).json({
         success: false,
@@ -194,9 +168,6 @@ export function validateId(paramName = "id") {
   };
 }
 
-/**
- * Valide les filtres de statut pour les jobs
- */
 export function validateJobStatus(req, res, next) {
   const { status } = req.query;
 
@@ -213,14 +184,9 @@ export function validateJobStatus(req, res, next) {
   next();
 }
 
-/**
- * Sanitise les entrées utilisateur
- */
 export function sanitizeInput(req, res, next) {
-  // Fonction récursive pour nettoyer un objet
   function sanitize(obj) {
     if (typeof obj === "string") {
-      // Supprimer les caractères dangereux
       return obj.trim().replace(/[<>]/g, "");
     } else if (typeof obj === "object" && obj !== null) {
       const sanitized = {};
@@ -243,9 +209,6 @@ export function sanitizeInput(req, res, next) {
   next();
 }
 
-/**
- * Valide les limites de taille des requêtes
- */
 export function validateRequestSize(maxSizeMB = 10) {
   return (req, res, next) => {
     const contentLength = parseInt(req.get("content-length"));
@@ -263,9 +226,6 @@ export function validateRequestSize(maxSizeMB = 10) {
   };
 }
 
-/**
- * Valide le Content-Type pour les requêtes POST/PUT
- */
 export function validateContentType(req, res, next) {
   if (["POST", "PUT", "PATCH"].includes(req.method)) {
     const contentType = req.get("content-type");

--- a/backend/src/services/conversionService.js
+++ b/backend/src/services/conversionService.js
@@ -58,7 +58,6 @@ class ConversionService {
         throw new Error("Conversion job not found");
       }
 
-      // Parse et valide la configuration de la source
       if (job.source) {
         job.source = enrichSourceWithConfig(job.source);
       }
@@ -70,6 +69,14 @@ class ConversionService {
     }
   }
 
+  /**
+   * Create a new pending ConversionJob record in the database.
+   * @param {string} sourceId - ID of the parent Source
+   * @param {string} fileName - Original file name
+   * @param {string} filePath - Local path to the downloaded file
+   * @param {number|null} [fileSize] - File size in bytes
+   * @returns {Promise<object>} Created job with source relation
+   */
   async createJob(sourceId, fileName, filePath, fileSize = null) {
     try {
       const job = await prisma.conversionJob.create({
@@ -85,12 +92,11 @@ class ConversionService {
         },
       });
 
-      // Parse et valide la configuration de la source
       if (job.source) {
         job.source = enrichSourceWithConfig(job.source);
       }
 
-      console.log(`📋 Conversion job created: ${fileName}`);
+      console.log(`Conversion job created: ${fileName}`);
       return job;
     } catch (error) {
       console.error("Error creating job:", error);
@@ -98,15 +104,20 @@ class ConversionService {
     }
   }
 
+  /**
+   * Execute a conversion job: download → convert → export → mark complete.
+   * Updates job status and progress in the database throughout.
+   * @param {string} jobId - ConversionJob DB id
+   * @returns {Promise<object>} Completed job record
+   * @throws {Error} On conversion failure (job is also marked as failed in DB)
+   */
   async processJob(jobId) {
     let job;
     try {
       job = await this.getJobById(jobId);
 
-      // Sauvegarder la config parsée avant l'update
       const parsedConfig = job.source.config;
 
-      // Marquer comme en cours
       job = await prisma.conversionJob.update({
         where: { id: jobId },
         data: {
@@ -117,29 +128,22 @@ class ConversionService {
         include: { source: true },
       });
 
-      // Restaurer la config parsée
       job.source.config = parsedConfig;
 
-      console.log(`🔄 Processing job: ${job.fileName}`);
+      console.log(`Processing job: ${job.fileName}`);
 
-      // Déterminer le type de fichier depuis le chemin téléchargé (pas fileName qui peut ne pas avoir d'extension pour Google Docs)
       const fileExtension = path.extname(job.filePath).toLowerCase();
-
-      // Obtenir le convertisseur approprié
       const converter = ConverterFactory.getConverter(fileExtension);
 
       if (!converter) {
         throw new Error(`Unsupported file format: ${fileExtension}`);
       }
 
-      // Mettre à jour le progrès
       await this.updateJobProgress(jobId, 30, "Initializing converter");
 
-      // Créer les dossiers de destination
       await fs.ensureDir(config.storagePath);
       await fs.ensureDir(config.tempPath);
 
-      // Définir le chemin de sortie avec destination validée
       const outputFileName = path.basename(job.fileName, fileExtension) + ".md";
       const destinationFolder = getValidatedDestination(
         job.source.config,
@@ -153,28 +157,22 @@ class ConversionService {
 
       await fs.ensureDir(path.dirname(outputPath));
 
-      // Mettre à jour le progrès
       await this.updateJobProgress(jobId, 50, "Converting file");
-
-      // Effectuer la conversion
       const result = await converter.convert(job.filePath, outputPath);
 
       if (!result.success) {
         throw new Error(result.error || "Conversion failed");
       }
 
-      // Mettre à jour le progrès
       await this.updateJobProgress(
         jobId,
         80,
         "Exporting to configured destination",
       );
 
-      // Export vers la destination configurée (une seule destination)
       try {
         await fs.ensureDir(config.exportPath);
 
-        // Récupérer et valider la destination configurée
         const destination = getValidatedDestination(
           job.source.config,
           job.source.name,
@@ -188,7 +186,7 @@ class ConversionService {
 
         await fs.ensureDir(path.dirname(exportFilePath));
         await fs.copy(outputPath, exportFilePath);
-        console.log(`📁 File exported to: ${exportFilePath}`);
+        console.log(`File exported to: ${exportFilePath}`);
       } catch (error) {
         console.warn(
           `Warning: Failed to export to configured destination:`,
@@ -196,7 +194,6 @@ class ConversionService {
         );
       }
 
-      // Marquer comme terminé
       const completedJob = await prisma.conversionJob.update({
         where: { id: jobId },
         data: {
@@ -207,7 +204,6 @@ class ConversionService {
         },
       });
 
-      // Enregistrer le fichier converti
       await prisma.convertedFile.create({
         data: {
           originalPath: job.filePath,
@@ -219,12 +215,11 @@ class ConversionService {
         },
       });
 
-      console.log(`✅ Job completed: ${job.fileName}`);
+      console.log(`Job completed: ${job.fileName}`);
       return completedJob;
     } catch (error) {
       console.error(`❌ Job failed: ${job?.fileName || jobId}`, error);
 
-      // Marquer comme échoué
       await prisma.conversionJob
         .update({
           where: { id: jobId },
@@ -234,7 +229,7 @@ class ConversionService {
             completedAt: new Date(),
           },
         })
-        .catch(() => null); // Ignore si la mise à jour échoue
+        .catch(() => null);
 
       throw error;
     }
@@ -250,7 +245,7 @@ class ConversionService {
       });
 
       if (message) {
-        console.log(`📊 Job ${jobId}: ${progress}% - ${message}`);
+        console.log(`Job ${jobId}: ${progress}% - ${message}`);
       }
     } catch (error) {
       console.error("Error updating job progress:", error);
@@ -271,7 +266,7 @@ class ConversionService {
         },
       });
 
-      console.log(`❌ Job cancelled: ${job.fileName}`);
+      console.log(`Job cancelled: ${job.fileName}`);
       return job;
     } catch (error) {
       console.error("Error cancelling job:", error);
@@ -296,16 +291,12 @@ class ConversionService {
         },
       });
 
-      // Note: Prisma ne supporte pas directement la différence de dates
-      // On skip cette partie pour éviter l'erreur
-
       return {
         byStatus: stats.reduce((acc, stat) => {
           acc[stat.status] = stat._count._all;
           return acc;
         }, {}),
         recent,
-        // avgProcessingTimeMs: avgProcessingTime // À implémenter
       };
     } catch (error) {
       console.error("Error fetching job stats:", error);
@@ -327,7 +318,7 @@ class ConversionService {
         },
       });
 
-      console.log(`🧹 Cleaned up ${result.count} old conversion jobs`);
+      console.log(`Cleaned up ${result.count} old conversion jobs`);
       return result.count;
     } catch (error) {
       console.error("Error cleaning up jobs:", error);

--- a/backend/src/services/monitoringService.js
+++ b/backend/src/services/monitoringService.js
@@ -33,16 +33,18 @@ class MonitoringService {
     return { parsedConfig, decryptedConfig };
   }
 
+  /**
+   * Start the monitoring service: connects all active sources and schedules periodic syncs.
+   */
   async start() {
     try {
       if (this.isRunning) {
-        console.log("⚠️ Monitoring service is already running");
+        console.warn("⚠️ Monitoring service is already running");
         return;
       }
 
-      console.log("🚀 Starting monitoring service...");
+      console.log("Starting monitoring service...");
 
-      // Démarrer le monitoring pour toutes les sources actives
       const activeSources = await prisma.source.findMany({
         where: { status: "active" },
       });
@@ -51,13 +53,10 @@ class MonitoringService {
         await this.startSourceMonitoring(source);
       }
 
-      // Démarrer le cron job pour la synchronisation périodique
       this.startCronJob();
 
       this.isRunning = true;
-      console.log(
-        `✅ Monitoring service started for ${activeSources.length} sources`,
-      );
+      console.log(`Monitoring service started for ${activeSources.length} sources`);
     } catch (error) {
       console.error("❌ Failed to start monitoring service:", error);
       throw error;
@@ -66,21 +65,19 @@ class MonitoringService {
 
   async stop() {
     try {
-      console.log("🛑 Stopping monitoring service...");
+      console.log("Stopping monitoring service...");
 
-      // Arrêter tous les monitors actifs
       for (const [sourceId] of this.activeMonitors) {
         await this.stopSourceMonitoring(sourceId);
       }
 
-      // Arrêter le cron job
       if (this.cronJob) {
         this.cronJob.destroy();
         this.cronJob = null;
       }
 
       this.isRunning = false;
-      console.log("✅ Monitoring service stopped");
+      console.log("Monitoring service stopped");
     } catch (error) {
       console.error("❌ Failed to stop monitoring service:", error);
       throw error;
@@ -88,13 +85,12 @@ class MonitoringService {
   }
 
   startCronJob() {
-    // Synchronisation périodique toutes les X minutes (configuré via env)
     const cronExpression = `*/${config.syncIntervalMinutes} * * * *`;
 
     this.cronJob = cron.schedule(
       cronExpression,
       async () => {
-        console.log("⏰ Running scheduled sync...");
+        console.log("Running scheduled sync...");
         await this.syncAllActiveSources();
       },
       {
@@ -103,37 +99,35 @@ class MonitoringService {
       },
     );
 
-    console.log(
-      `📅 Cron job scheduled: every ${config.syncIntervalMinutes} minutes`,
-    );
+    console.log(`Cron job scheduled: every ${config.syncIntervalMinutes} minutes`);
   }
 
+  /**
+   * Initialize monitoring for a single source: authenticate, test connection, and register the active monitor.
+   * @param {object} source - Prisma Source record
+   */
   async startSourceMonitoring(source) {
     try {
-      console.log(`🔍 Starting monitoring for: ${source.name}`);
+      console.log(`Starting monitoring for: ${source.name}`);
 
       const { decryptedConfig } = this._parseAndDecryptConfig(source);
 
-      // Créer le connecteur
       const connector = DriveConnectorFactory.createConnector(
         source.platform,
         decryptedConfig,
       );
 
-      // Tester la connexion
       const connectionTest = await connector.testConnection();
       if (!connectionTest.success) {
         throw new Error(`Connection failed: ${connectionTest.message}`);
       }
 
-      // Stocker le monitor actif
       this.activeMonitors.set(source.id, {
         source,
         connector,
         lastCheck: new Date(),
       });
 
-      // Log de démarrage
       await prisma.syncLog.create({
         data: {
           sourceId: source.id,
@@ -145,7 +139,6 @@ class MonitoringService {
     } catch (error) {
       console.error(`❌ Failed to start monitoring for ${source.name}:`, error);
 
-      // Log de l'erreur
       await prisma.syncLog.create({
         data: {
           sourceId: source.id,
@@ -165,9 +158,8 @@ class MonitoringService {
         return;
       }
 
-      console.log(`🛑 Stopping monitoring for: ${monitor.source.name}`);
+      console.log(`Stopping monitoring for: ${monitor.source.name}`);
 
-      // Nettoyer les ressources si nécessaire
       if (
         monitor.connector &&
         typeof monitor.connector.cleanup === "function"
@@ -177,7 +169,6 @@ class MonitoringService {
 
       this.activeMonitors.delete(sourceId);
 
-      // Log d'arrêt
       await prisma.syncLog.create({
         data: {
           sourceId,
@@ -206,10 +197,14 @@ class MonitoringService {
     }
   }
 
+  /**
+   * Sync a source: list remote files, filter by config, and enqueue conversion jobs for new/changed files.
+   * Skips if a sync is already in progress for this source.
+   * @param {string} sourceId - Source DB id
+   */
   async syncSource(sourceId) {
-    // Guard against concurrent syncs on the same source
     if (this.syncInProgress.has(sourceId)) {
-      console.log(`⚠️ Sync already in progress for source: ${sourceId}`);
+      console.warn(`⚠️ Sync already in progress for source: ${sourceId}`);
       return;
     }
 
@@ -234,12 +229,10 @@ class MonitoringService {
       let connector;
 
       if (monitor) {
-        // Sync automatique : utiliser le connecteur existant, mais rafraîchir les données source
         connector = monitor.connector;
         monitor.source = source;
       } else {
-        // Sync manuelle : créer un connecteur temporaire
-        console.log(`🔄 Manual sync for source: ${sourceId}`);
+        console.log(`Manual sync for source: ${sourceId}`);
 
         const { decryptedConfig } = this._parseAndDecryptConfig(source);
 
@@ -250,16 +243,14 @@ class MonitoringService {
         await connector.authenticate();
       }
 
-      console.log(`🔄 Syncing source: ${source.name}`);
+      console.log(`Syncing source: ${source.name}`);
 
-      // Parser le config une seule fois pour les filtres et le chemin
       const { parsedConfig } = this._parseAndDecryptConfig(source);
 
-      // Obtenir la liste des fichiers du drive
       const sourcePath = parsedConfig.sourcePath || "/";
       const files = await connector.listFiles(sourcePath);
 
-      // Normaliser les filtres (peuvent être des objets {"0":".docx",...} au lieu de tableaux)
+      // Normalize filters (may be objects {"0":".docx",...} instead of arrays)
       const rawExtensions = parsedConfig.filters?.extensions;
       const supportedExtensions = Array.isArray(rawExtensions)
         ? rawExtensions
@@ -274,7 +265,7 @@ class MonitoringService {
           ? Object.values(rawExclude)
           : [];
 
-      // Map Google Apps mimeTypes vers leurs extensions équivalentes
+      // Map Google Apps mimeTypes to their equivalent extensions
       const googleMimeToExt = {
         "application/vnd.google-apps.document": ".docx",
         "application/vnd.google-apps.spreadsheet": ".xlsx",
@@ -282,19 +273,19 @@ class MonitoringService {
       };
 
       const filteredFiles = files.filter((file) => {
-        // Vérifier par extension du nom de fichier
+        // Check by file name extension
         const hasValidExtension = supportedExtensions.some((ext) =>
           file.name.toLowerCase().endsWith(ext.toLowerCase()),
         );
 
-        // Ou par mimeType Google Apps (ces fichiers n'ont pas d'extension dans leur nom)
+        // Or by Google Apps mimeType (these files have no extension in their name)
         const googleExt = googleMimeToExt[file.mimeType];
         const matchesGoogleType = googleExt &&
           supportedExtensions.some((ext) => ext.toLowerCase() === googleExt);
 
         if (!hasValidExtension && !matchesGoogleType) return false;
 
-        // Vérifier les patterns d'exclusion
+        // Check exclusion patterns
         const isExcluded = excludePatterns.some((pattern) =>
           file.name.match(new RegExp(pattern)),
         );
@@ -302,24 +293,21 @@ class MonitoringService {
         return !isExcluded;
       });
 
-      console.log(`📁 Found ${filteredFiles.length} files to process`);
+      console.log(`Found ${filteredFiles.length} files to process`);
 
       for (const file of filteredFiles) {
         await this.processFileChange(sourceId, file, connector);
       }
 
-      // Mettre à jour le timestamp de dernière sync
       await prisma.source.update({
         where: { id: sourceId },
         data: { lastSync: new Date() },
       });
 
-      // Mettre à jour le monitor si présent
       if (monitor) {
         monitor.lastCheck = new Date();
       }
 
-      // Log de succès
       await prisma.syncLog.create({
         data: {
           sourceId,
@@ -354,7 +342,6 @@ class MonitoringService {
 
   async processFileChange(sourceId, file, connector) {
     try {
-      // Vérifier si le fichier a déjà été traité
       const existingFile = await prisma.convertedFile.findFirst({
         where: {
           originalPath: file.path,
@@ -362,17 +349,14 @@ class MonitoringService {
         },
       });
 
-      // Si le fichier existe et n'a pas été modifié, passer
       if (existingFile && existingFile.checksum === file.checksum) {
         return;
       }
 
-      console.log(`📄 Processing file: ${file.name}`);
+      console.log(`Processing file: ${file.name}`);
 
-      // Télécharger le fichier temporairement
       const tempPath = await connector.downloadFile(file.id, config.tempPath);
 
-      // Créer un job de conversion
       const job = await this.conversionService.createJob(
         sourceId,
         file.name,
@@ -380,16 +364,12 @@ class MonitoringService {
         file.size,
       );
 
-      // Ajouter le job à la queue asynchrone pour traitement en arrière-plan
       await queueService.enqueueConversion(job.id, file.name);
 
-      console.log(
-        `📥 Job ajouté à la queue pour traitement asynchrone: ${file.name}`,
-      );
+      console.log(`Job queued for async processing: ${file.name}`);
     } catch (error) {
       console.error(`❌ Failed to process file ${file.name}:`, error);
 
-      // Log de l'erreur
       await prisma.syncLog.create({
         data: {
           sourceId,

--- a/backend/src/services/queueService.js
+++ b/backend/src/services/queueService.js
@@ -2,81 +2,60 @@ import Queue from "bull";
 import config from "../config/env.js";
 import ConversionService from "./conversionService.js";
 
-/**
- * Service de gestion de la queue asynchrone pour les conversions de documents
- * Utilise Bull pour gérer les jobs de conversion de manière asynchrone
- */
 class QueueService {
   constructor() {
     this.conversionService = new ConversionService();
 
-    // Créer la queue de conversion avec Redis
     this.conversionQueue = new Queue("document-conversion", config.redisUrl, {
       defaultJobOptions: {
-        attempts: 3, // 3 tentatives en cas d'échec
+        attempts: 3,
         backoff: {
           type: "exponential",
-          delay: 2000, // Délai initial de 2s, puis 4s, puis 8s
+          delay: 2000,
         },
-        removeOnComplete: 100, // Garder les 100 derniers jobs complétés
-        removeOnFail: 200, // Garder les 200 derniers jobs échoués
+        removeOnComplete: 100,
+        removeOnFail: 200,
       },
     });
 
-    // Configuration des event handlers
     this.setupEventHandlers();
   }
 
-  /**
-   * Configure les gestionnaires d'événements pour la queue
-   */
   setupEventHandlers() {
-    // Job complété avec succès
     this.conversionQueue.on("completed", (job, result) => {
-      console.log(`✅ Job ${job.id} complété: ${result.fileName}`);
+      console.log(`Job ${job.id} completed: ${result.fileName}`);
     });
 
-    // Job échoué
     this.conversionQueue.on("failed", (job, error) => {
-      console.error(`❌ Job ${job.id} échoué:`, error.message);
+      console.error(`❌ Job ${job.id} failed:`, error.message);
     });
 
-    // Job en cours
     this.conversionQueue.on("active", (job) => {
-      console.log(`⚙️ Traitement du job ${job.id}: ${job.data.fileName}`);
+      console.log(`Processing job ${job.id}: ${job.data.fileName}`);
     });
 
-    // Progression d'un job
     this.conversionQueue.on("progress", (job, progress) => {
-      console.log(`📊 Job ${job.id} progression: ${progress}%`);
+      console.log(`Job ${job.id} progress: ${progress}%`);
     });
 
-    // Queue en erreur
     this.conversionQueue.on("error", (error) => {
-      console.error("❌ Erreur de queue:", error);
+      console.error("❌ Queue error:", error);
     });
   }
 
   /**
-   * Configure le processeur de jobs
-   * @param {number} concurrency - Nombre de jobs à traiter en parallèle (défaut: 3)
+   * Start consuming the conversion queue.
+   * @param {number} concurrency - Number of jobs to process in parallel
    */
   async startProcessing(concurrency = 3) {
-    console.log(
-      `🚀 Démarrage du processeur de queue (concurrence: ${concurrency})`,
-    );
+    console.log(`Starting queue processor (concurrency: ${concurrency})`);
 
     this.conversionQueue.process(concurrency, async (job) => {
       const { jobId, fileName } = job.data;
 
       try {
-        // Mettre à jour la progression: démarrage
         await job.progress(10);
-
-        // Traiter le job de conversion
         const result = await this.conversionService.processJob(jobId);
-
-        // Mettre à jour la progression: terminé
         await job.progress(100);
 
         return {
@@ -86,20 +65,18 @@ class QueueService {
           outputPath: result.outputPath,
         };
       } catch (error) {
-        console.error(`❌ Erreur lors du traitement du job ${jobId}:`, error);
-
-        // Relancer l'erreur pour que Bull gère les retries
+        console.error(`❌ Error processing job ${jobId}:`, error);
         throw error;
       }
     });
   }
 
   /**
-   * Ajoute un job de conversion à la queue
-   * @param {string} jobId - ID du job de conversion dans la base de données
-   * @param {string} fileName - Nom du fichier à convertir
-   * @param {object} options - Options du job (priority, delay, etc.)
-   * @returns {Promise<object>} Job Bull créé
+   * Add a conversion job to the queue.
+   * @param {string} jobId - ConversionJob DB id
+   * @param {string} fileName - Human-readable file name for logging
+   * @param {object} [options] - Optional Bull job options (priority, delay)
+   * @returns {Promise<Bull.Job>} The created Bull job
    */
   async enqueueConversion(jobId, fileName, options = {}) {
     try {
@@ -110,22 +87,18 @@ class QueueService {
         {
           priority,
           delay,
-          jobId: `conversion-${jobId}`, // ID unique pour éviter les duplications
+          jobId: `conversion-${jobId}`,
         },
       );
 
-      console.log(`📥 Job ajouté à la queue: ${fileName} (ID: ${job.id})`);
+      console.log(`Job enqueued: ${fileName} (ID: ${job.id})`);
       return job;
     } catch (error) {
-      console.error("❌ Erreur lors de l'ajout à la queue:", error);
+      console.error("❌ Error enqueuing job:", error);
       throw error;
     }
   }
 
-  /**
-   * Récupère les statistiques de la queue
-   * @returns {Promise<object>} Statistiques (waiting, active, completed, failed, delayed)
-   */
   async getStats() {
     try {
       const [waiting, active, completed, failed, delayed] = await Promise.all([
@@ -145,15 +118,11 @@ class QueueService {
         total: waiting + active + completed + failed + delayed,
       };
     } catch (error) {
-      console.error("❌ Erreur lors de la récupération des stats:", error);
+      console.error("❌ Error fetching stats:", error);
       throw error;
     }
   }
 
-  /**
-   * Récupère les jobs actifs
-   * @returns {Promise<Array>} Liste des jobs en cours
-   */
   async getActiveJobs() {
     try {
       const jobs = await this.conversionQueue.getActive();
@@ -164,18 +133,11 @@ class QueueService {
         timestamp: job.timestamp,
       }));
     } catch (error) {
-      console.error(
-        "❌ Erreur lors de la récupération des jobs actifs:",
-        error,
-      );
+      console.error("❌ Error fetching active jobs:", error);
       throw error;
     }
   }
 
-  /**
-   * Récupère les jobs en attente
-   * @returns {Promise<Array>} Liste des jobs en attente
-   */
   async getWaitingJobs() {
     try {
       const jobs = await this.conversionQueue.getWaiting();
@@ -185,19 +147,11 @@ class QueueService {
         timestamp: job.timestamp,
       }));
     } catch (error) {
-      console.error(
-        "❌ Erreur lors de la récupération des jobs en attente:",
-        error,
-      );
+      console.error("❌ Error fetching waiting jobs:", error);
       throw error;
     }
   }
 
-  /**
-   * Récupère les jobs échoués
-   * @param {number} limit - Nombre maximum de jobs à retourner
-   * @returns {Promise<Array>} Liste des jobs échoués
-   */
   async getFailedJobs(limit = 20) {
     try {
       const jobs = await this.conversionQueue.getFailed(0, limit - 1);
@@ -210,91 +164,63 @@ class QueueService {
         attemptsMade: job.attemptsMade,
       }));
     } catch (error) {
-      console.error(
-        "❌ Erreur lors de la récupération des jobs échoués:",
-        error,
-      );
+      console.error("❌ Error fetching failed jobs:", error);
       throw error;
     }
   }
 
-  /**
-   * Nettoie les anciens jobs (complétés et échoués)
-   * @param {number} grace - Période de grâce en millisecondes (défaut: 24h)
-   * @returns {Promise<void>}
-   */
   async cleanOldJobs(grace = 24 * 60 * 60 * 1000) {
     try {
       await this.conversionQueue.clean(grace, "completed");
       await this.conversionQueue.clean(grace, "failed");
-      console.log(
-        `🧹 Nettoyage des jobs terminés depuis plus de ${grace / 1000 / 60 / 60}h`,
-      );
+      console.log(`Cleaned jobs older than ${grace / 1000 / 60 / 60}h`);
     } catch (error) {
-      console.error("❌ Erreur lors du nettoyage des jobs:", error);
+      console.error("❌ Error cleaning jobs:", error);
       throw error;
     }
   }
 
-  /**
-   * Vide complètement la queue (tous les jobs)
-   * ⚠️ Utiliser avec précaution!
-   * @returns {Promise<void>}
-   */
   async emptyQueue() {
     try {
       await this.conversionQueue.empty();
-      console.log("🗑️ Queue vidée complètement");
+      console.log("Queue emptied");
     } catch (error) {
-      console.error("❌ Erreur lors du vidage de la queue:", error);
+      console.error("❌ Error emptying queue:", error);
       throw error;
     }
   }
 
-  /**
-   * Pause la queue (arrête le traitement des nouveaux jobs)
-   * @returns {Promise<void>}
-   */
   async pause() {
     try {
       await this.conversionQueue.pause();
-      console.log("⏸️ Queue mise en pause");
+      console.log("Queue paused");
     } catch (error) {
-      console.error("❌ Erreur lors de la pause de la queue:", error);
+      console.error("❌ Error pausing queue:", error);
       throw error;
     }
   }
 
-  /**
-   * Reprend le traitement de la queue
-   * @returns {Promise<void>}
-   */
   async resume() {
     try {
       await this.conversionQueue.resume();
-      console.log("▶️ Queue reprise");
+      console.log("Queue resumed");
     } catch (error) {
-      console.error("❌ Erreur lors de la reprise de la queue:", error);
+      console.error("❌ Error resuming queue:", error);
       throw error;
     }
   }
 
-  /**
-   * Ferme proprement la queue
-   * @returns {Promise<void>}
-   */
   async close() {
     try {
       await this.conversionQueue.close();
-      console.log("🛑 Queue fermée");
+      console.log("Queue closed");
     } catch (error) {
-      console.error("❌ Erreur lors de la fermeture de la queue:", error);
+      console.error("❌ Error closing queue:", error);
       throw error;
     }
   }
 }
 
-// Singleton instance
 const queueService = new QueueService();
 
 export default queueService;

--- a/backend/src/services/sourceService.js
+++ b/backend/src/services/sourceService.js
@@ -22,7 +22,6 @@ class SourceService {
         },
       });
 
-      // Déchiffrer les credentials pour l'affichage (sans les exposer complètement)
       return sources.map((source) => {
         const parsedConfig = JSON.parse(source.config);
         return {
@@ -57,7 +56,6 @@ class SourceService {
         throw new Error("Source not found");
       }
 
-      // Parse la config JSON
       return {
         ...source,
         config: JSON.parse(source.config),
@@ -68,16 +66,19 @@ class SourceService {
     }
   }
 
+  /**
+   * Create a new source with encrypted credentials.
+   * @param {object} sourceData - { name, platform, config: { credentials, sourcePath, destination, filters } }
+   * @returns {Promise<object>} Created Prisma Source record
+   */
   async createSource(sourceData) {
     try {
       const { name, platform, config } = sourceData;
 
-      // Validation des données
       if (!name || !platform || !config) {
         throw new Error("Missing required fields: name, platform, config");
       }
 
-      // Chiffrement des credentials
       const encryptedConfig = {
         ...config,
         credentials: config.credentials
@@ -94,7 +95,7 @@ class SourceService {
         },
       });
 
-      console.log(`✅ Source created: ${name} (${platform})`);
+      console.log(`Source created: ${name} (${platform})`);
       return source;
     } catch (error) {
       console.error("Error creating source:", error);
@@ -106,7 +107,6 @@ class SourceService {
     try {
       const existingSource = await this.getSourceById(id);
 
-      // Chiffrement des nouvelles credentials si fournies
       const updatedConfig = updateData.config
         ? {
             ...existingSource.config,
@@ -126,7 +126,7 @@ class SourceService {
         },
       });
 
-      console.log(`✅ Source updated: ${source.name}`);
+      console.log(`Source updated: ${source.name}`);
       return source;
     } catch (error) {
       console.error("Error updating source:", error);
@@ -140,7 +140,7 @@ class SourceService {
         where: { id },
       });
 
-      console.log(`✅ Source deleted: ${id}`);
+      console.log(`Source deleted: ${id}`);
       return { success: true };
     } catch (error) {
       console.error("Error deleting source:", error);
@@ -148,39 +148,29 @@ class SourceService {
     }
   }
 
+  /**
+   * Test raw credentials against a platform without persisting a source.
+   * @param {object} testData - { platform, credentials, sourcePath, siteUrl? }
+   * @returns {Promise<object>} Connection test result { success, message, details }
+   */
   async testCredentials(testData) {
     try {
       const { platform, credentials, sourcePath, siteUrl } = testData;
 
-      console.log(`🧪 Testing credentials for ${platform}:`, {
-        platform,
-        hasCredentials: !!credentials,
-        credentialsKeys: credentials ? Object.keys(credentials) : [],
-        sourcePath: sourcePath || "/",
-        siteUrl,
-      });
-
-      // Préparer la config pour le test avec la bonne structure
       const testConfig = {
-        credentials, // Les credentials doivent être dans config.credentials
+        credentials,
         sourcePath: sourcePath || "/",
         ...(siteUrl && { siteUrl }),
       };
 
-      // Créer le connecteur approprié
       const connector = DriveConnectorFactory.createConnector(
         platform,
         testConfig,
       );
 
-      // Test de connexion
       const result = await connector.testConnection();
 
-      console.log(
-        `🧪 Credentials test for ${platform}:`,
-        result.success ? "✅ Success" : "❌ Failed",
-        result,
-      );
+      console.log(`Credentials test for ${platform}: ${result.success ? "success" : "failed"}`);
 
       return result;
     } catch (error) {
@@ -188,7 +178,7 @@ class SourceService {
 
       return {
         success: false,
-        message: error.message || "Test des identifiants échoué",
+        message: error.message || "Credentials test failed",
         details: {
           platform: testData.platform,
           error: error.name || "Unknown error",
@@ -201,7 +191,6 @@ class SourceService {
     try {
       const source = await this.getSourceById(id);
 
-      // Déchiffrer les credentials pour le test
       const decryptedConfig = {
         ...source.config,
         credentials: source.config.credentials
@@ -209,16 +198,13 @@ class SourceService {
           : null,
       };
 
-      // Créer le connecteur approprié
       const connector = DriveConnectorFactory.createConnector(
         source.platform,
         decryptedConfig,
       );
 
-      // Test de connexion
       const result = await connector.testConnection();
 
-      // Log du résultat
       await prisma.syncLog.create({
         data: {
           sourceId: id,
@@ -233,7 +219,6 @@ class SourceService {
     } catch (error) {
       console.error("Connection test failed:", error);
 
-      // Log de l'erreur
       await prisma.syncLog.create({
         data: {
           sourceId: id,
@@ -250,11 +235,10 @@ class SourceService {
 
   async syncSource(id) {
     try {
-      // Importer dynamiquement pour éviter les dépendances circulaires
+      // Dynamic import to avoid circular dependencies
       const monitoringService = (await import("./monitoringService.js"))
         .default;
 
-      // Utiliser la méthode de synchronisation du monitoring service
       await monitoringService.syncSource(id);
 
       return {
@@ -282,7 +266,7 @@ class SourceService {
       const recentJobs = await prisma.conversionJob.count({
         where: {
           createdAt: {
-            gte: new Date(Date.now() - 24 * 60 * 60 * 1000), // 24h
+            gte: new Date(Date.now() - 24 * 60 * 60 * 1000),
           },
         },
       });
@@ -298,11 +282,16 @@ class SourceService {
     }
   }
 
+  /**
+   * List Google Drive folders under a given parent folder.
+   * @param {string} parentId - Drive folder ID (or "root")
+   * @param {object} credentials - Google OAuth credentials
+   * @returns {Promise<object[]>} Array of folder metadata objects
+   */
   async getGoogleDriveFolders(parentId, credentials) {
     try {
-      console.log(`🔍 Fetching Google Drive folders from parent: ${parentId}`);
+      console.log(`Fetching Google Drive folders from parent: ${parentId}`);
 
-      // Créer une configuration temporaire pour le connecteur
       const config = {
         credentials: credentials,
         sourcePath: parentId,
@@ -320,7 +309,7 @@ class SourceService {
 
       await connector.cleanup();
 
-      console.log(`✅ Found ${folders.length} folders`);
+      console.log(`Found ${folders.length} folders`);
       return folders;
     } catch (error) {
       console.error("Error fetching Google Drive folders:", error);
@@ -328,17 +317,17 @@ class SourceService {
     }
   }
 
+  /**
+   * Preview convertible files in a Google Drive folder without creating jobs.
+   * @param {string} folderId - Drive folder ID
+   * @param {object} credentials - Google OAuth credentials
+   * @param {string[]|object} allowedExtensions - File extensions to include (e.g. [".docx", ".pdf"])
+   * @returns {Promise<{totalFiles: number, convertibleFiles: number, files: object[]}>}
+   */
   async previewGoogleDriveFiles(folderId, credentials, allowedExtensions) {
     try {
-      console.log(`🔍 Previewing files in Google Drive folder: ${folderId}`);
-      console.log(
-        "allowedExtensions type:",
-        typeof allowedExtensions,
-        "value:",
-        allowedExtensions,
-      );
+      console.log(`Previewing files in Google Drive folder: ${folderId}`);
 
-      // Convert allowedExtensions to array properly
       let extensionsArray;
       if (Array.isArray(allowedExtensions)) {
         extensionsArray = allowedExtensions;
@@ -346,14 +335,11 @@ class SourceService {
         typeof allowedExtensions === "object" &&
         allowedExtensions !== null
       ) {
-        // Convert object with numeric indices to array
         extensionsArray = Object.values(allowedExtensions);
       } else {
         extensionsArray = [allowedExtensions];
       }
-      console.log("extensionsArray:", extensionsArray);
 
-      // Créer une configuration temporaire pour le connecteur
       const config = {
         credentials: credentials,
         sourcePath: folderId,
@@ -369,24 +355,14 @@ class SourceService {
 
       const files = await connector.listFiles(folderId);
 
-      console.log(
-        `📋 Files found in folder ${folderId}:`,
-        files.map((f) => ({
-          name: f.name,
-          mimeType: f.mimeType,
-        })),
-      );
-
-      // Filtrer par extensions OU par mimeType (pour Google Docs natifs)
       const filteredFiles = files.filter((file) => {
         if (!file.name) {
-          console.log("❌ File without name, skipping");
           return false;
         }
         const fileName = file.name.toLowerCase();
         const mimeType = file.mimeType || "";
 
-        // 1. Vérifier si c'est un Google Doc natif (à convertir en DOCX)
+        // Check for Google native docs (will be exported as DOCX/PDF)
         const isGoogleDoc = mimeType === "application/vnd.google-apps.document";
         const isGoogleSheet =
           mimeType === "application/vnd.google-apps.spreadsheet";
@@ -394,35 +370,23 @@ class SourceService {
           mimeType === "application/vnd.google-apps.presentation";
 
         if (isGoogleDoc || isGoogleSheet || isGoogleSlide) {
-          console.log(
-            `✅ Google native file "${file.name}" (${mimeType}) - will be exported as DOCX/PDF`,
-          );
           return true;
         }
 
-        // 2. Vérifier si le fichier se termine par une des extensions autorisées
+        // Check if the file matches an allowed extension
         const matches = extensionsArray.some((ext) => {
           const extension = ext.toLowerCase().startsWith(".")
             ? ext.toLowerCase()
             : `.${ext.toLowerCase()}`;
-          const endsWith = fileName.endsWith(extension);
-          console.log(
-            `  Checking "${fileName}" ends with "${extension}": ${endsWith}`,
-          );
-          return endsWith;
+          return fileName.endsWith(extension);
         });
 
-        console.log(
-          `${matches ? "✅" : "❌"} File "${file.name}" - matches: ${matches}`,
-        );
         return matches;
       });
 
       await connector.cleanup();
 
-      console.log(
-        `✅ Found ${filteredFiles.length} convertible files out of ${files.length} total`,
-      );
+      console.log(`Found ${filteredFiles.length} convertible files out of ${files.length} total`);
 
       return {
         totalFiles: files.length,
@@ -447,14 +411,10 @@ class SourceService {
     let errorCount = 0;
 
     try {
-      console.log(
-        `🔄 Starting conversion processing for ${files.length} files`,
-      );
+      console.log(`Starting conversion processing for ${files.length} files`);
 
-      // Traiter chaque fichier
       for (const file of files) {
         try {
-          // Vérifier si le fichier a déjà été traité récemment
           const existingFile = await prisma.convertedFile.findFirst({
             where: {
               originalPath: file.path || file.id,
@@ -463,25 +423,21 @@ class SourceService {
             orderBy: { createdAt: "desc" },
           });
 
-          // Si le fichier existe et a été modifié récemment, passer
           if (existingFile && file.modifiedTime) {
             const fileModified = new Date(file.modifiedTime);
             const lastProcessed = existingFile.createdAt;
             if (fileModified <= lastProcessed) {
-              console.log(`⏭️  File ${file.name} already up to date, skipping`);
               continue;
             }
           }
 
-          console.log(`📄 Processing file: ${file.name}`);
+          console.log(`Processing file: ${file.name}`);
 
-          // Télécharger le fichier temporairement
           const tempPath = await connector.downloadFile(
             file.id,
             config.tempPath,
           );
 
-          // Créer un job de conversion
           const job = await conversionService.createJob(
             source.id,
             file.name,
@@ -489,18 +445,16 @@ class SourceService {
             file.size,
           );
 
-          console.log(`📋 Created conversion job for: ${file.name}`);
+          console.log(`Created conversion job for: ${file.name}`);
 
-          // Traiter le job immédiatement
           await conversionService.processJob(job.id);
 
           processedCount++;
-          console.log(`✅ Successfully converted: ${file.name}`);
+          console.log(`Successfully converted: ${file.name}`);
         } catch (error) {
           errorCount++;
           console.error(`❌ Failed to process file ${file.name}:`, error);
 
-          // Log de l'erreur pour ce fichier spécifique
           await prisma.syncLog.create({
             data: {
               sourceId: source.id,
@@ -516,7 +470,6 @@ class SourceService {
         }
       }
 
-      // Mettre à jour le log de sync principal
       await prisma.syncLog.update({
         where: { id: syncLogId },
         data: {
@@ -532,16 +485,13 @@ class SourceService {
         },
       });
 
-      console.log(
-        `✅ Processing completed for source: ${source.name} (${processedCount}/${files.length} files converted)`,
-      );
+      console.log(`Processing completed for source: ${source.name} (${processedCount}/${files.length} files converted)`);
     } catch (error) {
       console.error(
         `❌ Critical error during file processing for source ${source.name}:`,
         error,
       );
 
-      // Mettre à jour le log avec l'erreur critique
       await prisma.syncLog.update({
         where: { id: syncLogId },
         data: {

--- a/backend/src/utils/configParser.js
+++ b/backend/src/utils/configParser.js
@@ -1,24 +1,12 @@
-/**
- * Utilitaires pour le parsing et la validation des configurations
- */
-
-/**
- * Parse de manière sécurisée la configuration JSON d'une source
- * @param {Object|string} source - La source avec sa configuration
- * @returns {Object} - La configuration parsée
- * @throws {Error} - Si le parsing échoue
- */
 export function parseSourceConfig(source) {
   if (!source || !source.config) {
     throw new Error("Source configuration is missing");
   }
 
-  // Si c'est déjà un objet, le retourner
   if (typeof source.config === "object") {
     return source.config;
   }
 
-  // Si c'est une string, essayer de la parser
   if (typeof source.config === "string") {
     try {
       return JSON.parse(source.config);
@@ -31,11 +19,6 @@ export function parseSourceConfig(source) {
   throw new Error("Source configuration must be an object or valid JSON string");
 }
 
-/**
- * Valide le chemin de destination pour éviter les attaques de traversal
- * @param {string} destination - Le chemin de destination à valider
- * @throws {Error} - Si le chemin n'est pas valide
- */
 export function validateDestinationPath(destination) {
   if (!destination || typeof destination !== "string") {
     throw new Error("Destination must be a non-empty string");
@@ -47,7 +30,6 @@ export function validateDestinationPath(destination) {
     throw new Error("Destination cannot be empty");
   }
 
-  // Vérifier les caractères dangereux
   if (trimmed.includes("..")) {
     throw new Error("Destination cannot contain '..' (path traversal prevention)");
   }
@@ -56,7 +38,6 @@ export function validateDestinationPath(destination) {
     throw new Error("Destination cannot start with '/' or '\\' (must be relative)");
   }
 
-  // Vérifier les caractères interdits
   const dangerousChars = ["<", ">", ":", '"', "|", "?", "*"];
   for (const char of dangerousChars) {
     if (trimmed.includes(char)) {
@@ -64,7 +45,6 @@ export function validateDestinationPath(destination) {
     }
   }
 
-  // Vérifier la longueur maximum
   if (trimmed.length > 200) {
     throw new Error("Destination path too long (max 200 characters)");
   }
@@ -72,22 +52,11 @@ export function validateDestinationPath(destination) {
   return trimmed;
 }
 
-/**
- * Extrait et valide la destination d'une configuration source
- * @param {Object} config - La configuration parsée
- * @param {string} fallback - Valeur par défaut si destination manquante
- * @returns {string} - La destination validée
- */
 export function getValidatedDestination(config, fallback = "default") {
   const destination = config.destination || fallback;
   return validateDestinationPath(destination);
 }
 
-/**
- * Parse et enrichit une source avec sa configuration validée
- * @param {Object} source - La source brute de la base de données
- * @returns {Object} - La source avec sa configuration parsée et validée
- */
 export function enrichSourceWithConfig(source) {
   try {
     const parsedConfig = parseSourceConfig(source);

--- a/backend/src/utils/encryption.js
+++ b/backend/src/utils/encryption.js
@@ -7,29 +7,18 @@ const IV_LENGTH = 12; // Pour GCM
 const TAG_LENGTH = 16;
 const ENCODING = "base64";
 
-/**
- * Chiffre des données sensibles (credentials, tokens)
- * @param {string|object} data - Données à chiffrer
- * @returns {string} - Données chiffrées encodées en base64
- */
 export function encryptCredentials(data) {
   try {
     const text = typeof data === "string" ? data : JSON.stringify(data);
 
-    // Générer un IV aléatoire
     const iv = crypto.randomBytes(IV_LENGTH);
-
-    // Créer le cipher
     const cipher = crypto.createCipheriv(ALGORITHM, config.encryptionKey, iv);
 
-    // Chiffrer les données
     let encrypted = cipher.update(text, "utf8", ENCODING);
     encrypted += cipher.final(ENCODING);
 
-    // Obtenir le tag d'authentification (pour GCM)
     const tag = cipher.getAuthTag();
 
-    // Combiner IV + tag + données chiffrées
     const result = Buffer.concat([
       iv,
       tag,
@@ -43,36 +32,25 @@ export function encryptCredentials(data) {
   }
 }
 
-/**
- * Déchiffre des données
- * @param {string} encryptedData - Données chiffrées en base64
- * @returns {string|object} - Données déchiffrées
- */
 export function decryptCredentials(encryptedData) {
   try {
     if (!encryptedData) {
       throw new Error("No encrypted data provided");
     }
 
-    // Décoder les données
     const buffer = Buffer.from(encryptedData, ENCODING);
-
-    // Extraire IV, tag et données chiffrées
     const iv = buffer.subarray(0, IV_LENGTH);
     const tag = buffer.subarray(IV_LENGTH, IV_LENGTH + TAG_LENGTH);
     const encrypted = buffer
       .subarray(IV_LENGTH + TAG_LENGTH)
       .toString(ENCODING);
 
-    // Créer le decipher
     const decipher = crypto.createDecipheriv(ALGORITHM, config.encryptionKey, iv);
     decipher.setAuthTag(tag);
 
-    // Déchiffrer
     let decrypted = decipher.update(encrypted, ENCODING, "utf8");
     decrypted += decipher.final("utf8");
 
-    // Essayer de parser en JSON, sinon retourner la string
     try {
       return JSON.parse(decrypted);
     } catch {
@@ -84,19 +62,10 @@ export function decryptCredentials(encryptedData) {
   }
 }
 
-/**
- * Génère une clé de chiffrement aléatoire de 32 caractères
- * @returns {string} - Clé de chiffrement
- */
 export function generateEncryptionKey() {
   return crypto.randomBytes(32).toString("hex");
 }
 
-/**
- * Hache un mot de passe avec salt
- * @param {string} password - Mot de passe à hacher
- * @returns {string} - Hash du mot de passe
- */
 export function hashPassword(password) {
   const salt = crypto.randomBytes(16).toString("hex");
   const hash = crypto
@@ -105,12 +74,6 @@ export function hashPassword(password) {
   return `${salt}:${hash}`;
 }
 
-/**
- * Vérifie un mot de passe contre son hash
- * @param {string} password - Mot de passe à vérifier
- * @param {string} hashedPassword - Hash stocké
- * @returns {boolean} - True si le mot de passe correspond
- */
 export function verifyPassword(password, hashedPassword) {
   try {
     const [salt, hash] = hashedPassword.split(":");
@@ -124,11 +87,6 @@ export function verifyPassword(password, hashedPassword) {
   }
 }
 
-/**
- * Génère un checksum MD5 pour un fichier
- * @param {string} filePath - Chemin vers le fichier
- * @returns {Promise<string>} - Checksum MD5
- */
 export async function generateFileChecksum(filePath) {
   return new Promise((resolve, reject) => {
     const hash = crypto.createHash("md5");

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,7 +10,6 @@ import Dashboard from "./pages/Dashboard";
 function App() {
   const { status: monitoringStatus } = useMonitoring();
 
-  // Détecter si on est sur la page de callback OAuth
   const isAuthCallback =
     window.location.pathname === "/auth/callback" ||
     window.location.search.includes("success=true") ||
@@ -18,7 +17,6 @@ function App() {
 
   return (
     <div className="min-h-screen bg-background flex flex-col">
-      {/* Header */}
       <header className="border-b">
         <div className="container mx-auto px-6 py-4 flex items-center justify-between">
           <div className="flex items-center gap-2">
@@ -33,23 +31,20 @@ function App() {
         </div>
       </header>
 
-      {/* Main Content */}
       <main className="container mx-auto px-6 py-8 flex-1">
         {isAuthCallback ? <AuthCallback /> : <Dashboard />}
       </main>
 
-      {/* Footer */}
       <footer className="border-t">
         <div className="container mx-auto px-6 py-4">
           <div className="flex items-center justify-between text-sm text-muted-foreground">
             <p>
-              Doc2AI - Convertisseur automatique de documentation pour
-              développeurs
+              Doc2AI - Automatic documentation converter for developers
             </p>
             {monitoringStatus?.isRunning && (
               <div className="flex items-center gap-1">
                 <div className="h-2 w-2 bg-green-500 rounded-full animate-pulse" />
-                <span className="text-xs">En ligne</span>
+                <span className="text-xs">Online</span>
               </div>
             )}
           </div>

--- a/frontend/src/components/auth/GoogleAuthButton.tsx
+++ b/frontend/src/components/auth/GoogleAuthButton.tsx
@@ -20,7 +20,7 @@ export function GoogleAuthButton({
       await connect();
     } catch (err) {
       const errorMessage =
-        err instanceof Error ? err.message : "Erreur de connexion";
+        err instanceof Error ? err.message : "Connection error";
       onAuthError?.(errorMessage);
     }
   };
@@ -29,14 +29,12 @@ export function GoogleAuthButton({
     disconnect();
   };
 
-  // Effet pour notifier le parent quand l'authentification réussit
   React.useEffect(() => {
     if (user && onAuthSuccess) {
       onAuthSuccess(user.refreshToken, user.email);
     }
   }, [user, onAuthSuccess]);
 
-  // Effet pour notifier le parent en cas d'erreur
   React.useEffect(() => {
     if (error && onAuthError) {
       onAuthError(error);
@@ -85,7 +83,7 @@ export function GoogleAuthButton({
         {isConnecting ? (
           <>
             <Loader2 className="mr-3 h-5 w-5 animate-spin" />
-            Connexion en cours...
+            Connecting...
           </>
         ) : (
           <>
@@ -109,7 +107,7 @@ export function GoogleAuthButton({
                 />
               </svg>
             </div>
-            Se connecter avec Google
+            Sign in with Google
           </>
         )}
       </Button>

--- a/frontend/src/components/dashboard/SourceCard.tsx
+++ b/frontend/src/components/dashboard/SourceCard.tsx
@@ -25,7 +25,6 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { format } from "date-fns";
-import { fr } from "date-fns/locale";
 import {
   Calendar,
   CheckCircle,
@@ -69,7 +68,7 @@ export function SourceCard({ source, onSync, onDelete }: SourceCardProps) {
     } catch (error) {
       setConnectionResult({
         success: false,
-        message: error instanceof Error ? error.message : "Erreur de test",
+        message: error instanceof Error ? error.message : "Test error",
       });
     } finally {
       setIsTestingConnection(false);
@@ -101,11 +100,11 @@ export function SourceCard({ source, onSync, onDelete }: SourceCardProps) {
   const getStatusBadge = (status: string) => {
     switch (status) {
       case "active":
-        return <Badge className="bg-green-100 text-green-800">Actif</Badge>;
+        return <Badge className="bg-green-100 text-green-800">Active</Badge>;
       case "inactive":
-        return <Badge variant="secondary">Inactif</Badge>;
+        return <Badge variant="secondary">Inactive</Badge>;
       case "error":
-        return <Badge variant="destructive">Erreur</Badge>;
+        return <Badge variant="destructive">Error</Badge>;
       default:
         return <Badge variant="outline">{status}</Badge>;
     }
@@ -129,12 +128,12 @@ export function SourceCard({ source, onSync, onDelete }: SourceCardProps) {
   };
 
   const formatDate = (dateString?: string) => {
-    if (!dateString) return "Jamais";
+    if (!dateString) return "Never";
     try {
       const date = new Date(dateString);
-      return format(date, "PPp", { locale: fr });
+      return format(date, "PPp");
     } catch {
-      return "Date invalide";
+      return "Invalid date";
     }
   };
 
@@ -170,7 +169,7 @@ export function SourceCard({ source, onSync, onDelete }: SourceCardProps) {
                     ) : (
                       <TestTube className="mr-2 h-4 w-4" />
                     )}
-                    Tester la connexion
+                    Test connection
                   </DropdownMenuItem>
                   <DropdownMenuItem onClick={handleSync} disabled={isSyncing}>
                     {isSyncing ? (
@@ -178,19 +177,19 @@ export function SourceCard({ source, onSync, onDelete }: SourceCardProps) {
                     ) : (
                       <RefreshCw className="mr-2 h-4 w-4" />
                     )}
-                    Synchroniser maintenant
+                    Sync now
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem>
                     <Settings className="mr-2 h-4 w-4" />
-                    Configurer
+                    Configure
                   </DropdownMenuItem>
                   <DropdownMenuItem
                     onClick={() => setShowDeleteDialog(true)}
                     className="text-red-600 hover:text-red-700"
                   >
                     <Trash2 className="mr-2 h-4 w-4" />
-                    Supprimer
+                    Delete
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
@@ -199,7 +198,6 @@ export function SourceCard({ source, onSync, onDelete }: SourceCardProps) {
         </CardHeader>
 
         <CardContent className="space-y-4">
-          {/* Résultat du test de connexion */}
           {connectionResult && (
             <div
               className={`p-3 rounded-lg border text-sm ${
@@ -216,20 +214,19 @@ export function SourceCard({ source, onSync, onDelete }: SourceCardProps) {
                 )}
                 <span className="font-medium">
                   {connectionResult.success
-                    ? "Connexion OK"
-                    : "Connexion échouée"}
+                    ? "Connection OK"
+                    : "Connection failed"}
                 </span>
               </div>
               <p className="mt-1">{connectionResult.message}</p>
             </div>
           )}
 
-          {/* Informations de la source */}
           <div className="grid grid-cols-1 gap-3 text-sm">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2 text-muted-foreground">
                 <FolderOpen className="h-4 w-4" />
-                <span>Chemin source:</span>
+                <span>Source path:</span>
               </div>
               <code className="bg-muted px-2 py-1 rounded text-xs">
                 {source.config.sourcePath}
@@ -251,13 +248,12 @@ export function SourceCard({ source, onSync, onDelete }: SourceCardProps) {
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2 text-muted-foreground">
                 <Calendar className="h-4 w-4" />
-                <span>Dernière sync réussie:</span>
+                <span>Last successful sync:</span>
               </div>
               <span className="text-xs">{formatDate(source.lastSync)}</span>
             </div>
           </div>
 
-          {/* Extensions et filtres */}
           {source.config.filters?.extensions && (() => {
             const exts = Array.isArray(source.config.filters.extensions)
               ? source.config.filters.extensions
@@ -282,11 +278,10 @@ export function SourceCard({ source, onSync, onDelete }: SourceCardProps) {
             ) : null;
           })()}
 
-          {/* Jobs récents */}
           {source.jobs && source.jobs.length > 0 && (
             <div>
               <span className="text-xs text-muted-foreground">
-                Jobs récents:
+                Recent jobs:
               </span>
               <div className="flex items-center gap-2 mt-1">
                 <Badge variant="outline" className="text-xs">
@@ -294,7 +289,7 @@ export function SourceCard({ source, onSync, onDelete }: SourceCardProps) {
                 </Badge>
                 {source.jobs.some((job) => job.status === "failed") && (
                   <Badge variant="destructive" className="text-xs">
-                    Erreurs
+                    Errors
                   </Badge>
                 )}
               </div>
@@ -303,24 +298,23 @@ export function SourceCard({ source, onSync, onDelete }: SourceCardProps) {
         </CardContent>
       </Card>
 
-      {/* Dialog de confirmation de suppression */}
       <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Supprimer la source ?</AlertDialogTitle>
+            <AlertDialogTitle>Delete source?</AlertDialogTitle>
             <AlertDialogDescription>
-              Cette action est irréversible. Toutes les données associées à la
-              source "{source.name}" seront supprimées, y compris l'historique
-              des conversions.
+              This action is irreversible. All data associated with the
+              source "{source.name}" will be deleted, including conversion
+              history.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Annuler</AlertDialogCancel>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
               onClick={handleDelete}
               className="bg-red-600 hover:bg-red-700"
             >
-              Supprimer
+              Delete
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/frontend/src/components/forms/AddSourceDialog.tsx
+++ b/frontend/src/components/forms/AddSourceDialog.tsx
@@ -39,7 +39,6 @@ import { GoogleAuthButton } from "../auth/GoogleAuthButton";
 import FilePreview from "./FilePreview";
 import GoogleDriveFolderPicker from "./GoogleDriveFolderPicker";
 
-// Composants SVG wrappés
 const GoogleDriveIcon = ({ className }: { className?: string }) => (
   <img src={GoogleDriveIconUrl} className={className} alt="Google Drive" />
 );
@@ -52,32 +51,31 @@ const SharePointIcon = ({ className }: { className?: string }) => (
   <img src={SharePointIconUrl} className={className} alt="SharePoint" />
 );
 
-// Schéma de validation simplifié
 const sourceFormSchema = z.object({
   name: z
     .string()
-    .min(1, "Donnez un nom à votre source")
-    .max(100, "Le nom est trop long"),
+    .min(1, "Give your source a name")
+    .max(100, "Name is too long"),
   platform: z.enum(["sharepoint", "googledrive", "onedrive"], {
-    message: "Choisissez votre plateforme",
+    message: "Choose your platform",
   }),
-  sourcePath: z.string().min(1, "Indiquez le dossier à surveiller"),
-  siteUrl: z.string().url("URL invalide").optional().or(z.literal("")),
+  sourcePath: z.string().min(1, "Specify the folder to monitor"),
+  siteUrl: z.string().url("Invalid URL").optional().or(z.literal("")),
   destination: z
     .string()
-    .min(1, "Où voulez-vous sauvegarder vos fichiers ?")
-    .max(200, "Le chemin de destination est trop long (max 200 caractères)")
+    .min(1, "Where do you want to save your files?")
+    .max(200, "Destination path is too long (max 200 characters)")
     .regex(
       /^[a-zA-Z0-9/_-]+$/,
-      "Le chemin ne peut contenir que des lettres, chiffres, tirets, underscores et slashes",
+      "Path can only contain letters, numbers, dashes, underscores, and slashes",
     )
     .refine(
       (val) => !val.includes(".."),
-      "Le chemin ne peut pas contenir '..' (sécurité)",
+      "Path cannot contain '..' (security)",
     )
     .refine(
       (val) => !val.startsWith("/") && !val.startsWith("\\"),
-      "Le chemin doit être relatif (ne peut pas commencer par / ou \\)",
+      "Path must be relative (cannot start with / or \\)",
     ),
   extensions: z.string().optional(),
   excludePatterns: z.string().optional(),
@@ -121,7 +119,6 @@ export function AddSourceDialog({
 
   const selectedPlatform = form.watch("platform");
 
-  // Réinitialiser la sélection de dossier quand on change de plateforme
   React.useEffect(() => {
     if (selectedPlatform !== "googledrive") {
       setSelectedFolder(null);
@@ -134,13 +131,13 @@ export function AddSourceDialog({
     path: string;
   }) => {
     setSelectedFolder(folder);
-    form.setValue("sourcePath", folder.id); // Pour Google Drive, on utilise l'ID
+    form.setValue("sourcePath", folder.id);
     setShowFolderPicker(false);
   };
 
   const openFolderPicker = () => {
     if (!googleUser?.refreshToken) {
-      alert("Veuillez vous connecter avec Google d'abord");
+      alert("Please connect with Google first");
       return;
     }
     setShowFolderPicker(true);
@@ -150,13 +147,11 @@ export function AddSourceDialog({
     try {
       setIsSubmitting(true);
 
-      // Validation spécifique pour Google Drive
       if (data.platform === "googledrive" && !googleUser?.refreshToken) {
-        alert("Veuillez vous connecter avec Google d'abord");
+        alert("Please connect with Google first");
         return;
       }
 
-      // Préparer les credentials selon la plateforme
       let credentials: any = {};
       if (data.platform === "googledrive") {
         credentials = {
@@ -165,7 +160,6 @@ export function AddSourceDialog({
           refreshToken: googleUser?.refreshToken,
         };
       } else {
-        // Microsoft credentials par défaut
         credentials = {
           clientId: import.meta.env.VITE_DEFAULT_MICROSOFT_CLIENT_ID,
           clientSecret: import.meta.env.VITE_DEFAULT_MICROSOFT_CLIENT_SECRET,
@@ -173,10 +167,8 @@ export function AddSourceDialog({
         };
       }
 
-      // Préparer la destination (string directe)
       const destination = data.destination.trim();
 
-      // Préparer les filtres
       const extensions = data.extensions
         ?.split(",")
         .map((e) => e.trim())
@@ -206,7 +198,6 @@ export function AddSourceDialog({
 
       await createSource(sourceData);
 
-      // Fermer le dialog et reset
       setOpen(false);
       form.reset();
       setSelectedFolder(null);
@@ -215,7 +206,7 @@ export function AddSourceDialog({
       console.error("Error creating source:", error);
       form.setError("platform", {
         message:
-          error instanceof Error ? error.message : "Erreur lors de la création",
+          error instanceof Error ? error.message : "Error creating source",
       });
     } finally {
       setIsSubmitting(false);
@@ -242,23 +233,23 @@ export function AddSourceDialog({
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <FileText className="h-5 w-5" />
-            Ajouter une source documentaire
+            Add a document source
           </DialogTitle>
           <DialogDescription>
-            Connectez votre plateforme de stockage pour convertir
-            automatiquement vos documents en Markdown
+            Connect your storage platform to automatically convert your
+            documents to Markdown
           </DialogDescription>
         </DialogHeader>
 
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-            {/* 1. Informations de base */}
+            {/* 1. Basic information */}
             <div className="space-y-4">
               <div className="flex items-center gap-2">
                 <div className="flex items-center justify-center w-6 h-6 bg-blue-100 text-blue-600 rounded-full text-sm font-semibold">
                   1
                 </div>
-                <h3 className="text-lg font-medium">Informations de base</h3>
+                <h3 className="text-lg font-medium">Basic information</h3>
               </div>
 
               <div className="flex flex-col md:flex-row gap-6">
@@ -267,14 +258,14 @@ export function AddSourceDialog({
                   name="platform"
                   render={({ field }) => (
                     <FormItem className="">
-                      <FormLabel>Plateforme de stockage</FormLabel>
+                      <FormLabel>Storage platform</FormLabel>
                       <Select
                         onValueChange={field.onChange}
                         defaultValue={field.value}
                       >
                         <FormControl>
                           <SelectTrigger>
-                            <SelectValue placeholder="Où sont stockés vos documents ?" />
+                            <SelectValue placeholder="Where are your documents stored?" />
                           </SelectTrigger>
                         </FormControl>
                         <SelectContent>
@@ -312,10 +303,10 @@ export function AddSourceDialog({
                   name="name"
                   render={({ field }) => (
                     <FormItem className="flex-1">
-                      <FormLabel>Nom de votre source</FormLabel>
+                      <FormLabel>Source name</FormLabel>
                       <FormControl>
                         <Input
-                          placeholder="ex: Documents équipe, Guides utilisateur..."
+                          placeholder="e.g. Team Documents, User Guides..."
                           {...field}
                         />
                       </FormControl>
@@ -326,7 +317,7 @@ export function AddSourceDialog({
               </div>
             </div>
 
-            {/* 2. Connexion à la plateforme */}
+            {/* 2. Platform connection */}
             {selectedPlatform && (
               <div className="space-y-4">
                 <div className="flex items-center gap-2">
@@ -334,7 +325,7 @@ export function AddSourceDialog({
                     2
                   </div>
                   <h3 className="text-lg font-medium flex items-center gap-2">
-                    Connexion à {getPlatformIcon(selectedPlatform)}
+                    Connect to {getPlatformIcon(selectedPlatform)}
                     {selectedPlatform === "googledrive"
                       ? "Google Drive"
                       : selectedPlatform === "sharepoint"
@@ -350,12 +341,12 @@ export function AddSourceDialog({
                     <div className="flex items-center gap-2 mb-2">
                       <CheckCircle className="h-5 w-5 text-blue-600" />
                       <span className="font-medium text-blue-800">
-                        Credentials Microsoft configurés
+                        Microsoft credentials configured
                       </span>
                     </div>
                     <p className="text-sm text-blue-700">
-                      L'authentification Microsoft est déjà configurée dans
-                      l'application
+                      Microsoft authentication is already configured in
+                      the application
                     </p>
                   </div>
                 )}
@@ -368,7 +359,7 @@ export function AddSourceDialog({
               </div>
             )}
 
-            {/* 3. Configuration des dossiers */}
+            {/* 3. Folder configuration */}
             {selectedPlatform &&
               (googleUser?.email || selectedPlatform !== "googledrive") && (
                 <div className="space-y-4">
@@ -377,7 +368,7 @@ export function AddSourceDialog({
                       3
                     </div>
                     <h3 className="text-lg font-medium">
-                      Configuration des dossiers
+                      Folder configuration
                     </h3>
                   </div>
 
@@ -388,7 +379,7 @@ export function AddSourceDialog({
                       <FormItem>
                         <FormLabel className="flex items-center gap-2">
                           <FolderOpen className="h-4 w-4" />
-                          Dossier à surveiller
+                          Folder to monitor
                         </FormLabel>
                         <FormControl>
                           {selectedPlatform === "googledrive" ? (
@@ -398,7 +389,7 @@ export function AddSourceDialog({
                                   placeholder={
                                     selectedFolder
                                       ? selectedFolder.name
-                                      : "Cliquez pour choisir un dossier"
+                                      : "Click to choose a folder"
                                   }
                                   value={
                                     selectedFolder ? selectedFolder.name : ""
@@ -418,21 +409,21 @@ export function AddSourceDialog({
                               </div>
                               {selectedFolder && (
                                 <p className="text-sm text-muted-foreground">
-                                  Chemin: {selectedFolder.path || "/"}
+                                  Path: {selectedFolder.path || "/"}
                                 </p>
                               )}
                             </div>
                           ) : (
                             <Input
-                              placeholder="/ (pour tout le drive)"
+                              placeholder="/ (for entire drive)"
                               {...field}
                             />
                           )}
                         </FormControl>
                         <FormDescription>
                           {selectedPlatform === "googledrive"
-                            ? "Choisissez le dossier à surveiller dans votre Google Drive"
-                            : 'Le dossier dont vous voulez convertir les documents. "/" pour surveiller tout le drive.'}
+                            ? "Choose the folder to monitor in your Google Drive"
+                            : 'The folder whose documents you want to convert. "/" to monitor the entire drive.'}
                         </FormDescription>
                         <FormMessage />
                       </FormItem>
@@ -445,15 +436,15 @@ export function AddSourceDialog({
                       name="siteUrl"
                       render={({ field }) => (
                         <FormItem>
-                          <FormLabel>URL de votre site SharePoint</FormLabel>
+                          <FormLabel>SharePoint site URL</FormLabel>
                           <FormControl>
                             <Input
-                              placeholder="https://monentreprise.sharepoint.com/sites/documents"
+                              placeholder="https://mycompany.sharepoint.com/sites/documents"
                               {...field}
                             />
                           </FormControl>
                           <FormDescription>
-                            L'adresse complète de votre site SharePoint
+                            The full URL of your SharePoint site
                           </FormDescription>
                           <FormMessage />
                         </FormItem>
@@ -467,7 +458,7 @@ export function AddSourceDialog({
                     render={({ field }) => (
                       <FormItem>
                         <FormLabel>
-                          Où sauvegarder les fichiers convertis
+                          Where to save converted files
                         </FormLabel>
                         <FormControl>
                           <div className="flex items-center">
@@ -482,15 +473,14 @@ export function AddSourceDialog({
                           </div>
                         </FormControl>
                         <FormDescription>
-                          Dossier relatif à votre EXPORT_PATH où copier les
-                          fichiers convertis. Exemple : "doc2ai-exports"
+                          Relative folder within your EXPORT_PATH for converted
+                          files. Example: "doc2ai-exports"
                         </FormDescription>
                         <FormMessage />
                       </FormItem>
                     )}
                   />
 
-                  {/* Prévisualisation des fichiers pour Google Drive */}
                   {selectedPlatform === "googledrive" &&
                     selectedFolder &&
                     googleUser?.refreshToken && (
@@ -521,7 +511,7 @@ export function AddSourceDialog({
                 </div>
               )}
 
-            {/* 4. Filtres (optionnel, collapsible) */}
+            {/* 4. Advanced filters (optional) */}
             {selectedPlatform &&
               (googleUser?.email || selectedPlatform !== "googledrive") && (
                 <details className="space-y-4">
@@ -530,7 +520,7 @@ export function AddSourceDialog({
                       4
                     </div>
                     <h3 className="text-lg font-medium">
-                      Filtres avancés (optionnel)
+                      Advanced filters (optional)
                     </h3>
                   </summary>
 
@@ -540,7 +530,7 @@ export function AddSourceDialog({
                       name="extensions"
                       render={({ field }) => (
                         <FormItem>
-                          <FormLabel>Types de fichiers à traiter</FormLabel>
+                          <FormLabel>File types to process</FormLabel>
                           <FormControl>
                             <Input
                               placeholder=".docx,.pdf,.doc,.txt"
@@ -548,7 +538,7 @@ export function AddSourceDialog({
                             />
                           </FormControl>
                           <FormDescription>
-                            Extensions de fichiers (séparées par des virgules)
+                            File extensions (comma-separated)
                           </FormDescription>
                           <FormMessage />
                         </FormItem>
@@ -560,13 +550,12 @@ export function AddSourceDialog({
                       name="excludePatterns"
                       render={({ field }) => (
                         <FormItem>
-                          <FormLabel>Fichiers à ignorer</FormLabel>
+                          <FormLabel>Files to ignore</FormLabel>
                           <FormControl>
                             <Input placeholder="temp,draft,~$" {...field} />
                           </FormControl>
                           <FormDescription>
-                            Mots dans le nom des fichiers à exclure (séparés par
-                            des virgules)
+                            Words in file names to exclude (comma-separated)
                           </FormDescription>
                           <FormMessage />
                         </FormItem>
@@ -576,7 +565,7 @@ export function AddSourceDialog({
                 </details>
               )}
 
-            {/* Boutons d'action */}
+            {/* Action buttons */}
             <div className="flex gap-3 pt-4">
               <Button
                 type="button"
@@ -584,7 +573,7 @@ export function AddSourceDialog({
                 onClick={() => setOpen(false)}
                 className="flex-1"
               >
-                Annuler
+                Cancel
               </Button>
               <Button
                 type="submit"
@@ -597,12 +586,12 @@ export function AddSourceDialog({
                 {isSubmitting ? (
                   <>
                     <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    Création...
+                    Creating...
                   </>
                 ) : (
                   <>
                     <Plus className="mr-2 h-4 w-4" />
-                    Créer la source
+                    Create source
                   </>
                 )}
               </Button>
@@ -610,7 +599,6 @@ export function AddSourceDialog({
           </form>
         </Form>
 
-        {/* Google Drive Folder Picker */}
         {selectedPlatform === "googledrive" && googleUser?.refreshToken && (
           <GoogleDriveFolderPicker
             isOpen={showFolderPicker}

--- a/frontend/src/components/forms/FilePreview.tsx
+++ b/frontend/src/components/forms/FilePreview.tsx
@@ -61,7 +61,7 @@ export function FilePreview({
       setPreviewData(data);
     } catch (error) {
       console.error("Error fetching file preview:", error);
-      toast.error("Erreur lors du chargement de la prévisualisation");
+      toast.error("Error loading file preview");
       setPreviewData(null);
     } finally {
       setLoading(false);
@@ -100,25 +100,24 @@ export function FilePreview({
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <FileText className="h-5 w-5" />
-          Aperçu des fichiers à convertir
+          File preview
         </CardTitle>
         <CardDescription>
-          Fichiers qui seront automatiquement convertis depuis le dossier "
-          {folderName}"
+          Files that will be automatically converted from the "{folderName}"
+          folder
         </CardDescription>
       </CardHeader>
       <CardContent>
         {loading ? (
           <div className="flex items-center justify-center py-8">
             <Loader2 className="h-6 w-6 animate-spin mr-2" />
-            <span>Analyse des fichiers en cours...</span>
+            <span>Analyzing files...</span>
           </div>
         ) : previewData ? (
           <div className="space-y-4">
-            {/* Statistiques */}
             <div className="flex gap-4">
               <Badge variant="outline">
-                {previewData.totalFiles} fichier
+                {previewData.totalFiles} file
                 {previewData.totalFiles > 1 ? "s" : ""} total
               </Badge>
               <Badge
@@ -126,13 +125,11 @@ export function FilePreview({
                   previewData.convertibleFiles > 0 ? "default" : "secondary"
                 }
               >
-                {previewData.convertibleFiles} fichier
-                {previewData.convertibleFiles > 1 ? "s" : ""} convertible
+                {previewData.convertibleFiles} convertible file
                 {previewData.convertibleFiles > 1 ? "s" : ""}
               </Badge>
             </div>
 
-            {/* Liste des fichiers convertibles */}
             {previewData.convertibleFiles > 0 ? (
               <ScrollArea className="h-[200px] w-full rounded-md border">
                 <div className="p-4 space-y-2">
@@ -147,18 +144,18 @@ export function FilePreview({
                         </span>
                         <div>
                           <p className="font-medium text-sm">
-                            {file.name || "Fichier sans nom"}
+                            {file.name || "Unnamed file"}
                           </p>
                           <p className="text-xs text-muted-foreground">
                             {file.size
                               ? formatFileSize(file.size)
-                              : "Taille inconnue"}{" "}
-                            • Modifié le{" "}
+                              : "Unknown size"}{" "}
+                            • Modified{" "}
                             {file.modifiedTime
                               ? new Date(file.modifiedTime).toLocaleDateString(
-                                  "fr-FR",
+                                  "en-US",
                                 )
-                              : "Date inconnue"}
+                              : "Unknown date"}
                           </p>
                         </div>
                       </div>
@@ -178,16 +175,16 @@ export function FilePreview({
             ) : (
               <div className="text-center py-6 text-muted-foreground">
                 <FileText className="h-12 w-12 mx-auto mb-2 opacity-50" />
-                <p>Aucun fichier convertible trouvé</p>
+                <p>No convertible files found</p>
                 <p className="text-sm">
-                  Formats supportés: {extensions.join(", ")}
+                  Supported formats: {extensions.join(", ")}
                 </p>
               </div>
             )}
           </div>
         ) : (
           <div className="text-center py-6 text-muted-foreground">
-            <p>Sélectionnez un dossier pour voir l'aperçu des fichiers</p>
+            <p>Select a folder to see the file preview</p>
           </div>
         )}
       </CardContent>

--- a/frontend/src/components/forms/GoogleDriveFolderPicker.tsx
+++ b/frontend/src/components/forms/GoogleDriveFolderPicker.tsx
@@ -48,13 +48,13 @@ export function GoogleDriveFolderPicker({
   const [loading, setLoading] = useState(false);
   const [currentFolderId, setCurrentFolderId] = useState("root");
   const [breadcrumbs, setBreadcrumbs] = useState<BreadcrumbItem[]>([
-    { id: "root", name: "Mon Drive" },
+    { id: "root", name: "My Drive" },
   ]);
 
   const fetchFolders = useCallback(
     async (folderId: string) => {
       if (!credentials?.refreshToken) {
-        toast.error("Credentials Google Drive manquants");
+        toast.error("Google Drive credentials missing");
         return;
       }
 
@@ -67,7 +67,7 @@ export function GoogleDriveFolderPicker({
         setFolders(folders);
       } catch (error) {
         console.error("Error fetching folders:", error);
-        toast.error("Erreur lors du chargement des dossiers Google Drive");
+        toast.error("Error loading Google Drive folders");
         setFolders([]);
       } finally {
         setLoading(false);
@@ -76,7 +76,6 @@ export function GoogleDriveFolderPicker({
     [credentials],
   );
 
-  // Charger les dossiers quand le dialog s'ouvre ou quand le dossier courant change
   useEffect(() => {
     if (isOpen && credentials?.refreshToken) {
       fetchFolders(currentFolderId);
@@ -84,7 +83,6 @@ export function GoogleDriveFolderPicker({
   }, [isOpen, currentFolderId, credentials?.refreshToken, fetchFolders]);
 
   const handleFolderClick = (folder: GoogleDriveFolder) => {
-    // Naviguer dans le dossier
     setCurrentFolderId(folder.id);
     setBreadcrumbs((prev) => [...prev, { id: folder.id, name: folder.name }]);
   };
@@ -121,11 +119,10 @@ export function GoogleDriveFolderPicker({
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <FolderOpen className="h-5 w-5" />
-            Choisir un dossier Google Drive
+            Choose a Google Drive folder
           </DialogTitle>
           <DialogDescription>
-            Sélectionnez le dossier que vous souhaitez surveiller pour la
-            conversion automatique
+            Select the folder you want to monitor for automatic conversion
           </DialogDescription>
         </DialogHeader>
 
@@ -149,10 +146,9 @@ export function GoogleDriveFolderPicker({
 
           <Separator />
 
-          {/* Bouton pour sélectionner le dossier courant */}
           <div className="flex justify-between items-center">
             <div className="text-sm text-muted-foreground">
-              Dossier actuel:{" "}
+              Current folder:{" "}
               <span className="font-medium">
                 {breadcrumbs[breadcrumbs.length - 1].name}
               </span>
@@ -162,25 +158,24 @@ export function GoogleDriveFolderPicker({
               variant="outline"
               size="sm"
             >
-              Sélectionner ce dossier
+              Select this folder
             </Button>
           </div>
 
           <Separator />
 
-          {/* Liste des dossiers */}
           <ScrollArea className="h-[400px] w-full rounded-md border p-4">
             {loading ? (
               <div className="flex items-center justify-center py-8">
                 <Loader2 className="h-6 w-6 animate-spin mr-2" />
-                <span>Chargement des dossiers...</span>
+                <span>Loading folders...</span>
               </div>
             ) : folders.length === 0 ? (
               <div className="text-center py-8 text-muted-foreground">
                 <Folder className="h-12 w-12 mx-auto mb-2 opacity-50" />
-                <p>Aucun sous-dossier trouvé</p>
+                <p>No subfolders found</p>
                 <p className="text-sm">
-                  Vous pouvez sélectionner le dossier courant ci-dessus
+                  You can select the current folder above
                 </p>
               </div>
             ) : (
@@ -198,9 +193,9 @@ export function GoogleDriveFolderPicker({
                       <div>
                         <p className="font-medium">{folder.name}</p>
                         <p className="text-sm text-muted-foreground">
-                          Modifié le{" "}
+                          Modified{" "}
                           {new Date(folder.modifiedTime).toLocaleDateString(
-                            "fr-FR",
+                            "en-US",
                           )}
                         </p>
                       </div>
@@ -214,7 +209,7 @@ export function GoogleDriveFolderPicker({
                         variant="outline"
                         size="sm"
                       >
-                        Sélectionner
+                        Select
                       </Button>
                       <Button
                         onClick={() => handleFolderClick(folder)}
@@ -230,10 +225,9 @@ export function GoogleDriveFolderPicker({
             )}
           </ScrollArea>
 
-          {/* Actions */}
           <div className="flex justify-end space-x-2">
             <Button variant="outline" onClick={onClose}>
-              Annuler
+              Cancel
             </Button>
           </div>
         </div>

--- a/frontend/src/hooks/useConversions.ts
+++ b/frontend/src/hooks/useConversions.ts
@@ -23,7 +23,7 @@ export function useConversions(page = 1, limit = 20, status?: string) {
       const errorMessage =
         err instanceof ApiError
           ? err.message
-          : "Erreur lors du chargement des conversions";
+          : "Failed to load conversions";
       setError(errorMessage);
       console.error("Error fetching conversions:", err);
     } finally {
@@ -35,13 +35,13 @@ export function useConversions(page = 1, limit = 20, status?: string) {
     async (id: string): Promise<ConversionJob> => {
       try {
         const cancelledJob = await conversionsApi.cancel(id);
-        await fetchConversions(); // Rafraîchir la liste
+        await fetchConversions();
         return cancelledJob;
       } catch (err) {
         const errorMessage =
           err instanceof ApiError
             ? err.message
-            : "Erreur lors de l'annulation du job";
+            : "Failed to cancel job";
         throw new Error(errorMessage);
       }
     },
@@ -52,13 +52,13 @@ export function useConversions(page = 1, limit = 20, status?: string) {
     async (id: string): Promise<ConversionJob> => {
       try {
         const retriedJob = await conversionsApi.retry(id);
-        await fetchConversions(); // Rafraîchir la liste
+        await fetchConversions();
         return retriedJob;
       } catch (err) {
         const errorMessage =
           err instanceof ApiError
             ? err.message
-            : "Erreur lors de la relance du job";
+            : "Failed to retry job";
         throw new Error(errorMessage);
       }
     },
@@ -95,7 +95,7 @@ export function useConversionStats() {
       const errorMessage =
         err instanceof ApiError
           ? err.message
-          : "Erreur lors du chargement des statistiques";
+          : "Failed to load statistics";
       setError(errorMessage);
       console.error("Error fetching conversion stats:", err);
     } finally {
@@ -142,7 +142,7 @@ export function useJobProgress(jobId: string | null, pollingInterval = 2000) {
       const errorMessage =
         err instanceof ApiError
           ? err.message
-          : "Erreur lors du chargement de la progression";
+          : "Failed to load progress";
       setError(errorMessage);
       console.error("Error fetching job progress:", err);
     } finally {
@@ -156,10 +156,8 @@ export function useJobProgress(jobId: string | null, pollingInterval = 2000) {
       return;
     }
 
-    // Fetch initial progress
     fetchProgress();
 
-    // Set up polling if job is in progress
     const interval = setInterval(() => {
       if (progress?.status === "processing" || progress?.status === "pending") {
         fetchProgress();

--- a/frontend/src/hooks/useGoogleAuth.ts
+++ b/frontend/src/hooks/useGoogleAuth.ts
@@ -22,11 +22,9 @@ export function useGoogleAuth(): UseGoogleAuthReturn {
   const [user, setUser] = useState<GoogleUser | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  // Vérifier s'il y a des données d'authentification au chargement
   useEffect(() => {
     const checkAuthData = () => {
       try {
-        // D'abord vérifier s'il y a des credentials persistés
         const storedCredentials = TokenStorage.getCredentials();
         if (storedCredentials) {
           setUser({
@@ -35,10 +33,9 @@ export function useGoogleAuth(): UseGoogleAuthReturn {
             photoLink: storedCredentials.photoLink,
             refreshToken: storedCredentials.refreshToken,
           });
-          return; // On a trouvé des credentials valides, pas besoin de vérifier OAuth callback
+          return;
         }
 
-        // Sinon, vérifier s'il y a des nouvelles données d'auth (callback OAuth)
         const authData = localStorage.getItem("google_auth_data");
         if (authData) {
           const parsedData = JSON.parse(authData);
@@ -50,21 +47,15 @@ export function useGoogleAuth(): UseGoogleAuthReturn {
           };
 
           setUser(userCredentials);
-
-          // Persister les credentials pour les prochaines fois
           TokenStorage.saveCredentials(userCredentials);
-
-          // Nettoyer les données temporaires du callback
           localStorage.removeItem("google_auth_data");
         }
 
-        // Vérifier s'il y a une erreur d'authentification dans l'URL
         const urlParams = new URLSearchParams(window.location.search);
         const authError = urlParams.get("auth_error");
         if (authError) {
           setError(authError);
 
-          // Nettoyer l'URL
           const newUrl = new URL(window.location.href);
           newUrl.searchParams.delete("auth_error");
           window.history.replaceState({}, "", newUrl.toString());
@@ -83,12 +74,11 @@ export function useGoogleAuth(): UseGoogleAuthReturn {
     TokenStorage.clearCredentials();
   }, []);
 
-  // Auto-disconnect when backend reports expired token
   useEffect(() => {
     const handleTokenExpired = () => {
       console.warn("Google token expired, disconnecting...");
       disconnect();
-      setError("Votre session Google a expiré, veuillez vous reconnecter");
+      setError("Your Google session has expired, please reconnect");
     };
 
     window.addEventListener(GOOGLE_TOKEN_EXPIRED_EVENT, handleTokenExpired);
@@ -102,7 +92,6 @@ export function useGoogleAuth(): UseGoogleAuthReturn {
     setError(null);
 
     try {
-      // Générer l'URL d'autorisation via l'API
       const authResponse = await fetch(
         `${import.meta.env.VITE_API_URL}/auth/google`,
       );
@@ -111,14 +100,13 @@ export function useGoogleAuth(): UseGoogleAuthReturn {
       if (!authData.success) {
         throw new Error(
           authData.message ||
-            "Erreur lors de la génération de l'URL d'autorisation",
+            "Error generating authorization URL",
         );
       }
 
-      // Rediriger directement vers Google (pas de popup)
       window.location.href = authData.data.authUrl;
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Erreur inconnue");
+      setError(err instanceof Error ? err.message : "Unknown error");
       setIsConnecting(false);
     }
   };

--- a/frontend/src/hooks/useMonitoring.ts
+++ b/frontend/src/hooks/useMonitoring.ts
@@ -17,7 +17,7 @@ export function useMonitoring() {
       const errorMessage =
         err instanceof ApiError
           ? err.message
-          : "Erreur lors du chargement du statut";
+          : "Failed to load status";
       setError(errorMessage);
       console.error("Error fetching monitoring status:", err);
     } finally {
@@ -28,12 +28,12 @@ export function useMonitoring() {
   const startMonitoring = useCallback(async (): Promise<void> => {
     try {
       await monitoringApi.start();
-      await fetchStatus(); // Rafraîchir le statut
+      await fetchStatus();
     } catch (err) {
       const errorMessage =
         err instanceof ApiError
           ? err.message
-          : "Erreur lors du démarrage du monitoring";
+          : "Failed to start monitoring";
       throw new Error(errorMessage);
     }
   }, [fetchStatus]);
@@ -41,12 +41,12 @@ export function useMonitoring() {
   const stopMonitoring = useCallback(async (): Promise<void> => {
     try {
       await monitoringApi.stop();
-      await fetchStatus(); // Rafraîchir le statut
+      await fetchStatus();
     } catch (err) {
       const errorMessage =
         err instanceof ApiError
           ? err.message
-          : "Erreur lors de l'arrêt du monitoring";
+          : "Failed to stop monitoring";
       throw new Error(errorMessage);
     }
   }, [fetchStatus]);
@@ -54,12 +54,12 @@ export function useMonitoring() {
   const restartMonitoring = useCallback(async (): Promise<void> => {
     try {
       await monitoringApi.restart();
-      await fetchStatus(); // Rafraîchir le statut
+      await fetchStatus();
     } catch (err) {
       const errorMessage =
         err instanceof ApiError
           ? err.message
-          : "Erreur lors du redémarrage du monitoring";
+          : "Failed to restart monitoring";
       throw new Error(errorMessage);
     }
   }, [fetchStatus]);
@@ -94,7 +94,7 @@ export function useLogs(sourceId?: string, limit = 50) {
       const errorMessage =
         err instanceof ApiError
           ? err.message
-          : "Erreur lors du chargement des logs";
+          : "Failed to load logs";
       setError(errorMessage);
       console.error("Error fetching logs:", err);
     } finally {
@@ -129,7 +129,7 @@ export function useHealthCheck() {
       const errorMessage =
         err instanceof ApiError
           ? err.message
-          : "Erreur lors de la vérification de santé";
+          : "Failed to check health";
       setError(errorMessage);
       console.error("Error fetching health status:", err);
     } finally {
@@ -140,7 +140,6 @@ export function useHealthCheck() {
   useEffect(() => {
     fetchHealth();
 
-    // Rafraîchir le health check toutes les 30 secondes
     const interval = setInterval(fetchHealth, 30000);
 
     return () => clearInterval(interval);

--- a/frontend/src/hooks/useSources.ts
+++ b/frontend/src/hooks/useSources.ts
@@ -14,7 +14,7 @@ export function useSources() {
       const data = await sourcesApi.getAll()
       setSources(data)
     } catch (err) {
-      const errorMessage = err instanceof ApiError ? err.message : 'Erreur lors du chargement des sources'
+      const errorMessage = err instanceof ApiError ? err.message : 'Failed to load sources'
       setError(errorMessage)
       console.error('Error fetching sources:', err)
     } finally {
@@ -28,7 +28,7 @@ export function useSources() {
       setSources(prev => [...prev, newSource])
       return newSource
     } catch (err) {
-      const errorMessage = err instanceof ApiError ? err.message : 'Erreur lors de la création de la source'
+      const errorMessage = err instanceof ApiError ? err.message : 'Failed to create source'
       throw new Error(errorMessage)
     }
   }, [])
@@ -39,7 +39,7 @@ export function useSources() {
       setSources(prev => prev.map(source => source.id === id ? updatedSource : source))
       return updatedSource
     } catch (err) {
-      const errorMessage = err instanceof ApiError ? err.message : 'Erreur lors de la mise à jour de la source'
+      const errorMessage = err instanceof ApiError ? err.message : 'Failed to update source'
       throw new Error(errorMessage)
     }
   }, [])
@@ -49,7 +49,7 @@ export function useSources() {
       await sourcesApi.delete(id)
       setSources(prev => prev.filter(source => source.id !== id))
     } catch (err) {
-      const errorMessage = err instanceof ApiError ? err.message : 'Erreur lors de la suppression de la source'
+      const errorMessage = err instanceof ApiError ? err.message : 'Failed to delete source'
       throw new Error(errorMessage)
     }
   }, [])
@@ -57,11 +57,10 @@ export function useSources() {
   const testConnection = useCallback(async (id: string) => {
     try {
       const result = await sourcesApi.testConnection(id)
-      // Optionnel: rafraîchir les sources après le test
       await fetchSources()
       return result
     } catch (err) {
-      const errorMessage = err instanceof ApiError ? err.message : 'Erreur lors du test de connexion'
+      const errorMessage = err instanceof ApiError ? err.message : 'Failed to test connection'
       throw new Error(errorMessage)
     }
   }, [fetchSources])
@@ -69,10 +68,9 @@ export function useSources() {
   const syncSource = useCallback(async (id: string): Promise<void> => {
     try {
       await sourcesApi.sync(id)
-      // Rafraîchir les sources après la sync
       await fetchSources()
     } catch (err) {
-      const errorMessage = err instanceof ApiError ? err.message : 'Erreur lors de la synchronisation'
+      const errorMessage = err instanceof ApiError ? err.message : 'Failed to sync'
       throw new Error(errorMessage)
     }
   }, [fetchSources])
@@ -106,7 +104,7 @@ export function useSourceStats() {
       const data = await sourcesApi.getStats()
       setStats(data)
     } catch (err) {
-      const errorMessage = err instanceof ApiError ? err.message : 'Erreur lors du chargement des statistiques'
+      const errorMessage = err instanceof ApiError ? err.message : 'Failed to load statistics'
       setError(errorMessage)
       console.error('Error fetching source stats:', err)
     } finally {
@@ -143,7 +141,7 @@ export function useSource(id: string | null) {
       const data = await sourcesApi.getById(id)
       setSource(data)
     } catch (err) {
-      const errorMessage = err instanceof ApiError ? err.message : 'Erreur lors du chargement de la source'
+      const errorMessage = err instanceof ApiError ? err.message : 'Failed to load source'
       setError(errorMessage)
       console.error('Error fetching source:', err)
     } finally {

--- a/frontend/src/pages/AuthCallback.tsx
+++ b/frontend/src/pages/AuthCallback.tsx
@@ -64,7 +64,7 @@ const AuthCallback: React.FC = () => {
           window.opener.postMessage(
             {
               type: "GOOGLE_AUTH_ERROR",
-              error: "Erreur lors du traitement de l'authentification",
+              error: "Error processing authentication",
             },
             window.location.origin,
           );
@@ -89,9 +89,9 @@ const AuthCallback: React.FC = () => {
               <div className="mx-auto mb-2">
                 <CheckCircle className="h-12 w-12 text-green-500" />
               </div>
-              <CardTitle>Authentification réussie</CardTitle>
+              <CardTitle>Authentication Successful</CardTitle>
               <CardDescription>
-                Votre compte Google a été connecté avec succès.
+                Your Google account has been connected successfully.
               </CardDescription>
             </>
           ) : error ? (
@@ -100,7 +100,7 @@ const AuthCallback: React.FC = () => {
                 <XCircle className="h-12 w-12 text-destructive" />
               </div>
               <CardTitle className="text-destructive">
-                Erreur d'authentification
+                Authentication Error
               </CardTitle>
               <CardDescription>{error}</CardDescription>
             </>
@@ -109,10 +109,9 @@ const AuthCallback: React.FC = () => {
               <div className="mx-auto mb-2">
                 <Loader2 className="h-12 w-12 animate-spin text-primary" />
               </div>
-              <CardTitle>Traitement en cours...</CardTitle>
+              <CardTitle>Processing...</CardTitle>
               <CardDescription>
-                Veuillez patienter pendant que nous traitons votre
-                authentification.
+                Please wait while we process your authentication.
               </CardDescription>
             </>
           )}
@@ -122,7 +121,7 @@ const AuthCallback: React.FC = () => {
           {success === "true" && (
             <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
               <Loader2 className="h-4 w-4 animate-spin" />
-              <span>Redirection automatique...</span>
+              <span>Redirecting...</span>
             </div>
           )}
 
@@ -133,7 +132,7 @@ const AuthCallback: React.FC = () => {
               className="w-full"
             >
               <ArrowLeft className="h-4 w-4" />
-              Retourner à l'application
+              Return to application
             </Button>
           )}
         </CardContent>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -56,12 +56,11 @@ export default function Dashboard() {
 
   return (
     <>
-      {/* Erreur globale */}
       {sourcesError && (
         <Alert className="mb-6">
           <AlertCircle className="h-4 w-4" />
           <AlertDescription>
-            Erreur lors du chargement : {sourcesError}
+            Error loading data: {sourcesError}
           </AlertDescription>
         </Alert>
       )}
@@ -72,7 +71,7 @@ export default function Dashboard() {
           <CardHeader>
             <CardTitle className="flex items-center justify-center gap-2">
               <Cloud className="h-5 w-5 text-blue-500" />
-              Sources connectées
+              Connected Sources
             </CardTitle>
           </CardHeader>
           <CardContent>
@@ -84,11 +83,11 @@ export default function Dashboard() {
               </div>
             )}
             <p className="text-sm text-muted-foreground">
-              Sources documentaires configurées
+              Configured document sources
             </p>
             {sourceStats && sourceStats.activeSources > 0 && (
               <Badge variant="outline" className="mt-2">
-                {sourceStats.activeSources} actives
+                {sourceStats.activeSources} active
               </Badge>
             )}
           </CardContent>
@@ -98,7 +97,7 @@ export default function Dashboard() {
           <CardHeader>
             <CardTitle className="flex items-center justify-center gap-2">
               <Download className="h-5 w-5 text-green-500" />
-              Fichiers convertis
+              Converted Files
             </CardTitle>
           </CardHeader>
           <CardContent>
@@ -106,7 +105,7 @@ export default function Dashboard() {
               {conversionStats?.recent ?? 0}
             </div>
             <p className="text-sm text-muted-foreground">
-              Dernières 24 heures
+              Last 24 hours
             </p>
           </CardContent>
         </Card>
@@ -115,7 +114,7 @@ export default function Dashboard() {
           <CardHeader>
             <CardTitle className="flex items-center justify-center gap-2">
               <Activity className="h-5 w-5 text-orange-500" />
-              Statut système
+              System Status
             </CardTitle>
           </CardHeader>
           <CardContent>
@@ -126,12 +125,12 @@ export default function Dashboard() {
                     monitoringStatus.isRunning ? "default" : "secondary"
                   }
                 >
-                  {monitoringStatus.isRunning ? "Actif" : "Inactif"}
+                  {monitoringStatus.isRunning ? "Active" : "Inactive"}
                 </Badge>
                 <p className="text-sm text-muted-foreground mt-2">
                   {monitoringStatus.isRunning
-                    ? `${monitoringStatus.totalActiveSources} sources surveillées`
-                    : "Monitoring arrêté"}
+                    ? `${monitoringStatus.totalActiveSources} sources monitored`
+                    : "Monitoring stopped"}
                 </p>
               </>
             ) : (
@@ -148,20 +147,19 @@ export default function Dashboard() {
       <div className="space-y-6">
         <div className="flex items-center justify-between">
           <div>
-            <h2 className="text-2xl font-semibold">Sources documentaires</h2>
+            <h2 className="text-2xl font-semibold">Document Sources</h2>
             <p className="text-muted-foreground">
-              Configurez vos drives cloud et dépôts de documents
+              Configure your cloud drives and document repositories
             </p>
           </div>
           <AddSourceDialog onSourceAdded={handleSourceAdded}>
             <Button>
               <Plus className="h-4 w-4" />
-              Ajouter une source
+              Add source
             </Button>
           </AddSourceDialog>
         </div>
 
-        {/* Loading state */}
         {sourcesLoading && (
           <div className="grid gap-4">
             {[1, 2, 3].map((i) => (
@@ -186,30 +184,28 @@ export default function Dashboard() {
           </div>
         )}
 
-        {/* Empty State */}
         {!sourcesLoading && sources.length === 0 && (
           <Card className="p-12 text-center">
             <CardContent>
               <Cloud className="h-16 w-16 text-muted-foreground mx-auto mb-4" />
               <CardTitle className="mb-2">
-                Aucune source documentaire
+                No document sources
               </CardTitle>
               <CardDescription className="mb-6 max-w-md mx-auto">
-                Commencez par connecter votre première source documentaire.
-                Support pour Microsoft SharePoint, Google Drive et autres
-                plateformes de stockage cloud.
+                Start by connecting your first document source.
+                Support for Microsoft SharePoint, Google Drive, and other
+                cloud storage platforms.
               </CardDescription>
               <AddSourceDialog onSourceAdded={handleSourceAdded}>
                 <Button size="lg">
                   <Plus className="h-4 w-4" />
-                  Ajouter votre première source
+                  Add your first source
                 </Button>
               </AddSourceDialog>
             </CardContent>
           </Card>
         )}
 
-        {/* Sources List */}
         {!sourcesLoading && sources.length > 0 && (
           <div className="grid gap-4">
             {sources.map((source) => (

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,3 @@
-// Services API pour communiquer avec le backend Doc2AI
-
 import type {
   ApiResponse,
   ConnectionTestResult,
@@ -60,13 +58,12 @@ async function fetchApi<T>(
     console.log("fetchApi: Response data:", data);
 
     if (!response.ok) {
-      // Detect expired Google token and notify the app
       if (response.status === 401 && data.code === "TOKEN_EXPIRED") {
         window.dispatchEvent(new CustomEvent(GOOGLE_TOKEN_EXPIRED_EVENT));
       }
 
       throw new ApiError(
-        data.message || "Une erreur est survenue",
+        data.message || "An error occurred",
         response.status,
         data,
       );
@@ -78,9 +75,8 @@ async function fetchApi<T>(
       throw error;
     }
 
-    // Erreur réseau ou parsing JSON
     throw new ApiError(
-      error instanceof Error ? error.message : "Erreur de connexion",
+      error instanceof Error ? error.message : "Connection error",
       0,
     );
   }
@@ -89,19 +85,16 @@ async function fetchApi<T>(
 // === Sources API ===
 
 export const sourcesApi = {
-  // Récupérer toutes les sources
   getAll: async (): Promise<Source[]> => {
     const response = await fetchApi<ApiResponse<Source[]>>("/sources");
     return response.data;
   },
 
-  // Récupérer une source par ID
   getById: async (id: string): Promise<Source> => {
     const response = await fetchApi<ApiResponse<Source>>(`/sources/${id}`);
     return response.data;
   },
 
-  // Créer une nouvelle source
   create: async (sourceData: CreateSourceRequest): Promise<Source> => {
     console.log("API: Creating source with data:", sourceData);
     console.log("API: Making POST request to:", `${API_BASE_URL}/sources`);
@@ -113,7 +106,6 @@ export const sourcesApi = {
     return response.data;
   },
 
-  // Mettre à jour une source
   update: async (
     id: string,
     sourceData: Partial<CreateSourceRequest>,
@@ -125,14 +117,12 @@ export const sourcesApi = {
     return response.data;
   },
 
-  // Supprimer une source
   delete: async (id: string): Promise<void> => {
     await fetchApi<ApiResponse<null>>(`/sources/${id}`, {
       method: "DELETE",
     });
   },
 
-  // Tester la connexion d'une source
   testConnection: async (id: string): Promise<ConnectionTestResult> => {
     const response = await fetchApi<ApiResponse<ConnectionTestResult>>(
       `/sources/${id}/test`,
@@ -143,7 +133,6 @@ export const sourcesApi = {
     return response.data;
   },
 
-  // Tester les identifiants avant création
   testCredentials: async (credentialsData: {
     platform: string;
     credentials: any;
@@ -160,7 +149,6 @@ export const sourcesApi = {
     return response.data;
   },
 
-  // Synchroniser une source manuellement
   sync: async (id: string): Promise<void> => {
     await fetchApi<ApiResponse<{ success: boolean; message: string }>>(
       `/sources/${id}/sync`,
@@ -170,13 +158,11 @@ export const sourcesApi = {
     );
   },
 
-  // Récupérer les statistiques des sources
   getStats: async (): Promise<SourceStats> => {
     const response = await fetchApi<ApiResponse<SourceStats>>("/sources/stats");
     return response.data;
   },
 
-  // Lister les dossiers Google Drive
   getGoogleDriveFolders: async (
     parentId: string,
     credentials: { clientId: string; clientSecret: string; refreshToken: string },
@@ -191,7 +177,6 @@ export const sourcesApi = {
     return response.data;
   },
 
-  // Prévisualiser les fichiers Google Drive
   previewGoogleDriveFiles: async (
     folderId: string,
     credentials: { clientId: string; clientSecret: string; refreshToken: string },
@@ -210,7 +195,6 @@ export const sourcesApi = {
 // === Conversions API ===
 
 export const conversionsApi = {
-  // Récupérer tous les jobs de conversion
   getAll: async (
     page = 1,
     limit = 20,
@@ -227,7 +211,6 @@ export const conversionsApi = {
     );
   },
 
-  // Récupérer un job par ID
   getById: async (id: string): Promise<ConversionJob> => {
     const response = await fetchApi<ApiResponse<ConversionJob>>(
       `/conversions/${id}`,
@@ -235,7 +218,6 @@ export const conversionsApi = {
     return response.data;
   },
 
-  // Créer un job de conversion manuel
   create: async (jobData: {
     sourceId: string;
     fileName: string;
@@ -252,7 +234,6 @@ export const conversionsApi = {
     return response.data;
   },
 
-  // Annuler un job
   cancel: async (id: string): Promise<ConversionJob> => {
     const response = await fetchApi<ApiResponse<ConversionJob>>(
       `/conversions/${id}`,
@@ -263,7 +244,6 @@ export const conversionsApi = {
     return response.data;
   },
 
-  // Relancer un job échoué
   retry: async (id: string): Promise<ConversionJob> => {
     const response = await fetchApi<ApiResponse<ConversionJob>>(
       `/conversions/${id}/retry`,
@@ -274,7 +254,6 @@ export const conversionsApi = {
     return response.data;
   },
 
-  // Récupérer la progression d'un job
   getProgress: async (
     id: string,
   ): Promise<{
@@ -291,14 +270,12 @@ export const conversionsApi = {
     return response.data;
   },
 
-  // Récupérer les statistiques des conversions
   getStats: async (): Promise<ConversionStats> => {
     const response =
       await fetchApi<ApiResponse<ConversionStats>>("/conversions/stats");
     return response.data;
   },
 
-  // Nettoyer les anciens jobs
   cleanup: async (olderThanDays = 30): Promise<{ deletedCount: number }> => {
     const response = await fetchApi<ApiResponse<{ deletedCount: number }>>(
       "/conversions/cleanup",
@@ -314,35 +291,30 @@ export const conversionsApi = {
 // === Monitoring API ===
 
 export const monitoringApi = {
-  // Récupérer le statut du monitoring
   getStatus: async (): Promise<MonitoringStatus> => {
     const response =
       await fetchApi<ApiResponse<MonitoringStatus>>("/monitoring/status");
     return response.data;
   },
 
-  // Démarrer le monitoring
   start: async (): Promise<void> => {
     await fetchApi<ApiResponse<null>>("/monitoring/start", {
       method: "POST",
     });
   },
 
-  // Arrêter le monitoring
   stop: async (): Promise<void> => {
     await fetchApi<ApiResponse<null>>("/monitoring/stop", {
       method: "POST",
     });
   },
 
-  // Redémarrer le monitoring
   restart: async (): Promise<void> => {
     await fetchApi<ApiResponse<null>>("/monitoring/restart", {
       method: "POST",
     });
   },
 
-  // Récupérer les logs
   getLogs: async (sourceId?: string, limit = 50): Promise<SyncLog[]> => {
     const params = new URLSearchParams({
       limit: limit.toString(),
@@ -355,14 +327,12 @@ export const monitoringApi = {
     return response.data;
   },
 
-  // Synchroniser une source spécifique
   syncSource: async (sourceId: string): Promise<void> => {
     await fetchApi<ApiResponse<null>>(`/monitoring/sync/${sourceId}`, {
       method: "POST",
     });
   },
 
-  // Health check
   healthCheck: async (): Promise<{
     status: string;
     monitoring: boolean;
@@ -379,7 +349,6 @@ export const monitoringApi = {
 // === Health API ===
 
 export const healthApi = {
-  // Health check général
   check: async (): Promise<{
     name: string;
     version: string;
@@ -393,5 +362,4 @@ export const healthApi = {
   },
 };
 
-// Export de l'erreur pour la gestion
 export { ApiError };

--- a/frontend/src/services/tokenStorage.ts
+++ b/frontend/src/services/tokenStorage.ts
@@ -7,7 +7,7 @@ interface GoogleCredentials {
 }
 
 const STORAGE_KEY = "doc2ai_google_credentials";
-const TOKEN_EXPIRY_HOURS = 24; // Les tokens expirent après 24h
+const TOKEN_EXPIRY_HOURS = 24;
 
 export class TokenStorage {
   static saveCredentials(credentials: GoogleCredentials): void {
@@ -30,7 +30,7 @@ export class TokenStorage {
 
       const credentials: GoogleCredentials = JSON.parse(stored);
 
-      // Vérifier si le token n'a pas expiré
+      // Check if token has expired
       if (credentials.expiresAt && Date.now() > credentials.expiresAt) {
         this.clearCredentials();
         return null;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,5 +1,3 @@
-// Types pour l'API Backend Doc2AI
-
 export interface Source {
   id: string;
   name: string;
@@ -14,7 +12,7 @@ export interface Source {
 }
 
 export interface SourceConfig {
-  credentials: any; // Chiffré côté backend
+  credentials: any;
   sourcePath: string;
   siteUrl?: string; // Pour SharePoint
   destination: string;


### PR DESCRIPTION
## Summary

- Translated all French strings, UI labels, error messages, and comments to English across 39 files (backend + frontend)
- Removed redundant/self-evident JSDoc and inline comments; kept only non-obvious ones
- Stripped decorative emojis from log messages — `❌` reserved for `console.error`, `⚠️` for `console.warn`
- Added JSDoc to the most important service functions (`processJob`, `syncSource`, `enqueueConversion`, `testCredentials`, `previewGoogleDriveFiles`, etc.)
- Also removed noisy debug `console.log` calls left over from development in `sourceService`

## Test plan

- [ ] Start the app with `./start.sh` and verify no startup errors
- [ ] Add a Google Drive source and confirm UI labels are in English
- [ ] Trigger a manual sync and check backend logs — no decorative emojis, errors use `❌` only
- [ ] Verify OAuth flow still works end-to-end