### PR TITLE
Remove hardcoded container names to fix multi-workspace conflicts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile
-    container_name: doc2ai-backend
     restart: unless-stopped
     ports:
       - "${BACKEND_PORT:-3000}:3000"
@@ -53,7 +52,6 @@ services:
         - VITE_DEFAULT_MICROSOFT_CLIENT_SECRET=${MICROSOFT_CLIENT_SECRET}
         - VITE_DEFAULT_MICROSOFT_TENANT_ID=${MICROSOFT_TENANT_ID}
         - VITE_EXPORT_PATH=${EXPORT_PATH}
-    container_name: doc2ai-frontend
     restart: unless-stopped
     ports:
       - "${FRONTEND_PORT:-5173}:5173"
@@ -66,7 +64,6 @@ services:
 
   redis:
     image: redis:7-alpine
-    container_name: doc2ai-redis
     restart: unless-stopped
     ports:
       - "${REDIS_PORT:-6379}:6379"


### PR DESCRIPTION
Remove the `container_name` directives for `doc2ai-backend`, `doc2ai-frontend`, and `doc2ai-redis` from `docker-compose.yml`. These hardcoded names are global to the Docker daemon, causing conflicts when the stack is running in more than one Conductor workspace simultaneously. Docker Compose will now auto-generate unique names scoped to each workspace directory.