### PR TITLE
Use CONDUCTOR_WORKSPACE_NAME as page title

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Doc2AI</title>
+    <title>%TITLE%</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,7 +5,19 @@ import { defineConfig } from "vite"
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [
+    react(),
+    tailwindcss(),
+    {
+      name: 'conductor-workspace-title',
+      transformIndexHtml(html) {
+        return html.replace(
+          /%TITLE%/g,
+          process.env.CONDUCTOR_WORKSPACE_NAME || 'Doc2AI'
+        )
+      },
+    },
+  ],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
Replace the hardcoded `Doc2AI` page title in `index.html` with a `%TITLE%` token. A Vite plugin in `vite.config.ts` resolves this token at build time using the `CONDUCTOR_WORKSPACE_NAME` environment variable, falling back to `Doc2AI` if the variable is not set.