### PR TITLE
Remove MIT license from backend package.json

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -50,6 +50,5 @@
     "sharepoint",
     "google-drive"
   ],
-  "author": "Doc2AI",
-  "license": "MIT"
+  "author": "Doc2AI"
 }


### PR DESCRIPTION
## Summary
- Remove the `"license": "MIT"` field from `backend/package.json` in preparation for switching to BSL 1.1.

## Test plan
- [ ] Verify `backend/package.json` is valid JSON
- [ ] Verify no other files reference the old MIT license