### PR TITLE
Add CI workflow and Prettier formatting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,12 @@
 name: Build
 
+# Disabled until SonarQube is configured
+# on:
+#   push:
+#     branches:
+#       - main
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run build
+
+  backend:
+    name: Backend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+      - run: npm ci
+      - run: npm run lint
+      - run: npx prisma validate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - run: npm ci
+      - run: npm run format:check
       - run: npm run lint
       - run: npm run build
 
@@ -40,5 +41,6 @@ jobs:
           cache: npm
           cache-dependency-path: backend/package-lock.json
       - run: npm ci
+      - run: npm run format:check
       - run: npm run lint
       - run: npx prisma validate

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+build
+*.db
+prisma/migrations
+package-lock.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2
+}

--- a/backend/eslint.config.js
+++ b/backend/eslint.config.js
@@ -1,15 +1,15 @@
-import js from "@eslint/js";
-import globals from "globals";
+import js from '@eslint/js';
+import globals from 'globals';
 
 export default [
   {
-    ignores: ["node_modules/**", "prisma/**"],
+    ignores: ['node_modules/**', 'prisma/**'],
   },
   {
-    files: ["**/*.js"],
+    files: ['**/*.js'],
     languageOptions: {
       ecmaVersion: 2022,
-      sourceType: "module",
+      sourceType: 'module',
       globals: {
         ...globals.node,
         ...globals.es2021,
@@ -17,11 +17,8 @@ export default [
     },
     rules: {
       ...js.configs.recommended.rules,
-      "no-unused-vars": [
-        "error",
-        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
-      ],
-      "no-console": "off",
+      'no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+      'no-console': 'off',
     },
   },
 ];

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "doc2ai-backend",
       "version": "1.0.0",
-      "license": "MIT",
       "dependencies": {
         "@prisma/adapter-better-sqlite3": "^7.2.0",
         "@prisma/client": "^7.2.0",
@@ -26,6 +25,7 @@
         "multer": "^1.4.5-lts.1",
         "node-cron": "^3.0.3",
         "pdf-parse": "^2.4.5",
+        "prisma": "^7.2.0",
         "winston": "^3.11.0"
       },
       "devDependencies": {
@@ -33,14 +33,13 @@
         "eslint": "^9.17.0",
         "globals": "^15.14.0",
         "nodemon": "^3.0.2",
-        "prisma": "^7.2.0"
+        "prettier": "^3.8.3"
       }
     },
     "node_modules/@chevrotain/cst-dts-gen": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-10.5.0.tgz",
       "integrity": "sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@chevrotain/gast": "10.5.0",
@@ -52,7 +51,6 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-10.5.0.tgz",
       "integrity": "sha512-pXdMJ9XeDAbgOWKuD1Fldz4ieCs6+nLNmyVhe2gZVqoO7v8HXuHYs5OV2EzUtbuai37TlOAQHrTDvxMnvMJz3A==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@chevrotain/types": "10.5.0",
@@ -63,14 +61,12 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-10.5.0.tgz",
       "integrity": "sha512-f1MAia0x/pAVPWH/T73BJVyO2XU5tI4/iE7cnxb7tqdNTNhQI3Uq3XkqcoteTmD4t1aM0LbHCJOhgIDn07kl2A==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@chevrotain/utils": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.5.0.tgz",
       "integrity": "sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@colors/colors": {
@@ -97,14 +93,13 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.2.tgz",
       "integrity": "sha512-zfWWa+V2ViDCY/cmUfRqeWY1yLto+EpxjXnZzenB1TyxsTiXaTWeZFIZw6mac52BsuQm0RjCnisjBtdBaXOI6w==",
-      "devOptional": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@electric-sql/pglite-socket": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite-socket/-/pglite-socket-0.0.6.tgz",
       "integrity": "sha512-6RjmgzphIHIBA4NrMGJsjNWK4pu+bCWJlEWlwcxFTVY3WT86dFpKwbZaGWZV6C5Rd7sCk1Z0CI76QEfukLAUXw==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "pglite-server": "dist/scripts/server.js"
@@ -117,7 +112,6 @@
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.2.7.tgz",
       "integrity": "sha512-9dAccClqxx4cZB+Ar9B+FZ5WgxDc/Xvl9DPrTWv+dYTf0YNubLzi4wHHRGRGhrJv15XwnyKcGOZAP1VXSneSUg==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "peerDependencies": {
         "@electric-sql/pglite": "0.3.2"
@@ -271,7 +265,6 @@
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.6.tgz",
       "integrity": "sha512-Shz/KjlIeAhfiuE93NDKVdZ7HdBVLQAfdbaXEaoAVO3ic9ibRSLGIQGkcBbFyuLr+7/1D5ZCINM8B+6IvXeMtw==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -342,7 +335,6 @@
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@mrleebo/prisma-ast/-/prisma-ast-0.12.1.tgz",
       "integrity": "sha512-JwqeCQ1U3fvccttHZq7Tk0m/TMC6WcFAQZdukypW3AzlJYKYTGNVd1ANU2GuhKnv4UQuOFj3oAl0LLG/gxFN1w==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chevrotain": "^10.5.0",
@@ -658,7 +650,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.2.0.tgz",
       "integrity": "sha512-qmvSnfQ6l/srBW1S7RZGfjTQhc44Yl3ldvU6y3pgmuLM+83SBDs6UQVgMtQuMRe9J3gGqB0RF8wER6RlXEr6jQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "c12": "3.1.0",
@@ -677,7 +668,6 @@
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.17.0.tgz",
       "integrity": "sha512-6sGebe5jxX+FEsQTpjHLzvOGPn6ypFQprcs3jcuIWv1Xp/5v6P/rjfdvAwTkP2iF6pDx2tCd8vGLNWcsWzImTA==",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "@electric-sql/pglite": "0.3.2",
@@ -712,7 +702,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.2.0.tgz",
       "integrity": "sha512-HUeOI/SvCDsHrR9QZn24cxxZcujOjcS3w1oW/XVhnSATAli5SRMOfp/WkG3TtT5rCxDA4xOnlJkW7xkho4nURA==",
-      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -726,14 +715,12 @@
       "version": "7.2.0-4.0c8ef2ce45c83248ab3df073180d5eda9e8be7a3",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.2.0-4.0c8ef2ce45c83248ab3df073180d5eda9e8be7a3.tgz",
       "integrity": "sha512-KezsjCZDsbjNR7SzIiVlUsn9PnLePI7r5uxABlwL+xoerurZTfgQVbIjvjF2sVr3Uc0ZcsnREw3F84HvbggGdA==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines/node_modules/@prisma/get-platform": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.2.0.tgz",
       "integrity": "sha512-k1V0l0Td1732EHpAfi2eySTezyllok9dXb6UQanajkJQzPUGi3vO2z7jdkz67SypFTdmbnyGYxvEvYZdZsMAVA==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "7.2.0"
@@ -743,7 +730,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.2.0.tgz",
       "integrity": "sha512-Z5XZztJ8Ap+wovpjPD2lQKnB8nWFGNouCrglaNFjxIWAGWz0oeHXwUJRiclIoSSXN/ptcs9/behptSk8d0Yy6w==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "7.2.0",
@@ -755,7 +741,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.2.0.tgz",
       "integrity": "sha512-k1V0l0Td1732EHpAfi2eySTezyllok9dXb6UQanajkJQzPUGi3vO2z7jdkz67SypFTdmbnyGYxvEvYZdZsMAVA==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "7.2.0"
@@ -765,7 +750,6 @@
       "version": "6.8.2",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.8.2.tgz",
       "integrity": "sha512-vXSxyUgX3vm1Q70QwzwkjeYfRryIvKno1SXbIqwSptKwqKzskINnDUcx85oX+ys6ooN2ATGSD0xN2UTfg6Zcow==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "6.8.2"
@@ -775,21 +759,18 @@
       "version": "6.8.2",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.8.2.tgz",
       "integrity": "sha512-4muBSSUwJJ9BYth5N8tqts8JtiLT8QI/RSAzEogwEfpbYGFo9mYsInsVo8dqXdPO2+Rm5OG5q0qWDDE3nyUbVg==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/query-plan-executor": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/@prisma/query-plan-executor/-/query-plan-executor-6.18.0.tgz",
       "integrity": "sha512-jZ8cfzFgL0jReE1R10gT8JLHtQxjWYLiQ//wHmVYZ2rVkFHoh0DT8IXsxcKcFlfKN7ak7k6j0XMNn2xVNyr5cA==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/studio-core": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@prisma/studio-core/-/studio-core-0.9.0.tgz",
       "integrity": "sha512-xA2zoR/ADu/NCSQuriBKTh6Ps4XjU0bErkEcgMfnSGh346K1VI7iWKnoq1l2DoxUqiddPHIEWwtxJ6xCHG6W7g==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "peerDependencies": {
         "@types/react": "^18.0.0 || ^19.0.0",
@@ -801,7 +782,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -822,7 +802,6 @@
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.8.tgz",
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
-      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -863,6 +842,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -962,7 +942,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
       "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6.0.0"
@@ -1249,7 +1228,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
       "integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.3",
@@ -1278,7 +1256,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -1294,7 +1271,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -1364,7 +1340,6 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-10.5.0.tgz",
       "integrity": "sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@chevrotain/cst-dts-gen": "10.5.0",
@@ -1423,7 +1398,6 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
       "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "consola": "^3.2.3"
@@ -1540,14 +1514,12 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
       "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/consola": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
       "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
@@ -1624,7 +1596,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -1639,9 +1610,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -1695,7 +1664,6 @@
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
       "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
-      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=16.0.0"
@@ -1705,7 +1673,6 @@
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
       "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/delayed-stream": {
@@ -1739,7 +1706,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
       "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/destroy": {
@@ -1821,7 +1787,6 @@
       "version": "3.18.4",
       "resolved": "https://registry.npmjs.org/effect/-/effect-3.18.4.tgz",
       "integrity": "sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
@@ -1832,7 +1797,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
       "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -1932,6 +1896,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2204,14 +2169,12 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
       "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/fast-check": {
       "version": "3.23.2",
       "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
       "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
-      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -2390,7 +2353,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -2407,7 +2369,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -2498,7 +2459,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
       "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-property": "^1.0.2"
@@ -2544,7 +2504,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.1.2.tgz",
       "integrity": "sha512-Gxc29eLs1fbn6LQ4jSU4vXjlwyZhF5HsGuMAa7gqBP4Rw4yxxltyDUuF5MBclFzDTXO+ACchGQoeela4DSfzdQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/get-proto": {
@@ -2564,7 +2523,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
       "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "citty": "^0.1.6",
@@ -2632,7 +2590,6 @@
       "version": "3.1.12",
       "resolved": "https://registry.npmjs.org/grammex/-/grammex-3.1.12.tgz",
       "integrity": "sha512-6ufJOsSA7LcQehIJNCO7HIBykfM7DXQual0Ny780/DEcJIpBlHRvcqEBWGPYd7hrXL2GJ3oJI1MIhaXjWmLQOQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/has-flag": {
@@ -2697,8 +2654,8 @@
       "version": "4.10.6",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.10.6.tgz",
       "integrity": "sha512-BIdolzGpDO9MQ4nu3AUuDwHZZ+KViNm+EZ75Ae55eMXMqLVhDFqEMXxtUe9Qh8hjL+pIna/frs2j6Y2yD5Ua/g==",
-      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2723,7 +2680,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
       "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/iconv-lite": {
@@ -2903,7 +2859,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/is-stream": {
@@ -2928,14 +2883,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -3085,7 +3038,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
       "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -3195,7 +3147,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/lop": {
@@ -3213,7 +3164,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.3.tgz",
       "integrity": "sha512-Lkk/vx6ak3rYkRR0Nhu4lFUT2VDnQSxBe8Hbl7f36358p6ow8Bnvr8lrLt98H8J1aGxfhbX4Fs5tYg2+FTwr5Q==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "bun": ">=1.0.0",
@@ -3448,7 +3398,6 @@
       "version": "3.15.3",
       "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.15.3.tgz",
       "integrity": "sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "aws-ssl-profiles": "^1.1.1",
@@ -3469,7 +3418,6 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -3486,7 +3434,6 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.6.tgz",
       "integrity": "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "lru.min": "^1.1.0"
@@ -3545,7 +3492,6 @@
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
       "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/node-gyp-build-optional-packages": {
@@ -3629,7 +3575,6 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.2.tgz",
       "integrity": "sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "citty": "^0.1.6",
@@ -3670,7 +3615,6 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/on-finished": {
@@ -3810,7 +3754,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3826,7 +3769,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/pdf-parse": {
@@ -3865,7 +3807,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
       "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/picomatch": {
@@ -3885,7 +3826,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
       "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "confbox": "^0.2.2",
@@ -3897,7 +3837,6 @@
       "version": "3.4.7",
       "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.7.tgz",
       "integrity": "sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==",
-      "devOptional": true,
       "license": "Unlicense",
       "engines": {
         "node": ">=12"
@@ -3943,13 +3882,29 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/prisma": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.2.0.tgz",
       "integrity": "sha512-jSdHWgWOgFF24+nRyyNRVBIgGDQEsMEF8KPHvhBBg3jWyR9fUAK0Nq9ThUmiGlNgq2FA7vSk/ZoCvefod+a8qg==",
-      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "7.2.0",
         "@prisma/dev": "0.17.0",
@@ -3987,7 +3942,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
       "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -4045,7 +3999,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
       "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
-      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -4154,7 +4107,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
       "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "defu": "^6.1.4",
@@ -4165,7 +4117,6 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
-      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -4176,7 +4127,6 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
-      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -4245,14 +4195,12 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
       "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/remeda": {
       "version": "2.21.3",
       "resolved": "https://registry.npmjs.org/remeda/-/remeda-2.21.3.tgz",
       "integrity": "sha512-XXrZdLA10oEOQhLLzEJEiFFSKi21REGAkHdImIb4rt/XXy8ORGXh5HCcpUOsElfPNDb+X6TA/+wkh+p2KffYmg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "type-fest": "^4.39.1"
@@ -4262,7 +4210,6 @@
       "version": "4.41.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
       "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "devOptional": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
@@ -4285,7 +4232,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -4330,9 +4276,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.2",
@@ -4397,8 +4341,7 @@
     "node_modules/seq-queue": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
-      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==",
-      "devOptional": true
+      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
     },
     "node_modules/serve-static": {
       "version": "1.16.2",
@@ -4431,7 +4374,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -4444,7 +4386,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4526,7 +4467,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/simple-concat": {
@@ -4612,7 +4552,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
       "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4646,7 +4585,6 @@
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
       "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/streamsearch": {
@@ -4750,7 +4688,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
       "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4910,7 +4847,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
       "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
-      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "typescript": ">=5"
@@ -4934,7 +4870,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -5061,7 +4996,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/zeptomatch/-/zeptomatch-2.0.2.tgz",
       "integrity": "sha512-H33jtSKf8Ijtb5BW6wua3G5DhnFjbFML36eFu+VdOoVY4HD9e7ggjqdM6639B+L87rjnR6Y+XeRzBXZdy52B/g==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "grammex": "^3.1.10"

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,7 +13,9 @@
     "prisma:reset": "prisma migrate reset",
     "build": "echo 'No build step needed for Node.js'",
     "test": "echo 'No tests configured yet'",
-    "lint": "eslint src/"
+    "lint": "eslint src/",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "dependencies": {
     "@prisma/adapter-better-sqlite3": "^7.2.0",
@@ -40,7 +42,8 @@
     "@eslint/js": "^9.17.0",
     "eslint": "^9.17.0",
     "globals": "^15.14.0",
-    "nodemon": "^3.0.2"
+    "nodemon": "^3.0.2",
+    "prettier": "^3.8.3"
   },
   "keywords": [
     "documentation",

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,31 +1,27 @@
-import express from "express";
-import cors from "cors";
-import helmet from "helmet";
-import rateLimit from "express-rate-limit";
-import { initializeDatabase, closeDatabase } from "./config/database.js";
-import config from "./config/env.js";
-import apiRoutes from "./routes/index.js";
-import {
-  errorHandler,
-  notFoundHandler,
-  logError,
-} from "./middleware/errorHandler.js";
-import { extractUserInfo } from "./middleware/auth.js";
-import { sanitizeInput } from "./middleware/validation.js";
-import monitoringService from "./services/monitoringService.js";
-import queueService from "./services/queueService.js";
-import fs from "fs-extra";
+import express from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
+import rateLimit from 'express-rate-limit';
+import { initializeDatabase, closeDatabase } from './config/database.js';
+import config from './config/env.js';
+import apiRoutes from './routes/index.js';
+import { errorHandler, notFoundHandler, logError } from './middleware/errorHandler.js';
+import { extractUserInfo } from './middleware/auth.js';
+import { sanitizeInput } from './middleware/validation.js';
+import monitoringService from './services/monitoringService.js';
+import queueService from './services/queueService.js';
+import fs from 'fs-extra';
 
 const app = express();
 
-app.set("trust proxy", 1);
+app.set('trust proxy', 1);
 
 async function setupApp() {
-  console.log("Starting Doc2AI Backend...");
+  console.log('Starting Doc2AI Backend...');
 
   await fs.ensureDir(config.storagePath);
   await fs.ensureDir(config.tempPath);
-  console.log("Storage directories created");
+  console.log('Storage directories created');
 
   app.use(
     helmet({
@@ -35,7 +31,7 @@ async function setupApp() {
           defaultSrc: ["'self'"],
           styleSrc: ["'self'", "'unsafe-inline'"],
           scriptSrc: ["'self'"],
-          imgSrc: ["'self'", "data:", "https:"],
+          imgSrc: ["'self'", 'data:', 'https:'],
         },
       },
     }),
@@ -45,8 +41,8 @@ async function setupApp() {
     cors({
       origin: config.corsOrigin,
       credentials: true,
-      methods: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
-      allowedHeaders: ["Content-Type", "Authorization", "X-Requested-With"],
+      methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
+      allowedHeaders: ['Content-Type', 'Authorization', 'X-Requested-With'],
     }),
   );
 
@@ -55,16 +51,16 @@ async function setupApp() {
     max: config.rateLimit.max,
     message: {
       success: false,
-      message: "Too many requests",
-      error: "Rate limit exceeded. Please try again later.",
+      message: 'Too many requests',
+      error: 'Rate limit exceeded. Please try again later.',
     },
     standardHeaders: true,
     legacyHeaders: false,
   });
-  app.use("/api/", limiter);
+  app.use('/api/', limiter);
 
-  app.use(express.json({ limit: "10mb" }));
-  app.use(express.urlencoded({ extended: true, limit: "10mb" }));
+  app.use(express.json({ limit: '10mb' }));
+  app.use(express.urlencoded({ extended: true, limit: '10mb' }));
 
   app.use(sanitizeInput);
   app.use(extractUserInfo);
@@ -74,19 +70,19 @@ async function setupApp() {
     next();
   });
 
-  app.use("/api", apiRoutes);
+  app.use('/api', apiRoutes);
 
-  app.get("/", (req, res) => {
+  app.get('/', (req, res) => {
     res.json({
-      name: "Doc2AI Backend",
-      version: "1.0.0",
-      status: "running",
+      name: 'Doc2AI Backend',
+      version: '1.0.0',
+      status: 'running',
       timestamp: new Date().toISOString(),
       environment: config.nodeEnv,
       endpoints: {
-        api: "/api",
-        health: "/api/health",
-        docs: "/api",
+        api: '/api',
+        health: '/api/health',
+        docs: '/api',
       },
     });
   });
@@ -110,20 +106,20 @@ async function startServer() {
       console.log(`API available at: http://localhost:${externalPort}/api`);
     });
 
-    console.log("Starting queue processor...");
+    console.log('Starting queue processor...');
     try {
       await queueService.startProcessing(3);
-      console.log("Queue processor started successfully");
+      console.log('Queue processor started successfully');
     } catch (error) {
-      console.error("❌ Queue processor failed to start:", error.message);
+      console.error('❌ Queue processor failed to start:', error.message);
     }
 
-    console.log("Starting monitoring service...");
+    console.log('Starting monitoring service...');
     try {
       await monitoringService.start();
-      console.log("Monitoring service started successfully");
+      console.log('Monitoring service started successfully');
     } catch (error) {
-      console.warn("⚠️ Monitoring service failed to start:", error.message);
+      console.warn('⚠️ Monitoring service failed to start:', error.message);
     }
 
     const gracefulShutdown = async (signal) => {
@@ -133,39 +129,37 @@ async function startServer() {
         await monitoringService.stop();
       }
 
-      console.log("Closing queue...");
+      console.log('Closing queue...');
       await queueService.close();
 
       await closeDatabase();
 
       server.close(() => {
-        console.log("Doc2AI Backend stopped gracefully");
+        console.log('Doc2AI Backend stopped gracefully');
         process.exit(0);
       });
 
       setTimeout(() => {
-        console.error(
-          "❌ Could not close connections in time, forcefully shutting down",
-        );
+        console.error('❌ Could not close connections in time, forcefully shutting down');
         process.exit(1);
       }, 10000);
     };
 
-    process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));
-    process.on("SIGINT", () => gracefulShutdown("SIGINT"));
+    process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
+    process.on('SIGINT', () => gracefulShutdown('SIGINT'));
 
-    process.on("unhandledRejection", (reason, promise) => {
-      console.error("❌ Unhandled Rejection at:", promise, "reason:", reason);
+    process.on('unhandledRejection', (reason, promise) => {
+      console.error('❌ Unhandled Rejection at:', promise, 'reason:', reason);
     });
 
-    process.on("uncaughtException", (error) => {
-      console.error("❌ Uncaught Exception:", error);
+    process.on('uncaughtException', (error) => {
+      console.error('❌ Uncaught Exception:', error);
       process.exit(1);
     });
 
     return server;
   } catch (error) {
-    console.error("❌ Failed to start server:", error);
+    console.error('❌ Failed to start server:', error);
     process.exit(1);
   }
 }

--- a/backend/src/config/database.js
+++ b/backend/src/config/database.js
@@ -1,7 +1,7 @@
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient } from '@prisma/client';
 import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3';
 
-let prisma
+let prisma;
 
 function getPrismaClient() {
   if (!prisma) {
@@ -9,33 +9,33 @@ function getPrismaClient() {
     prisma = new PrismaClient({
       adapter,
       log: process.env.NODE_ENV === 'development' ? ['query', 'info', 'warn', 'error'] : ['error'],
-    })
+    });
   }
-  return prisma
+  return prisma;
 }
 
 export async function initializeDatabase() {
   try {
-    console.log('Initializing database...')
-    
-    const client = getPrismaClient()
-    
-    await client.$connect()
-    console.log('Database connected successfully')
-    
-    return client
+    console.log('Initializing database...');
+
+    const client = getPrismaClient();
+
+    await client.$connect();
+    console.log('Database connected successfully');
+
+    return client;
   } catch (error) {
-    console.error('❌ Database initialization failed:', error)
-    throw error
+    console.error('❌ Database initialization failed:', error);
+    throw error;
   }
 }
 
 export async function closeDatabase() {
   if (prisma) {
-    await prisma.$disconnect()
-    console.log('Database disconnected')
+    await prisma.$disconnect();
+    console.log('Database disconnected');
   }
 }
 
-export { getPrismaClient }
-export default getPrismaClient
+export { getPrismaClient };
+export default getPrismaClient;

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -1,8 +1,8 @@
-import dotenv from "dotenv";
-import path from "path";
+import dotenv from 'dotenv';
+import path from 'path';
 
 dotenv.config();
-const requiredVars = ["JWT_SECRET", "ENCRYPTION_KEY", "DATABASE_URL"];
+const requiredVars = ['JWT_SECRET', 'ENCRYPTION_KEY', 'DATABASE_URL'];
 
 for (const varName of requiredVars) {
   if (!process.env[varName]) {
@@ -13,8 +13,8 @@ for (const varName of requiredVars) {
 
 const config = {
   port: parseInt(process.env.PORT) || 3000,
-  nodeEnv: process.env.NODE_ENV || "development",
-  corsOrigin: process.env.CORS_ORIGIN || "http://localhost:5173",
+  nodeEnv: process.env.NODE_ENV || 'development',
+  corsOrigin: process.env.CORS_ORIGIN || 'http://localhost:5173',
 
   databaseUrl: process.env.DATABASE_URL,
 
@@ -35,11 +35,11 @@ const config = {
 
   redisUrl: process.env.REDIS_URL,
 
-  storagePath: path.resolve(process.env.STORAGE_PATH || "./storage"),
-  tempPath: path.resolve(process.env.TEMP_PATH || "./temp"),
-  exportPath: path.resolve(process.env.EXPORT_PATH || "./exports"),
+  storagePath: path.resolve(process.env.STORAGE_PATH || './storage'),
+  tempPath: path.resolve(process.env.TEMP_PATH || './temp'),
+  exportPath: path.resolve(process.env.EXPORT_PATH || './exports'),
 
-  logLevel: process.env.LOG_LEVEL || "info",
+  logLevel: process.env.LOG_LEVEL || 'info',
   syncIntervalMinutes: parseInt(process.env.SYNC_INTERVAL_MINUTES) || 15,
 
   rateLimit: {
@@ -49,7 +49,7 @@ const config = {
 };
 
 if (config.encryptionKey.length !== 32) {
-  console.error("❌ ENCRYPTION_KEY must be exactly 32 characters long");
+  console.error('❌ ENCRYPTION_KEY must be exactly 32 characters long');
   process.exit(1);
 }
 

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -1,5 +1,5 @@
-import axios from "axios";
-import config from "../config/env.js";
+import axios from 'axios';
+import config from '../config/env.js';
 
 class AuthController {
   // GET /api/auth/google/callback
@@ -10,7 +10,7 @@ class AuthController {
       if (error) {
         return res.status(400).json({
           success: false,
-          message: "Authorization denied",
+          message: 'Authorization denied',
           error: error,
         });
       }
@@ -18,38 +18,37 @@ class AuthController {
       if (!code) {
         return res.status(400).json({
           success: false,
-          message: "Missing authorization code",
-          error: "No code parameter found in callback",
+          message: 'Missing authorization code',
+          error: 'No code parameter found in callback',
         });
       }
 
       const tokenResponse = await axios.post(
-        "https://oauth2.googleapis.com/token",
+        'https://oauth2.googleapis.com/token',
         {
           client_id: process.env.GOOGLE_CLIENT_ID,
           client_secret: process.env.GOOGLE_CLIENT_SECRET,
           code: code,
-          grant_type: "authorization_code",
+          grant_type: 'authorization_code',
           redirect_uri: config.google.redirectUri,
         },
         {
           headers: {
-            "Content-Type": "application/x-www-form-urlencoded",
+            'Content-Type': 'application/x-www-form-urlencoded',
           },
         },
       );
 
-      const { access_token, refresh_token, expires_in, scope } =
-        tokenResponse.data;
+      const { access_token, refresh_token, expires_in, scope } = tokenResponse.data;
 
       if (!refresh_token) {
         return res.status(400).json({
           success: false,
-          message: "No refresh token received",
+          message: 'No refresh token received',
           error:
-            "Google did not provide a refresh token. Try adding prompt=consent to the authorization URL.",
+            'Google did not provide a refresh token. Try adding prompt=consent to the authorization URL.',
           data: {
-            access_token: access_token ? "received" : "missing",
+            access_token: access_token ? 'received' : 'missing',
             expires_in,
             scope,
           },
@@ -58,7 +57,7 @@ class AuthController {
 
       try {
         const userInfoResponse = await axios.get(
-          "https://www.googleapis.com/drive/v3/about?fields=user",
+          'https://www.googleapis.com/drive/v3/about?fields=user',
           {
             headers: {
               Authorization: `Bearer ${access_token}`,
@@ -80,16 +79,12 @@ class AuthController {
           },
         };
 
-        const encodedData = Buffer.from(JSON.stringify(successData)).toString(
-          "base64",
-        );
+        const encodedData = Buffer.from(JSON.stringify(successData)).toString('base64');
         const frontendUrl = config.corsOrigin;
 
-        return res.redirect(
-          `${frontendUrl}/auth/callback?data=${encodedData}&success=true`,
-        );
+        return res.redirect(`${frontendUrl}/auth/callback?data=${encodedData}&success=true`);
       } catch (userInfoError) {
-        console.warn("Could not fetch user info:", userInfoError.message);
+        console.warn('Could not fetch user info:', userInfoError.message);
 
         const fallbackData = {
           refresh_token,
@@ -97,15 +92,13 @@ class AuthController {
           expires_in,
           scope,
           user: {
-            email: "unknown@gmail.com",
-            name: "Google User",
+            email: 'unknown@gmail.com',
+            name: 'Google User',
             photoLink: null,
           },
         };
 
-        const encodedFallbackData = Buffer.from(
-          JSON.stringify(fallbackData),
-        ).toString("base64");
+        const encodedFallbackData = Buffer.from(JSON.stringify(fallbackData)).toString('base64');
         const frontendUrl = config.corsOrigin;
 
         return res.redirect(
@@ -113,16 +106,14 @@ class AuthController {
         );
       }
     } catch (error) {
-      console.error("Error in Google OAuth callback:", error);
+      console.error('Error in Google OAuth callback:', error);
 
-      let errorMessage = "OAuth callback failed";
+      let errorMessage = 'OAuth callback failed';
       let errorDetails = error.message;
 
       if (error.response?.data) {
         errorMessage =
-          error.response.data.error_description ||
-          error.response.data.error ||
-          errorMessage;
+          error.response.data.error_description || error.response.data.error || errorMessage;
         errorDetails = error.response.data;
       }
 
@@ -137,36 +128,36 @@ class AuthController {
   // GET /api/auth/google
   async getGoogleAuthUrl(req, res) {
     try {
-      const baseUrl = "https://accounts.google.com/o/oauth2/v2/auth";
+      const baseUrl = 'https://accounts.google.com/o/oauth2/v2/auth';
       const params = new URLSearchParams({
         client_id: process.env.GOOGLE_CLIENT_ID,
         redirect_uri: config.google.redirectUri,
-        response_type: "code",
-        scope: "https://www.googleapis.com/auth/drive",
-        access_type: "offline",
-        prompt: "consent",
+        response_type: 'code',
+        scope: 'https://www.googleapis.com/auth/drive',
+        access_type: 'offline',
+        prompt: 'consent',
       });
 
       const authUrl = `${baseUrl}?${params.toString()}`;
 
       res.json({
         success: true,
-        message: "Google authorization URL generated",
+        message: 'Google authorization URL generated',
         data: {
           authUrl,
           instructions: [
-            "1. Open the authUrl in your browser",
-            "2. Sign in to Google and authorize the application",
-            "3. You will be redirected back with your tokens",
-            "4. Copy the refresh_token from the response",
+            '1. Open the authUrl in your browser',
+            '2. Sign in to Google and authorize the application',
+            '3. You will be redirected back with your tokens',
+            '4. Copy the refresh_token from the response',
           ],
         },
       });
     } catch (error) {
-      console.error("Error generating Google auth URL:", error);
+      console.error('Error generating Google auth URL:', error);
       res.status(500).json({
         success: false,
-        message: "Failed to generate authorization URL",
+        message: 'Failed to generate authorization URL',
         error: error.message,
       });
     }

--- a/backend/src/controllers/conversionController.js
+++ b/backend/src/controllers/conversionController.js
@@ -1,165 +1,166 @@
-import ConversionService from '../services/conversionService.js'
+import ConversionService from '../services/conversionService.js';
 
-const conversionService = new ConversionService()
+const conversionService = new ConversionService();
 
 class ConversionController {
   // GET /api/conversions
   async getAllJobs(req, res) {
     try {
-      const page = parseInt(req.query.page) || 1
-      const limit = parseInt(req.query.limit) || 20
-      const status = req.query.status || null
+      const page = parseInt(req.query.page) || 1;
+      const limit = parseInt(req.query.limit) || 20;
+      const status = req.query.status || null;
 
-      const result = await conversionService.getAllJobs(page, limit, status)
-      
+      const result = await conversionService.getAllJobs(page, limit, status);
+
       res.json({
         success: true,
         data: result.jobs,
-        pagination: result.pagination
-      })
+        pagination: result.pagination,
+      });
     } catch (error) {
-      console.error('Error in getAllJobs:', error)
+      console.error('Error in getAllJobs:', error);
       res.status(500).json({
         success: false,
         message: 'Failed to fetch conversion jobs',
-        error: error.message
-      })
+        error: error.message,
+      });
     }
   }
 
   // GET /api/conversions/:id
   async getJobById(req, res) {
     try {
-      const { id } = req.params
-      const job = await conversionService.getJobById(id)
-      
+      const { id } = req.params;
+      const job = await conversionService.getJobById(id);
+
       res.json({
         success: true,
-        data: job
-      })
+        data: job,
+      });
     } catch (error) {
-      console.error('Error in getJobById:', error)
-      
+      console.error('Error in getJobById:', error);
+
       if (error.message === 'Conversion job not found') {
         return res.status(404).json({
           success: false,
-          message: 'Conversion job not found'
-        })
+          message: 'Conversion job not found',
+        });
       }
 
       res.status(500).json({
         success: false,
         message: 'Failed to fetch conversion job',
-        error: error.message
-      })
+        error: error.message,
+      });
     }
   }
 
   // POST /api/conversions
   async createJob(req, res) {
     try {
-      const { sourceId, fileName, filePath, fileSize } = req.body
+      const { sourceId, fileName, filePath, fileSize } = req.body;
 
       // Validation
       if (!sourceId || !fileName || !filePath) {
         return res.status(400).json({
           success: false,
-          message: 'Missing required fields: sourceId, fileName, filePath'
-        })
+          message: 'Missing required fields: sourceId, fileName, filePath',
+        });
       }
 
-      const job = await conversionService.createJob(sourceId, fileName, filePath, fileSize)
-      
-      conversionService.processJob(job.id)
+      const job = await conversionService.createJob(sourceId, fileName, filePath, fileSize);
+
+      conversionService
+        .processJob(job.id)
         .then(() => {
-          console.log(`Job ${job.id} completed`)
+          console.log(`Job ${job.id} completed`);
         })
         .catch((error) => {
-          console.error(`❌ Job ${job.id} failed:`, error)
-        })
+          console.error(`❌ Job ${job.id} failed:`, error);
+        });
 
       res.status(201).json({
         success: true,
         data: job,
-        message: 'Conversion job created and started'
-      })
+        message: 'Conversion job created and started',
+      });
     } catch (error) {
-      console.error('Error in createJob:', error)
+      console.error('Error in createJob:', error);
       res.status(500).json({
         success: false,
         message: 'Failed to create conversion job',
-        error: error.message
-      })
+        error: error.message,
+      });
     }
   }
 
   // DELETE /api/conversions/:id
   async cancelJob(req, res) {
     try {
-      const { id } = req.params
-      const job = await conversionService.cancelJob(id)
-      
+      const { id } = req.params;
+      const job = await conversionService.cancelJob(id);
+
       res.json({
         success: true,
         data: job,
-        message: 'Job cancelled successfully'
-      })
+        message: 'Job cancelled successfully',
+      });
     } catch (error) {
-      console.error('Error in cancelJob:', error)
+      console.error('Error in cancelJob:', error);
       res.status(500).json({
         success: false,
         message: 'Failed to cancel job',
-        error: error.message
-      })
+        error: error.message,
+      });
     }
   }
 
   // GET /api/conversions/stats
   async getStats(req, res) {
     try {
-      const stats = await conversionService.getJobStats()
-      
+      const stats = await conversionService.getJobStats();
+
       res.json({
         success: true,
-        data: stats
-      })
+        data: stats,
+      });
     } catch (error) {
-      console.error('Error in getStats:', error)
+      console.error('Error in getStats:', error);
       res.status(500).json({
         success: false,
         message: 'Failed to fetch conversion statistics',
-        error: error.message
-      })
+        error: error.message,
+      });
     }
   }
 
   // POST /api/conversions/cleanup
   async cleanupJobs(req, res) {
     try {
-      const { olderThanDays = 30 } = req.body
-      const deletedCount = await conversionService.cleanupCompletedJobs(olderThanDays)
-      
+      const { olderThanDays = 30 } = req.body;
+      const deletedCount = await conversionService.cleanupCompletedJobs(olderThanDays);
+
       res.json({
         success: true,
         data: { deletedCount },
-        message: `Cleaned up ${deletedCount} old conversion jobs`
-      })
+        message: `Cleaned up ${deletedCount} old conversion jobs`,
+      });
     } catch (error) {
-      console.error('Error in cleanupJobs:', error)
+      console.error('Error in cleanupJobs:', error);
       res.status(500).json({
         success: false,
         message: 'Failed to cleanup jobs',
-        error: error.message
-      })
+        error: error.message,
+      });
     }
   }
 
   // GET /api/conversions/:id/progress
   async getJobProgress(req, res) {
     try {
-      const { id } = req.params
-      const job = await conversionService.getJobById(id)
-      
+      const { id } = req.params;
+      const job = await conversionService.getJobById(id);
+
       res.json({
         success: true,
         data: {
@@ -168,61 +169,62 @@ class ConversionController {
           progress: job.progress,
           error: job.error,
           startedAt: job.startedAt,
-          completedAt: job.completedAt
-        }
-      })
+          completedAt: job.completedAt,
+        },
+      });
     } catch (error) {
-      console.error('Error in getJobProgress:', error)
+      console.error('Error in getJobProgress:', error);
       res.status(500).json({
         success: false,
         message: 'Failed to get job progress',
-        error: error.message
-      })
+        error: error.message,
+      });
     }
   }
 
   // POST /api/conversions/:id/retry
   async retryJob(req, res) {
     try {
-      const { id } = req.params
-      const job = await conversionService.getJobById(id)
-      
+      const { id } = req.params;
+      const job = await conversionService.getJobById(id);
+
       if (job.status !== 'failed') {
         return res.status(400).json({
           success: false,
-          message: 'Can only retry failed jobs'
-        })
+          message: 'Can only retry failed jobs',
+        });
       }
 
       const updatedJob = await conversionService.createJob(
         job.sourceId,
         job.fileName,
         job.filePath,
-        job.fileSize
-      )
+        job.fileSize,
+      );
 
-      conversionService.processJob(updatedJob.id)
+      conversionService
+        .processJob(updatedJob.id)
         .then(() => {
-          console.log(`Retry job ${updatedJob.id} completed`)
+          console.log(`Retry job ${updatedJob.id} completed`);
         })
         .catch((error) => {
-          console.error(`❌ Retry job ${updatedJob.id} failed:`, error)
-        })
+          console.error(`❌ Retry job ${updatedJob.id} failed:`, error);
+        });
 
       res.json({
         success: true,
         data: updatedJob,
-        message: 'Job retry started'
-      })
+        message: 'Job retry started',
+      });
     } catch (error) {
-      console.error('Error in retryJob:', error)
+      console.error('Error in retryJob:', error);
       res.status(500).json({
         success: false,
         message: 'Failed to retry job',
-        error: error.message
-      })
+        error: error.message,
+      });
     }
   }
 }
 
-export default ConversionController
+export default ConversionController;

--- a/backend/src/controllers/monitoringController.js
+++ b/backend/src/controllers/monitoringController.js
@@ -1,22 +1,22 @@
-import monitoringService from '../services/monitoringService.js'
+import monitoringService from '../services/monitoringService.js';
 
 class MonitoringController {
   // GET /api/monitoring/status
   async getStatus(req, res) {
     try {
-      const status = await monitoringService.getStatus()
-      
+      const status = await monitoringService.getStatus();
+
       res.json({
         success: true,
-        data: status
-      })
+        data: status,
+      });
     } catch (error) {
-      console.error('Error in getStatus:', error)
+      console.error('Error in getStatus:', error);
       res.status(500).json({
         success: false,
         message: 'Failed to get monitoring status',
-        error: error.message
-      })
+        error: error.message,
+      });
     }
   }
 
@@ -26,23 +26,23 @@ class MonitoringController {
       if (monitoringService.isRunning) {
         return res.status(400).json({
           success: false,
-          message: 'Monitoring service is already running'
-        })
+          message: 'Monitoring service is already running',
+        });
       }
 
-      await monitoringService.start()
-      
+      await monitoringService.start();
+
       res.json({
         success: true,
-        message: 'Monitoring service started successfully'
-      })
+        message: 'Monitoring service started successfully',
+      });
     } catch (error) {
-      console.error('Error in startMonitoring:', error)
+      console.error('Error in startMonitoring:', error);
       res.status(500).json({
         success: false,
         message: 'Failed to start monitoring service',
-        error: error.message
-      })
+        error: error.message,
+      });
     }
   }
 
@@ -52,82 +52,82 @@ class MonitoringController {
       if (!monitoringService.isRunning) {
         return res.status(400).json({
           success: false,
-          message: 'Monitoring service is not running'
-        })
+          message: 'Monitoring service is not running',
+        });
       }
 
-      await monitoringService.stop()
-      
+      await monitoringService.stop();
+
       res.json({
         success: true,
-        message: 'Monitoring service stopped successfully'
-      })
+        message: 'Monitoring service stopped successfully',
+      });
     } catch (error) {
-      console.error('Error in stopMonitoring:', error)
+      console.error('Error in stopMonitoring:', error);
       res.status(500).json({
         success: false,
         message: 'Failed to stop monitoring service',
-        error: error.message
-      })
+        error: error.message,
+      });
     }
   }
 
   // GET /api/monitoring/logs
   async getLogs(req, res) {
     try {
-      const sourceId = req.query.sourceId || null
-      const limit = parseInt(req.query.limit) || 50
+      const sourceId = req.query.sourceId || null;
+      const limit = parseInt(req.query.limit) || 50;
 
-      const logs = await monitoringService.getLogs(sourceId, limit)
-      
+      const logs = await monitoringService.getLogs(sourceId, limit);
+
       res.json({
         success: true,
-        data: logs
-      })
+        data: logs,
+      });
     } catch (error) {
-      console.error('Error in getLogs:', error)
+      console.error('Error in getLogs:', error);
       res.status(500).json({
         success: false,
         message: 'Failed to fetch monitoring logs',
-        error: error.message
-      })
+        error: error.message,
+      });
     }
   }
 
   // POST /api/monitoring/sync/:sourceId
   async syncSource(req, res) {
     try {
-      const { sourceId } = req.params
-      
+      const { sourceId } = req.params;
+
       if (!monitoringService.isRunning) {
         return res.status(400).json({
           success: false,
-          message: 'Monitoring service is not running'
-        })
+          message: 'Monitoring service is not running',
+        });
       }
 
-      await monitoringService.syncSource(sourceId)
-      
+      await monitoringService.syncSource(sourceId);
+
       res.json({
         success: true,
-        message: 'Source sync completed successfully'
-      })
+        message: 'Source sync completed successfully',
+      });
     } catch (error) {
-      console.error('Error in syncSource:', error)
+      console.error('Error in syncSource:', error);
       res.status(500).json({
         success: false,
         message: 'Failed to sync source',
-        error: error.message
-      })
+        error: error.message,
+      });
     }
   }
 
   // GET /api/monitoring/health
   async healthCheck(req, res) {
     try {
-      const status = await monitoringService.getStatus()
-      const isHealthy = status.isRunning && status.activeMonitors === status.totalActiveSources
-      
+      const status = await monitoringService.getStatus();
+      const isHealthy = status.isRunning && status.activeMonitors === status.totalActiveSources;
+
       res.status(isHealthy ? 200 : 503).json({
         success: isHealthy,
         data: {
@@ -136,69 +136,69 @@ class MonitoringController {
           activeMonitors: status.activeMonitors,
           totalSources: status.totalActiveSources,
           lastSync: status.lastSync,
-          timestamp: new Date().toISOString()
-        }
-      })
+          timestamp: new Date().toISOString(),
+        },
+      });
     } catch (error) {
-      console.error('Error in healthCheck:', error)
+      console.error('Error in healthCheck:', error);
       res.status(503).json({
         success: false,
         data: {
           status: 'error',
           error: error.message,
-          timestamp: new Date().toISOString()
-        }
-      })
+          timestamp: new Date().toISOString(),
+        },
+      });
     }
   }
 
   // POST /api/monitoring/restart
   async restartMonitoring(req, res) {
     try {
-      console.log('Restarting monitoring service...')
-      
+      console.log('Restarting monitoring service...');
+
       if (monitoringService.isRunning) {
-        await monitoringService.stop()
+        await monitoringService.stop();
       }
-      
-      await new Promise(resolve => setTimeout(resolve, 1000))
-      await monitoringService.start()
-      
+
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      await monitoringService.start();
+
       res.json({
         success: true,
-        message: 'Monitoring service restarted successfully'
-      })
+        message: 'Monitoring service restarted successfully',
+      });
     } catch (error) {
-      console.error('Error in restartMonitoring:', error)
+      console.error('Error in restartMonitoring:', error);
       res.status(500).json({
         success: false,
         message: 'Failed to restart monitoring service',
-        error: error.message
-      })
+        error: error.message,
+      });
     }
   }
 
   // GET /api/monitoring/sources/:sourceId/logs
   async getSourceLogs(req, res) {
     try {
-      const { sourceId } = req.params
-      const limit = parseInt(req.query.limit) || 50
+      const { sourceId } = req.params;
+      const limit = parseInt(req.query.limit) || 50;
 
-      const logs = await monitoringService.getLogs(sourceId, limit)
-      
+      const logs = await monitoringService.getLogs(sourceId, limit);
+
       res.json({
         success: true,
-        data: logs
-      })
+        data: logs,
+      });
     } catch (error) {
-      console.error('Error in getSourceLogs:', error)
+      console.error('Error in getSourceLogs:', error);
       res.status(500).json({
         success: false,
         message: 'Failed to fetch source logs',
-        error: error.message
-      })
+        error: error.message,
+      });
     }
   }
 }
 
-export default MonitoringController
+export default MonitoringController;

--- a/backend/src/controllers/sourceController.js
+++ b/backend/src/controllers/sourceController.js
@@ -1,5 +1,5 @@
-import { TokenExpiredError } from "../integrations/base/driveConnector.js";
-import SourceService from "../services/sourceService.js";
+import { TokenExpiredError } from '../integrations/base/driveConnector.js';
+import SourceService from '../services/sourceService.js';
 
 const sourceService = new SourceService();
 
@@ -13,10 +13,10 @@ class SourceController {
         data: sources,
       });
     } catch (error) {
-      console.error("Error in getAllSources:", error);
+      console.error('Error in getAllSources:', error);
       res.status(500).json({
         success: false,
-        message: "Failed to fetch sources",
+        message: 'Failed to fetch sources',
         error: error.message,
       });
     }
@@ -33,18 +33,18 @@ class SourceController {
         data: source,
       });
     } catch (error) {
-      console.error("Error in getSourceById:", error);
+      console.error('Error in getSourceById:', error);
 
-      if (error.message === "Source not found") {
+      if (error.message === 'Source not found') {
         return res.status(404).json({
           success: false,
-          message: "Source not found",
+          message: 'Source not found',
         });
       }
 
       res.status(500).json({
         success: false,
-        message: "Failed to fetch source",
+        message: 'Failed to fetch source',
         error: error.message,
       });
     }
@@ -58,15 +58,15 @@ class SourceController {
       if (!name || !platform || !config) {
         return res.status(400).json({
           success: false,
-          message: "Missing required fields: name, platform, config",
+          message: 'Missing required fields: name, platform, config',
         });
       }
 
-      const supportedPlatforms = ["sharepoint", "googledrive", "onedrive"];
+      const supportedPlatforms = ['sharepoint', 'googledrive', 'onedrive'];
       if (!supportedPlatforms.includes(platform)) {
         return res.status(400).json({
           success: false,
-          message: `Unsupported platform. Supported: ${supportedPlatforms.join(", ")}`,
+          message: `Unsupported platform. Supported: ${supportedPlatforms.join(', ')}`,
         });
       }
 
@@ -75,13 +75,13 @@ class SourceController {
       res.status(201).json({
         success: true,
         data: source,
-        message: "Source created successfully",
+        message: 'Source created successfully',
       });
     } catch (error) {
-      console.error("Error in createSource:", error);
+      console.error('Error in createSource:', error);
       res.status(500).json({
         success: false,
-        message: "Failed to create source",
+        message: 'Failed to create source',
         error: error.message,
       });
     }
@@ -96,21 +96,21 @@ class SourceController {
       res.json({
         success: true,
         data: source,
-        message: "Source updated successfully",
+        message: 'Source updated successfully',
       });
     } catch (error) {
-      console.error("Error in updateSource:", error);
+      console.error('Error in updateSource:', error);
 
-      if (error.message === "Source not found") {
+      if (error.message === 'Source not found') {
         return res.status(404).json({
           success: false,
-          message: "Source not found",
+          message: 'Source not found',
         });
       }
 
       res.status(500).json({
         success: false,
-        message: "Failed to update source",
+        message: 'Failed to update source',
         error: error.message,
       });
     }
@@ -124,13 +124,13 @@ class SourceController {
 
       res.json({
         success: true,
-        message: "Source deleted successfully",
+        message: 'Source deleted successfully',
       });
     } catch (error) {
-      console.error("Error in deleteSource:", error);
+      console.error('Error in deleteSource:', error);
       res.status(500).json({
         success: false,
-        message: "Failed to delete source",
+        message: 'Failed to delete source',
         error: error.message,
       });
     }
@@ -144,22 +144,22 @@ class SourceController {
       if (!platform || !credentials) {
         return res.status(400).json({
           success: false,
-          message: "Missing required fields: platform, credentials",
+          message: 'Missing required fields: platform, credentials',
         });
       }
 
-      const supportedPlatforms = ["sharepoint", "googledrive", "onedrive"];
+      const supportedPlatforms = ['sharepoint', 'googledrive', 'onedrive'];
       if (!supportedPlatforms.includes(platform)) {
         return res.status(400).json({
           success: false,
-          message: `Unsupported platform. Supported: ${supportedPlatforms.join(", ")}`,
+          message: `Unsupported platform. Supported: ${supportedPlatforms.join(', ')}`,
         });
       }
 
       const result = await sourceService.testCredentials({
         platform,
         credentials,
-        sourcePath: sourcePath || "/",
+        sourcePath: sourcePath || '/',
         ...(siteUrl && { siteUrl }),
       });
 
@@ -168,17 +168,17 @@ class SourceController {
         data: result,
       });
     } catch (error) {
-      console.error("Error in testCredentials:", error);
+      console.error('Error in testCredentials:', error);
       if (error instanceof TokenExpiredError) {
         return res.status(401).json({
           success: false,
-          code: "TOKEN_EXPIRED",
-          message: "Your Google session has expired, please reconnect",
+          code: 'TOKEN_EXPIRED',
+          message: 'Your Google session has expired, please reconnect',
         });
       }
       res.status(500).json({
         success: false,
-        message: "Credentials test failed",
+        message: 'Credentials test failed',
         error: error.message,
       });
     }
@@ -195,17 +195,17 @@ class SourceController {
         data: result,
       });
     } catch (error) {
-      console.error("Error in testConnection:", error);
+      console.error('Error in testConnection:', error);
       if (error instanceof TokenExpiredError) {
         return res.status(401).json({
           success: false,
-          code: "TOKEN_EXPIRED",
-          message: "Your Google session has expired, please reconnect",
+          code: 'TOKEN_EXPIRED',
+          message: 'Your Google session has expired, please reconnect',
         });
       }
       res.status(500).json({
         success: false,
-        message: "Connection test failed",
+        message: 'Connection test failed',
         error: error.message,
       });
     }
@@ -222,10 +222,10 @@ class SourceController {
         data: result,
       });
     } catch (error) {
-      console.error("Error in syncSource:", error);
+      console.error('Error in syncSource:', error);
       res.status(500).json({
         success: false,
-        message: "Sync failed",
+        message: 'Sync failed',
         error: error.message,
       });
     }
@@ -241,10 +241,10 @@ class SourceController {
         data: stats,
       });
     } catch (error) {
-      console.error("Error in getStats:", error);
+      console.error('Error in getStats:', error);
       res.status(500).json({
         success: false,
-        message: "Failed to fetch statistics",
+        message: 'Failed to fetch statistics',
         error: error.message,
       });
     }
@@ -253,37 +253,34 @@ class SourceController {
   // GET /api/sources/google-drive/folders?parent_id=xxx&credentials=xxx
   async getGoogleDriveFolders(req, res) {
     try {
-      const { parent_id = "root" } = req.query;
+      const { parent_id = 'root' } = req.query;
       const { credentials } = req.body;
 
       if (!credentials) {
         return res.status(400).json({
           success: false,
-          message: "Missing Google Drive credentials",
+          message: 'Missing Google Drive credentials',
         });
       }
 
-      const folders = await sourceService.getGoogleDriveFolders(
-        parent_id,
-        credentials,
-      );
+      const folders = await sourceService.getGoogleDriveFolders(parent_id, credentials);
 
       res.json({
         success: true,
         data: folders,
       });
     } catch (error) {
-      console.error("Error in getGoogleDriveFolders:", error);
+      console.error('Error in getGoogleDriveFolders:', error);
       if (error instanceof TokenExpiredError) {
         return res.status(401).json({
           success: false,
-          code: "TOKEN_EXPIRED",
-          message: "Your Google session has expired, please reconnect",
+          code: 'TOKEN_EXPIRED',
+          message: 'Your Google session has expired, please reconnect',
         });
       }
       res.status(500).json({
         success: false,
-        message: "Failed to fetch Google Drive folders",
+        message: 'Failed to fetch Google Drive folders',
         error: error.message,
       });
     }
@@ -293,40 +290,36 @@ class SourceController {
   async previewGoogleDriveFiles(req, res) {
     try {
       const {
-        folder_id = "root",
+        folder_id = 'root',
         credentials,
-        extensions = [".docx", ".pdf", ".doc", ".txt"],
+        extensions = ['.docx', '.pdf', '.doc', '.txt'],
       } = req.body;
 
       if (!credentials) {
         return res.status(400).json({
           success: false,
-          message: "Missing Google Drive credentials",
+          message: 'Missing Google Drive credentials',
         });
       }
 
-      const files = await sourceService.previewGoogleDriveFiles(
-        folder_id,
-        credentials,
-        extensions,
-      );
+      const files = await sourceService.previewGoogleDriveFiles(folder_id, credentials, extensions);
 
       res.json({
         success: true,
         data: files,
       });
     } catch (error) {
-      console.error("Error in previewGoogleDriveFiles:", error);
+      console.error('Error in previewGoogleDriveFiles:', error);
       if (error instanceof TokenExpiredError) {
         return res.status(401).json({
           success: false,
-          code: "TOKEN_EXPIRED",
-          message: "Your Google session has expired, please reconnect",
+          code: 'TOKEN_EXPIRED',
+          message: 'Your Google session has expired, please reconnect',
         });
       }
       res.status(500).json({
         success: false,
-        message: "Failed to preview Google Drive files",
+        message: 'Failed to preview Google Drive files',
         error: error.message,
       });
     }

--- a/backend/src/converters/baseConverter.js
+++ b/backend/src/converters/baseConverter.js
@@ -1,15 +1,15 @@
-import fs from "fs-extra";
-import path from "path";
-import { generateFileChecksum } from "../utils/encryption.js";
+import fs from 'fs-extra';
+import path from 'path';
+import { generateFileChecksum } from '../utils/encryption.js';
 
 class BaseConverter {
   constructor() {
-    this.name = "Base Converter";
+    this.name = 'Base Converter';
     this.supportedExtensions = [];
   }
 
   async convert(_inputPath, _outputPath) {
-    throw new Error("convert() method must be implemented by subclass");
+    throw new Error('convert() method must be implemented by subclass');
   }
 
   async validateInputFile(filePath) {
@@ -49,14 +49,14 @@ class BaseConverter {
   }
 
   cleanMarkdown(markdown) {
-    if (!markdown) return "";
+    if (!markdown) return '';
 
-    let cleaned = markdown.replace(/\n{3,}/g, "\n\n");
-    cleaned = cleaned.replace(/[ \t]+$/gm, "");
+    let cleaned = markdown.replace(/\n{3,}/g, '\n\n');
+    cleaned = cleaned.replace(/[ \t]+$/gm, '');
     cleaned = cleaned.trim();
 
-    if (cleaned && !cleaned.endsWith("\n")) {
-      cleaned += "\n";
+    if (cleaned && !cleaned.endsWith('\n')) {
+      cleaned += '\n';
     }
 
     return cleaned;
@@ -64,22 +64,20 @@ class BaseConverter {
 
   addMetadata(markdown, metadata = {}) {
     const defaultMetadata = {
-      generated_by: "Doc2AI",
+      generated_by: 'Doc2AI',
       generated_at: new Date().toISOString(),
       ...metadata,
     };
 
     const metadataLines = [
-      "---",
-      ...Object.entries(defaultMetadata).map(
-        ([key, value]) => `${key}: ${value}`,
-      ),
-      "---",
-      "",
+      '---',
+      ...Object.entries(defaultMetadata).map(([key, value]) => `${key}: ${value}`),
+      '---',
+      '',
       markdown,
     ];
 
-    return metadataLines.join("\n");
+    return metadataLines.join('\n');
   }
 
   async saveMarkdown(markdown, outputPath) {
@@ -87,7 +85,7 @@ class BaseConverter {
       await this.prepareOutputFile(outputPath);
 
       const cleanedMarkdown = this.cleanMarkdown(markdown);
-      await fs.writeFile(outputPath, cleanedMarkdown, "utf8");
+      await fs.writeFile(outputPath, cleanedMarkdown, 'utf8');
 
       const checksum = await generateFileChecksum(outputPath);
 
@@ -136,9 +134,7 @@ class BaseConverter {
         isSupported: this.supportedExtensions.includes(extension),
       };
     } catch (error) {
-      throw new Error(
-        `Failed to get file info for ${filePath}: ${error.message}`,
-      );
+      throw new Error(`Failed to get file info for ${filePath}: ${error.message}`);
     }
   }
 

--- a/backend/src/converters/converterFactory.js
+++ b/backend/src/converters/converterFactory.js
@@ -1,33 +1,35 @@
-import DocxToMarkdownConverter from './docxToMarkdownConverter.js'
-import PdfToMarkdownConverter from './pdfToMarkdownConverter.js'
+import DocxToMarkdownConverter from './docxToMarkdownConverter.js';
+import PdfToMarkdownConverter from './pdfToMarkdownConverter.js';
 
 class ConverterFactory {
   static getConverter(fileExtension) {
     if (!fileExtension) {
-      throw new Error('File extension is required')
+      throw new Error('File extension is required');
     }
 
-    const normalizedExt = fileExtension.toLowerCase()
+    const normalizedExt = fileExtension.toLowerCase();
 
     switch (normalizedExt) {
       case '.docx':
       case '.doc':
-        return new DocxToMarkdownConverter()
+        return new DocxToMarkdownConverter();
 
       case '.pdf':
-        return new PdfToMarkdownConverter()
+        return new PdfToMarkdownConverter();
 
       default:
-        throw new Error(`Unsupported file format: ${fileExtension}. Supported formats: .docx, .doc, .pdf`)
+        throw new Error(
+          `Unsupported file format: ${fileExtension}. Supported formats: .docx, .doc, .pdf`,
+        );
     }
   }
 
   static getSupportedExtensions() {
-    return ['.docx', '.doc', '.pdf']
+    return ['.docx', '.doc', '.pdf'];
   }
 
   static isExtensionSupported(fileExtension) {
-    return this.getSupportedExtensions().includes(fileExtension.toLowerCase())
+    return this.getSupportedExtensions().includes(fileExtension.toLowerCase());
   }
 
   static getConverterInfo() {
@@ -36,54 +38,54 @@ class ConverterFactory {
         name: 'DOCX to Markdown',
         description: 'Converts Microsoft Word documents to Markdown',
         library: 'mammoth.js',
-        features: ['Text extraction', 'Basic formatting', 'Images', 'Tables']
+        features: ['Text extraction', 'Basic formatting', 'Images', 'Tables'],
       },
       '.doc': {
         name: 'DOC to Markdown',
         description: 'Converts legacy Word documents to Markdown',
         library: 'mammoth.js',
         features: ['Text extraction', 'Basic formatting'],
-        note: 'Limited support compared to DOCX'
+        note: 'Limited support compared to DOCX',
       },
       '.pdf': {
         name: 'PDF to Markdown',
         description: 'Converts PDF documents to Markdown',
         library: 'pdf-parse',
         features: ['Text extraction', 'Page separation'],
-        limitations: ['No formatting preservation', 'Image extraction limited']
-      }
-    }
+        limitations: ['No formatting preservation', 'Image extraction limited'],
+      },
+    };
   }
 
   static getConverterFromFileName(fileName) {
     if (!fileName) {
-      throw new Error('File name is required')
+      throw new Error('File name is required');
     }
 
-    const extension = fileName.substring(fileName.lastIndexOf('.')).toLowerCase()
-    return this.getConverter(extension)
+    const extension = fileName.substring(fileName.lastIndexOf('.')).toLowerCase();
+    return this.getConverter(extension);
   }
 
   static validateFile(fileName) {
     if (!fileName) {
-      return { canConvert: false, reason: 'File name is required' }
+      return { canConvert: false, reason: 'File name is required' };
     }
 
-    const extension = fileName.substring(fileName.lastIndexOf('.')).toLowerCase()
+    const extension = fileName.substring(fileName.lastIndexOf('.')).toLowerCase();
 
     if (!extension) {
-      return { canConvert: false, reason: 'File has no extension' }
+      return { canConvert: false, reason: 'File has no extension' };
     }
 
     if (!this.isExtensionSupported(extension)) {
       return {
         canConvert: false,
-        reason: `Unsupported extension: ${extension}. Supported: ${this.getSupportedExtensions().join(', ')}`
-      }
+        reason: `Unsupported extension: ${extension}. Supported: ${this.getSupportedExtensions().join(', ')}`,
+      };
     }
 
-    return { canConvert: true }
+    return { canConvert: true };
   }
 }
 
-export { ConverterFactory }
+export { ConverterFactory };

--- a/backend/src/converters/docxToMarkdownConverter.js
+++ b/backend/src/converters/docxToMarkdownConverter.js
@@ -1,21 +1,21 @@
-import BaseConverter from "./baseConverter.js";
-import { createRequire } from "module";
-import path from "path";
+import BaseConverter from './baseConverter.js';
+import { createRequire } from 'module';
+import path from 'path';
 
 const require = createRequire(import.meta.url);
-const mammoth = require("mammoth");
+const mammoth = require('mammoth');
 
 class DocxToMarkdownConverter extends BaseConverter {
   constructor() {
     super();
-    this.name = "DOCX to Markdown Converter";
-    this.supportedExtensions = [".docx", ".doc"];
+    this.name = 'DOCX to Markdown Converter';
+    this.supportedExtensions = ['.docx', '.doc'];
   }
 
   async convert(inputPath, outputPath) {
     try {
-      this.log("convert", { inputPath, outputPath });
-      this.updateProgress(10, "Validating input file");
+      this.log('convert', { inputPath, outputPath });
+      this.updateProgress(10, 'Validating input file');
 
       await this.validateInputFile(inputPath);
 
@@ -24,7 +24,7 @@ class DocxToMarkdownConverter extends BaseConverter {
         throw new Error(`Unsupported file extension: ${fileInfo.extension}`);
       }
 
-      this.updateProgress(20, "Reading DOCX file");
+      this.updateProgress(20, 'Reading DOCX file');
 
       const options = {
         styleMap: [
@@ -43,7 +43,7 @@ class DocxToMarkdownConverter extends BaseConverter {
         ],
         convertImage: mammoth.images.imgElement(async (image) => {
           await image.read();
-          const imageName = `image_${Date.now()}.${image.contentType.split("/")[1] || "png"}`;
+          const imageName = `image_${Date.now()}.${image.contentType.split('/')[1] || 'png'}`;
 
           return {
             src: `./images/${imageName}`,
@@ -53,24 +53,21 @@ class DocxToMarkdownConverter extends BaseConverter {
         ignoreEmptyParagraphs: true,
       };
 
-      this.updateProgress(40, "Converting to Markdown");
+      this.updateProgress(40, 'Converting to Markdown');
 
-      const result = await mammoth.convertToMarkdown(
-        { path: inputPath },
-        options,
-      );
+      const result = await mammoth.convertToMarkdown({ path: inputPath }, options);
 
-      this.updateProgress(60, "Processing conversion result");
+      this.updateProgress(60, 'Processing conversion result');
 
       let markdown = result.value;
       markdown = this.enhanceMarkdown(markdown);
 
-      this.updateProgress(80, "Adding metadata and saving");
+      this.updateProgress(80, 'Adding metadata and saving');
 
       const metadata = {
         source_file: path.basename(inputPath),
         file_size: fileInfo.size,
-        converted_from: "DOCX",
+        converted_from: 'DOCX',
         conversion_warnings: result.messages.length,
       };
 
@@ -79,7 +76,7 @@ class DocxToMarkdownConverter extends BaseConverter {
       const checksum = await this.saveMarkdown(markdown, outputPath);
 
       if (result.messages.length > 0) {
-        this.log("conversion_warnings", {
+        this.log('conversion_warnings', {
           count: result.messages.length,
           messages: result.messages.map((m) => ({
             type: m.type,
@@ -88,7 +85,7 @@ class DocxToMarkdownConverter extends BaseConverter {
         });
       }
 
-      this.updateProgress(100, "Conversion completed");
+      this.updateProgress(100, 'Conversion completed');
 
       return {
         success: true,
@@ -102,29 +99,29 @@ class DocxToMarkdownConverter extends BaseConverter {
         },
       };
     } catch (error) {
-      return this.handleError(error, "DOCX conversion", inputPath);
+      return this.handleError(error, 'DOCX conversion', inputPath);
     }
   }
 
   enhanceMarkdown(markdown) {
-    if (!markdown) return "";
+    if (!markdown) return '';
 
     let enhanced = markdown;
 
-    enhanced = enhanced.replace(/^#{7,}/gm, "######");
-    enhanced = enhanced.replace(/^\* /gm, "- ");
-    enhanced = enhanced.replace(/^(#{1,6})\s+(.+)$/gm, "$1 $2");
-    enhanced = enhanced.replace(/\[([^\]]+)\]\(\s*([^)]+)\s*\)/g, "[$1]($2)");
+    enhanced = enhanced.replace(/^#{7,}/gm, '######');
+    enhanced = enhanced.replace(/^\* /gm, '- ');
+    enhanced = enhanced.replace(/^(#{1,6})\s+(.+)$/gm, '$1 $2');
+    enhanced = enhanced.replace(/\[([^\]]+)\]\(\s*([^)]+)\s*\)/g, '[$1]($2)');
     enhanced = this.fixTables(enhanced);
-    enhanced = enhanced.replace(/^>\s*/gm, "> ");
-    enhanced = enhanced.replace(/\n{4,}/g, "\n\n\n");
+    enhanced = enhanced.replace(/^>\s*/gm, '> ');
+    enhanced = enhanced.replace(/\n{4,}/g, '\n\n\n');
 
     return enhanced;
   }
 
   fixTables(markdown) {
     let fixed = markdown;
-    fixed = fixed.replace(/^([^|\n]*\|[^|\n]*\|[^|\n]*)$/gm, "|$1|");
+    fixed = fixed.replace(/^([^|\n]*\|[^|\n]*\|[^|\n]*)$/gm, '|$1|');
     return fixed;
   }
 
@@ -135,22 +132,19 @@ class DocxToMarkdownConverter extends BaseConverter {
 
     if (!this.supportedExtensions.includes(extension)) {
       throw new Error(
-        `Unsupported extension: ${extension}. Supported: ${this.supportedExtensions.join(", ")}`,
+        `Unsupported extension: ${extension}. Supported: ${this.supportedExtensions.join(', ')}`,
       );
     }
 
     // Check file magic bytes for valid Office document
-    const fs = require("fs");
+    const fs = require('fs');
     const buffer = Buffer.alloc(8);
-    const fd = fs.openSync(filePath, "r");
+    const fd = fs.openSync(filePath, 'r');
 
     try {
       fs.readSync(fd, buffer, 0, 8, 0);
 
-      if (
-        extension === ".docx" &&
-        !buffer.toString("ascii", 0, 2).includes("PK")
-      ) {
+      if (extension === '.docx' && !buffer.toString('ascii', 0, 2).includes('PK')) {
         console.warn(`Warning: ${filePath} may not be a valid DOCX file`);
       }
     } finally {

--- a/backend/src/converters/pdfToMarkdownConverter.js
+++ b/backend/src/converters/pdfToMarkdownConverter.js
@@ -1,21 +1,21 @@
-import BaseConverter from "./baseConverter.js";
-import { PDFParse } from "pdf-parse";
-import fs from "fs-extra";
-import path from "path";
+import BaseConverter from './baseConverter.js';
+import { PDFParse } from 'pdf-parse';
+import fs from 'fs-extra';
+import path from 'path';
 
 class PdfToMarkdownConverter extends BaseConverter {
   constructor() {
     super();
-    this.name = "PDF to Markdown Converter";
-    this.supportedExtensions = [".pdf"];
+    this.name = 'PDF to Markdown Converter';
+    this.supportedExtensions = ['.pdf'];
   }
 
   async convert(inputPath, outputPath) {
     let parser = null;
 
     try {
-      this.log("convert", { inputPath, outputPath });
-      this.updateProgress(10, "Validating input file");
+      this.log('convert', { inputPath, outputPath });
+      this.updateProgress(10, 'Validating input file');
 
       await this.validateInputFile(inputPath);
 
@@ -24,37 +24,31 @@ class PdfToMarkdownConverter extends BaseConverter {
         throw new Error(`Unsupported file extension: ${fileInfo.extension}`);
       }
 
-      this.updateProgress(20, "Reading PDF file");
+      this.updateProgress(20, 'Reading PDF file');
 
       const dataBuffer = await fs.readFile(inputPath);
 
-      this.updateProgress(40, "Parsing PDF content");
+      this.updateProgress(40, 'Parsing PDF content');
 
       parser = new PDFParse({ data: dataBuffer });
 
-      const [textResult, infoResult] = await Promise.all([
-        parser.getText(),
-        parser.getInfo(),
-      ]);
+      const [textResult, infoResult] = await Promise.all([parser.getText(), parser.getInfo()]);
 
-      this.updateProgress(60, "Converting to Markdown");
+      this.updateProgress(60, 'Converting to Markdown');
 
-      let markdown = this.convertTextToMarkdown(
-        textResult.text,
-        textResult.total,
-      );
+      let markdown = this.convertTextToMarkdown(textResult.text, textResult.total);
 
-      this.updateProgress(80, "Adding metadata and saving");
+      this.updateProgress(80, 'Adding metadata and saving');
 
       const metadata = {
         source_file: path.basename(inputPath),
         file_size: fileInfo.size,
-        converted_from: "PDF",
+        converted_from: 'PDF',
         pages: textResult.total,
         pdf_info: {
-          title: infoResult.info?.Title || "Unknown",
-          author: infoResult.info?.Author || "Unknown",
-          creator: infoResult.info?.Creator || "Unknown",
+          title: infoResult.info?.Title || 'Unknown',
+          author: infoResult.info?.Author || 'Unknown',
+          creator: infoResult.info?.Creator || 'Unknown',
           creation_date: infoResult.info?.CreationDate || null,
         },
       };
@@ -63,7 +57,7 @@ class PdfToMarkdownConverter extends BaseConverter {
 
       const checksum = await this.saveMarkdown(markdown, outputPath);
 
-      this.updateProgress(100, "Conversion completed");
+      this.updateProgress(100, 'Conversion completed');
 
       return {
         success: true,
@@ -77,7 +71,7 @@ class PdfToMarkdownConverter extends BaseConverter {
         },
       };
     } catch (error) {
-      return this.handleError(error, "PDF conversion", inputPath);
+      return this.handleError(error, 'PDF conversion', inputPath);
     } finally {
       if (parser) {
         await parser.destroy();
@@ -86,7 +80,7 @@ class PdfToMarkdownConverter extends BaseConverter {
   }
 
   convertTextToMarkdown(text, pageCount) {
-    if (!text) return "";
+    if (!text) return '';
 
     let markdown = text;
 
@@ -103,11 +97,11 @@ class PdfToMarkdownConverter extends BaseConverter {
     let cleaned = text;
 
     // eslint-disable-next-line no-control-regex
-    cleaned = cleaned.replace(/[\x00-\x08\x0B-\x0C\x0E-\x1F\x7F]/g, "");
-    cleaned = cleaned.replace(/\r\n/g, "\n");
-    cleaned = cleaned.replace(/\r/g, "\n");
-    cleaned = cleaned.replace(/[ \t]+$/gm, "");
-    cleaned = cleaned.replace(/([a-z])-\n([a-z])/g, "$1$2");
+    cleaned = cleaned.replace(/[\x00-\x08\x0B-\x0C\x0E-\x1F\x7F]/g, '');
+    cleaned = cleaned.replace(/\r\n/g, '\n');
+    cleaned = cleaned.replace(/\r/g, '\n');
+    cleaned = cleaned.replace(/[ \t]+$/gm, '');
+    cleaned = cleaned.replace(/([a-z])-\n([a-z])/g, '$1$2');
 
     return cleaned;
   }
@@ -115,13 +109,13 @@ class PdfToMarkdownConverter extends BaseConverter {
   detectHeaders(text) {
     let formatted = text;
 
-    const lines = formatted.split("\n");
+    const lines = formatted.split('\n');
     const processedLines = [];
 
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i].trim();
-      const nextLine = i + 1 < lines.length ? lines[i + 1].trim() : "";
-      const prevLine = i > 0 ? lines[i - 1].trim() : "";
+      const nextLine = i + 1 < lines.length ? lines[i + 1].trim() : '';
+      const prevLine = i > 0 ? lines[i - 1].trim() : '';
 
       let isHeader = false;
       let headerLevel = 1;
@@ -130,7 +124,7 @@ class PdfToMarkdownConverter extends BaseConverter {
         if (line.toUpperCase() === line && line.length > 5) {
           isHeader = true;
           headerLevel = 1;
-        } else if (nextLine === "" && prevLine === "" && line.length < 50) {
+        } else if (nextLine === '' && prevLine === '' && line.length < 50) {
           isHeader = true;
           headerLevel = 2;
         } else if (/^\d+\./.test(line)) {
@@ -143,22 +137,22 @@ class PdfToMarkdownConverter extends BaseConverter {
       }
 
       if (isHeader) {
-        processedLines.push("#".repeat(headerLevel) + " " + line);
+        processedLines.push('#'.repeat(headerLevel) + ' ' + line);
       } else {
         processedLines.push(line);
       }
     }
 
-    return processedLines.join("\n");
+    return processedLines.join('\n');
   }
 
   detectLists(text) {
     let formatted = text;
 
-    formatted = formatted.replace(/^[\s]*[•·‣▪▫‪‬]\s+(.+)$/gm, "- $1");
-    formatted = formatted.replace(/^[\s]*[*]\s+(.+)$/gm, "- $1");
-    formatted = formatted.replace(/^[\s]*[-]\s+(.+)$/gm, "- $1");
-    formatted = formatted.replace(/^[\s]*(\d+)[.)]\s+(.+)$/gm, "$1. $2");
+    formatted = formatted.replace(/^[\s]*[•·‣▪▫‪‬]\s+(.+)$/gm, '- $1');
+    formatted = formatted.replace(/^[\s]*[*]\s+(.+)$/gm, '- $1');
+    formatted = formatted.replace(/^[\s]*[-]\s+(.+)$/gm, '- $1');
+    formatted = formatted.replace(/^[\s]*(\d+)[.)]\s+(.+)$/gm, '$1. $2');
 
     return formatted;
   }
@@ -166,8 +160,8 @@ class PdfToMarkdownConverter extends BaseConverter {
   detectParagraphs(text) {
     let formatted = text;
 
-    formatted = formatted.replace(/\n([^\n\s-#*\d])/g, "\n\n$1");
-    formatted = formatted.replace(/\n{3,}/g, "\n\n");
+    formatted = formatted.replace(/\n([^\n\s-#*\d])/g, '\n\n$1');
+    formatted = formatted.replace(/\n{3,}/g, '\n\n');
 
     return formatted;
   }
@@ -176,8 +170,7 @@ class PdfToMarkdownConverter extends BaseConverter {
     if (pageCount <= 1) return text;
 
     let enhanced = text;
-    enhanced =
-      `> Extracted from a ${pageCount}-page PDF document\n\n` + enhanced;
+    enhanced = `> Extracted from a ${pageCount}-page PDF document\n\n` + enhanced;
 
     return enhanced;
   }
@@ -187,19 +180,19 @@ class PdfToMarkdownConverter extends BaseConverter {
 
     const extension = path.extname(filePath).toLowerCase();
 
-    if (extension !== ".pdf") {
+    if (extension !== '.pdf') {
       throw new Error(`Expected PDF file, got: ${extension}`);
     }
 
     try {
       const buffer = await fs.readFile(filePath, { encoding: null });
-      const header = buffer.subarray(0, 4).toString("ascii");
+      const header = buffer.subarray(0, 4).toString('ascii');
 
-      if (!header.includes("%PDF")) {
+      if (!header.includes('%PDF')) {
         throw new Error(`File does not appear to be a valid PDF: ${filePath}`);
       }
     } catch (error) {
-      if (error.code === "ENOENT") {
+      if (error.code === 'ENOENT') {
         throw new Error(`PDF file not found: ${filePath}`);
       }
       throw error;
@@ -222,7 +215,7 @@ class PdfToMarkdownConverter extends BaseConverter {
         textLength: 0,
       };
     } catch (error) {
-      this.log("metadata_extraction_failed", { error: error.message });
+      this.log('metadata_extraction_failed', { error: error.message });
       return {
         pages: 0,
         info: {},

--- a/backend/src/integrations/base/driveConnector.js
+++ b/backend/src/integrations/base/driveConnector.js
@@ -3,10 +3,10 @@
  * Controllers should catch this to return 401 instead of 500.
  */
 export class TokenExpiredError extends Error {
-  constructor(message = "Refresh token expired or revoked") {
+  constructor(message = 'Refresh token expired or revoked') {
     super(message);
-    this.name = "TokenExpiredError";
-    this.code = "TOKEN_EXPIRED";
+    this.name = 'TokenExpiredError';
+    this.code = 'TOKEN_EXPIRED';
   }
 }
 
@@ -17,23 +17,23 @@ class DriveConnector {
   }
 
   async authenticate() {
-    throw new Error("authenticate() method must be implemented by subclass");
+    throw new Error('authenticate() method must be implemented by subclass');
   }
 
   async testConnection() {
-    throw new Error("testConnection() method must be implemented by subclass");
+    throw new Error('testConnection() method must be implemented by subclass');
   }
 
-  async listFiles(_path = "/") {
-    throw new Error("listFiles() method must be implemented by subclass");
+  async listFiles(_path = '/') {
+    throw new Error('listFiles() method must be implemented by subclass');
   }
 
   async downloadFile(_fileId, _destinationPath) {
-    throw new Error("downloadFile() method must be implemented by subclass");
+    throw new Error('downloadFile() method must be implemented by subclass');
   }
 
   async watchForChanges(_path, _callback) {
-    throw new Error("watchForChanges() method must be implemented by subclass");
+    throw new Error('watchForChanges() method must be implemented by subclass');
   }
 
   async cleanup() {
@@ -42,11 +42,11 @@ class DriveConnector {
 
   validateConfig() {
     if (!this.config) {
-      throw new Error("Configuration is required");
+      throw new Error('Configuration is required');
     }
 
     if (!this.config.credentials) {
-      throw new Error("Credentials are required");
+      throw new Error('Credentials are required');
     }
 
     return true;
@@ -55,15 +55,13 @@ class DriveConnector {
   normalizeFileInfo(rawFile) {
     return {
       id: rawFile.id,
-      name: rawFile.name || "Unknown",
+      name: rawFile.name || 'Unknown',
       path: rawFile.path || rawFile.name,
       size: rawFile.size || 0,
-      modifiedTime: rawFile.modifiedTime
-        ? new Date(rawFile.modifiedTime)
-        : new Date(),
+      modifiedTime: rawFile.modifiedTime ? new Date(rawFile.modifiedTime) : new Date(),
       checksum: rawFile.checksum || rawFile.md5Checksum || null,
       mimeType: rawFile.mimeType || null,
-      platform: this.constructor.name.replace("Connector", "").toLowerCase(),
+      platform: this.constructor.name.replace('Connector', '').toLowerCase(),
     };
   }
 
@@ -72,12 +70,9 @@ class DriveConnector {
 
     // Detect expired/revoked OAuth tokens
     const responseData = error.response?.data;
-    if (
-      responseData?.error === "invalid_grant" ||
-      error.response?.status === 401
-    ) {
+    if (responseData?.error === 'invalid_grant' || error.response?.status === 401) {
       throw new TokenExpiredError(
-        `${operation} failed: ${responseData?.error_description || "Refresh token expired or revoked"}`,
+        `${operation} failed: ${responseData?.error_description || 'Refresh token expired or revoked'}`,
       );
     }
 

--- a/backend/src/integrations/base/driveConnectorFactory.js
+++ b/backend/src/integrations/base/driveConnectorFactory.js
@@ -1,48 +1,50 @@
-import SharePointConnector from '../sharepoint/sharepointConnector.js'
-import GoogleDriveConnector from '../googledrive/googledriveConnector.js'
+import SharePointConnector from '../sharepoint/sharepointConnector.js';
+import GoogleDriveConnector from '../googledrive/googledriveConnector.js';
 
 class DriveConnectorFactory {
   static createConnector(platform, config) {
     if (!platform) {
-      throw new Error('Platform is required')
+      throw new Error('Platform is required');
     }
 
     if (!config) {
-      throw new Error('Config is required')
+      throw new Error('Config is required');
     }
 
-    const normalizedPlatform = platform.toLowerCase()
+    const normalizedPlatform = platform.toLowerCase();
 
     switch (normalizedPlatform) {
       case 'sharepoint':
-        return new SharePointConnector(config)
-      
+        return new SharePointConnector(config);
+
       case 'googledrive':
       case 'google-drive':
-        return new GoogleDriveConnector(config)
-      
+        return new GoogleDriveConnector(config);
+
       case 'onedrive':
         // OneDrive uses the same Microsoft Graph API as SharePoint
         return new SharePointConnector({
           ...config,
-          isOneDrive: true
-        })
-      
+          isOneDrive: true,
+        });
+
       default:
-        throw new Error(`Unsupported platform: ${platform}. Supported platforms: sharepoint, googledrive, onedrive`)
+        throw new Error(
+          `Unsupported platform: ${platform}. Supported platforms: sharepoint, googledrive, onedrive`,
+        );
     }
   }
 
   static getSupportedPlatforms() {
-    return ['sharepoint', 'googledrive', 'onedrive']
+    return ['sharepoint', 'googledrive', 'onedrive'];
   }
 
   static isPlatformSupported(platform) {
-    return this.getSupportedPlatforms().includes(platform.toLowerCase())
+    return this.getSupportedPlatforms().includes(platform.toLowerCase());
   }
 
   static getConfigSchema(platform) {
-    const normalizedPlatform = platform.toLowerCase()
+    const normalizedPlatform = platform.toLowerCase();
 
     switch (normalizedPlatform) {
       case 'sharepoint':
@@ -50,77 +52,123 @@ class DriveConnectorFactory {
         return {
           credentials: {
             clientId: { required: true, type: 'string', description: 'Microsoft App Client ID' },
-            clientSecret: { required: true, type: 'string', description: 'Microsoft App Client Secret' },
-            tenantId: { required: true, type: 'string', description: 'Microsoft Tenant ID' }
+            clientSecret: {
+              required: true,
+              type: 'string',
+              description: 'Microsoft App Client Secret',
+            },
+            tenantId: { required: true, type: 'string', description: 'Microsoft Tenant ID' },
           },
-          sourcePath: { required: false, type: 'string', default: '/', description: 'Path to monitor' },
+          sourcePath: {
+            required: false,
+            type: 'string',
+            default: '/',
+            description: 'Path to monitor',
+          },
           siteUrl: { required: true, type: 'string', description: 'SharePoint site URL' },
-          destinations: { required: false, type: 'array', default: [], description: 'Local destination paths' },
+          destinations: {
+            required: false,
+            type: 'array',
+            default: [],
+            description: 'Local destination paths',
+          },
           filters: {
-            extensions: { required: false, type: 'array', default: ['.docx', '.pdf'], description: 'File extensions to process' },
-            excludePatterns: { required: false, type: 'array', default: [], description: 'Regex patterns to exclude' }
-          }
-        }
+            extensions: {
+              required: false,
+              type: 'array',
+              default: ['.docx', '.pdf'],
+              description: 'File extensions to process',
+            },
+            excludePatterns: {
+              required: false,
+              type: 'array',
+              default: [],
+              description: 'Regex patterns to exclude',
+            },
+          },
+        };
 
       case 'googledrive':
         return {
           credentials: {
             clientId: { required: true, type: 'string', description: 'Google Client ID' },
             clientSecret: { required: true, type: 'string', description: 'Google Client Secret' },
-            refreshToken: { required: true, type: 'string', description: 'Google Refresh Token' }
+            refreshToken: { required: true, type: 'string', description: 'Google Refresh Token' },
           },
-          sourcePath: { required: false, type: 'string', default: 'root', description: 'Folder ID to monitor' },
-          destinations: { required: false, type: 'array', default: [], description: 'Local destination paths' },
+          sourcePath: {
+            required: false,
+            type: 'string',
+            default: 'root',
+            description: 'Folder ID to monitor',
+          },
+          destinations: {
+            required: false,
+            type: 'array',
+            default: [],
+            description: 'Local destination paths',
+          },
           filters: {
-            extensions: { required: false, type: 'array', default: ['.docx', '.pdf'], description: 'File extensions to process' },
-            excludePatterns: { required: false, type: 'array', default: [], description: 'Regex patterns to exclude' }
-          }
-        }
+            extensions: {
+              required: false,
+              type: 'array',
+              default: ['.docx', '.pdf'],
+              description: 'File extensions to process',
+            },
+            excludePatterns: {
+              required: false,
+              type: 'array',
+              default: [],
+              description: 'Regex patterns to exclude',
+            },
+          },
+        };
 
       default:
-        throw new Error(`Unknown platform: ${platform}`)
+        throw new Error(`Unknown platform: ${platform}`);
     }
   }
 
   static validateConfig(platform, config) {
     try {
-      const schema = this.getConfigSchema(platform)
-      const errors = []
+      const schema = this.getConfigSchema(platform);
+      const errors = [];
 
       function validateObject(obj, schemaObj, path = '') {
         for (const [key, schemaValue] of Object.entries(schemaObj)) {
-          const currentPath = path ? `${path}.${key}` : key
-          
+          const currentPath = path ? `${path}.${key}` : key;
+
           if (typeof schemaValue === 'object' && schemaValue.required !== undefined) {
             if (schemaValue.required && !obj[key]) {
-              errors.push(`Missing required field: ${currentPath}`)
+              errors.push(`Missing required field: ${currentPath}`);
             } else if (obj[key] && schemaValue.type) {
-              const actualType = Array.isArray(obj[key]) ? 'array' : typeof obj[key]
+              const actualType = Array.isArray(obj[key]) ? 'array' : typeof obj[key];
               if (actualType !== schemaValue.type) {
-                errors.push(`Invalid type for ${currentPath}: expected ${schemaValue.type}, got ${actualType}`)
+                errors.push(
+                  `Invalid type for ${currentPath}: expected ${schemaValue.type}, got ${actualType}`,
+                );
               }
             }
           } else if (typeof schemaValue === 'object') {
             if (obj[key]) {
-              validateObject(obj[key], schemaValue, currentPath)
+              validateObject(obj[key], schemaValue, currentPath);
             }
           }
         }
       }
 
-      validateObject(config, schema)
+      validateObject(config, schema);
 
       return {
         valid: errors.length === 0,
-        errors
-      }
+        errors,
+      };
     } catch (error) {
       return {
         valid: false,
-        errors: [`Validation error: ${error.message}`]
-      }
+        errors: [`Validation error: ${error.message}`],
+      };
     }
   }
 }
 
-export { DriveConnectorFactory }
+export { DriveConnectorFactory };

--- a/backend/src/integrations/googledrive/googledriveConnector.js
+++ b/backend/src/integrations/googledrive/googledriveConnector.js
@@ -1,14 +1,14 @@
-import DriveConnector from "../base/driveConnector.js";
-import axios from "axios";
-import fs from "fs-extra";
-import path from "path";
+import DriveConnector from '../base/driveConnector.js';
+import axios from 'axios';
+import fs from 'fs-extra';
+import path from 'path';
 
 class GoogleDriveConnector extends DriveConnector {
   constructor(config) {
     super(config);
     this.accessToken = null;
     this.tokenExpiry = null;
-    this.baseUrl = "https://www.googleapis.com/drive/v3";
+    this.baseUrl = 'https://www.googleapis.com/drive/v3';
   }
 
   async authenticate() {
@@ -17,20 +17,20 @@ class GoogleDriveConnector extends DriveConnector {
 
       const { clientId, clientSecret, refreshToken } = this.config.credentials;
 
-      const tokenUrl = "https://oauth2.googleapis.com/token";
+      const tokenUrl = 'https://oauth2.googleapis.com/token';
 
       const params = {
         client_id: clientId,
         client_secret: clientSecret,
         refresh_token: refreshToken,
-        grant_type: "refresh_token",
+        grant_type: 'refresh_token',
       };
 
-      this.log("authenticate", { clientId: clientId.substring(0, 12) + "..." });
+      this.log('authenticate', { clientId: clientId.substring(0, 12) + '...' });
 
       const response = await axios.post(tokenUrl, params, {
         headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
+          'Content-Type': 'application/x-www-form-urlencoded',
         },
       });
 
@@ -38,13 +38,13 @@ class GoogleDriveConnector extends DriveConnector {
       this.tokenExpiry = Date.now() + response.data.expires_in * 1000;
       this.isAuthenticated = true;
 
-      this.log("authenticate", {
+      this.log('authenticate', {
         success: true,
         tokenExpiry: new Date(this.tokenExpiry),
       });
       return true;
     } catch (error) {
-      this.handleApiError(error, "authenticate");
+      this.handleApiError(error, 'authenticate');
     }
   }
 
@@ -53,16 +53,16 @@ class GoogleDriveConnector extends DriveConnector {
       await this.authenticate();
 
       const response = await this.makeAuthenticatedRequest(
-        "https://www.googleapis.com/drive/v3/about?fields=user,storageQuota",
+        'https://www.googleapis.com/drive/v3/about?fields=user,storageQuota',
       );
 
       const userInfo = response.data;
 
       return {
         success: true,
-        message: "Connection successful",
+        message: 'Connection successful',
         details: {
-          platform: "Google Drive",
+          platform: 'Google Drive',
           user: userInfo.user?.emailAddress,
           storageUsed: userInfo.storageQuota?.usage,
           authenticated: this.isAuthenticated,
@@ -73,29 +73,25 @@ class GoogleDriveConnector extends DriveConnector {
         success: false,
         message: error.message,
         details: {
-          error:
-            error.originalError?.response?.data || error.originalError?.message,
+          error: error.originalError?.response?.data || error.originalError?.message,
         },
       };
     }
   }
 
-  async listFolders(folderId = "root") {
+  async listFolders(folderId = 'root') {
     try {
       await this.ensureAuthenticated();
 
       const params = {
         q: `'${folderId}' in parents and trashed=false and mimeType='application/vnd.google-apps.folder'`,
-        fields: "files(id,name,modifiedTime,parents)",
-        orderBy: "name",
+        fields: 'files(id,name,modifiedTime,parents)',
+        orderBy: 'name',
       };
 
-      this.log("listFolders", { folderId });
+      this.log('listFolders', { folderId });
 
-      const response = await this.makeAuthenticatedRequest(
-        `${this.baseUrl}/files`,
-        { params },
-      );
+      const response = await this.makeAuthenticatedRequest(`${this.baseUrl}/files`, { params });
 
       const folders = response.data.files || [];
 
@@ -105,34 +101,30 @@ class GoogleDriveConnector extends DriveConnector {
         path: `/${folder.name}`,
         modifiedTime: folder.modifiedTime,
         parents: folder.parents,
-        type: "folder",
+        type: 'folder',
       }));
     } catch (error) {
-      this.handleApiError(error, "listFolders");
+      this.handleApiError(error, 'listFolders');
     }
   }
 
-  async listFiles(folderId = "root", limit = null) {
+  async listFiles(folderId = 'root', limit = null) {
     try {
       await this.ensureAuthenticated();
 
       const params = {
         q: `'${folderId}' in parents and trashed=false and mimeType!='application/vnd.google-apps.folder'`,
-        fields:
-          "files(id,name,size,modifiedTime,mimeType,webViewLink,md5Checksum,parents)",
-        orderBy: "modifiedTime desc",
+        fields: 'files(id,name,size,modifiedTime,mimeType,webViewLink,md5Checksum,parents)',
+        orderBy: 'modifiedTime desc',
       };
 
       if (limit) {
         params.pageSize = limit;
       }
 
-      this.log("listFiles", { folderId, limit });
+      this.log('listFiles', { folderId, limit });
 
-      const response = await this.makeAuthenticatedRequest(
-        `${this.baseUrl}/files`,
-        { params },
-      );
+      const response = await this.makeAuthenticatedRequest(`${this.baseUrl}/files`, { params });
 
       const files = response.data.files || [];
 
@@ -150,7 +142,7 @@ class GoogleDriveConnector extends DriveConnector {
         }),
       );
     } catch (error) {
-      this.handleApiError(error, "listFiles");
+      this.handleApiError(error, 'listFiles');
     }
   }
 
@@ -160,22 +152,18 @@ class GoogleDriveConnector extends DriveConnector {
 
       const params = {
         q: `name contains '${query}' and trashed=false`,
-        fields:
-          "files(id,name,size,modifiedTime,mimeType,webViewLink,md5Checksum)",
+        fields: 'files(id,name,size,modifiedTime,mimeType,webViewLink,md5Checksum)',
         pageSize: limit,
       };
 
-      this.log("searchFiles", { query, limit });
+      this.log('searchFiles', { query, limit });
 
-      const response = await this.makeAuthenticatedRequest(
-        `${this.baseUrl}/files`,
-        { params },
-      );
+      const response = await this.makeAuthenticatedRequest(`${this.baseUrl}/files`, { params });
 
       const files = response.data.files || [];
       return files.map((file) => this.normalizeFileInfo(file));
     } catch (error) {
-      this.handleApiError(error, "searchFiles");
+      this.handleApiError(error, 'searchFiles');
     }
   }
 
@@ -183,7 +171,7 @@ class GoogleDriveConnector extends DriveConnector {
     try {
       await this.ensureAuthenticated();
 
-      this.log("downloadFile", { fileId, destinationDir });
+      this.log('downloadFile', { fileId, destinationDir });
 
       const fileInfoResponse = await this.makeAuthenticatedRequest(
         `${this.baseUrl}/files/${fileId}?fields=name,size,mimeType`,
@@ -197,38 +185,33 @@ class GoogleDriveConnector extends DriveConnector {
       let fileName = fileInfo.name;
 
       // Handle Google Docs native formats (export required)
-      if (fileInfo.mimeType.startsWith("application/vnd.google-apps.")) {
+      if (fileInfo.mimeType.startsWith('application/vnd.google-apps.')) {
         const conversionMap = {
-          "application/vnd.google-apps.document": {
-            mimeType:
-              "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-            extension: ".docx",
+          'application/vnd.google-apps.document': {
+            mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            extension: '.docx',
           },
-          "application/vnd.google-apps.spreadsheet": {
-            mimeType:
-              "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-            extension: ".xlsx",
+          'application/vnd.google-apps.spreadsheet': {
+            mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            extension: '.xlsx',
           },
-          "application/vnd.google-apps.presentation": {
-            mimeType:
-              "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-            extension: ".pptx",
+          'application/vnd.google-apps.presentation': {
+            mimeType: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+            extension: '.pptx',
           },
         };
 
         const conversion = conversionMap[fileInfo.mimeType];
         if (conversion) {
           downloadUrl = `${this.baseUrl}/files/${fileId}/export?mimeType=${encodeURIComponent(conversion.mimeType)}`;
-          fileName = fileName.replace(/\.[^/.]+$/, "") + conversion.extension;
+          fileName = fileName.replace(/\.[^/.]+$/, '') + conversion.extension;
         } else {
-          throw new Error(
-            `Unsupported Google Apps format: ${fileInfo.mimeType}`,
-          );
+          throw new Error(`Unsupported Google Apps format: ${fileInfo.mimeType}`);
         }
       }
 
       const response = await this.makeAuthenticatedRequest(downloadUrl, {
-        responseType: "stream",
+        responseType: 'stream',
       });
 
       const filePath = path.join(destinationDir, fileName);
@@ -237,24 +220,24 @@ class GoogleDriveConnector extends DriveConnector {
       response.data.pipe(writer);
 
       return new Promise((resolve, reject) => {
-        writer.on("finish", () => {
-          this.log("downloadFile", {
+        writer.on('finish', () => {
+          this.log('downloadFile', {
             completed: filePath,
             originalSize: fileInfo.size,
           });
           resolve(filePath);
         });
-        writer.on("error", reject);
+        writer.on('error', reject);
       });
     } catch (error) {
-      this.handleApiError(error, "downloadFile");
+      this.handleApiError(error, 'downloadFile');
     }
   }
 
   async watchForChanges(folderId, callback) {
-    this.log("watchForChanges", {
+    this.log('watchForChanges', {
       folderId,
-      note: "Using polling approach - push notifications require webhook setup",
+      note: 'Using polling approach - push notifications require webhook setup',
     });
 
     let pageToken = null;
@@ -263,7 +246,7 @@ class GoogleDriveConnector extends DriveConnector {
       try {
         const params = {
           fields:
-            "nextPageToken,newStartPageToken,changes(fileId,file(id,name,parents,modifiedTime,trashed))",
+            'nextPageToken,newStartPageToken,changes(fileId,file(id,name,parents,modifiedTime,trashed))',
           includeRemoved: false,
         };
 
@@ -271,35 +254,24 @@ class GoogleDriveConnector extends DriveConnector {
           params.pageToken = pageToken;
         }
 
-        const response = await this.makeAuthenticatedRequest(
-          `${this.baseUrl}/changes`,
-          { params },
-        );
+        const response = await this.makeAuthenticatedRequest(`${this.baseUrl}/changes`, { params });
 
         const changes = response.data.changes || [];
 
         const relevantChanges = changes.filter((change) => {
           const file = change.file;
-          return (
-            file &&
-            file.parents &&
-            file.parents.includes(folderId) &&
-            !file.trashed
-          );
+          return file && file.parents && file.parents.includes(folderId) && !file.trashed;
         });
 
         if (relevantChanges.length > 0) {
-          this.log("watchForChanges", { changes: relevantChanges.length });
-          const changedFiles = relevantChanges.map((change) =>
-            this.normalizeFileInfo(change.file),
-          );
+          this.log('watchForChanges', { changes: relevantChanges.length });
+          const changedFiles = relevantChanges.map((change) => this.normalizeFileInfo(change.file));
           callback(changedFiles);
         }
 
-        pageToken =
-          response.data.nextPageToken || response.data.newStartPageToken;
+        pageToken = response.data.nextPageToken || response.data.newStartPageToken;
       } catch (error) {
-        console.error("Error in watchForChanges polling:", error);
+        console.error('Error in watchForChanges polling:', error);
       }
     };
 
@@ -309,7 +281,7 @@ class GoogleDriveConnector extends DriveConnector {
 
     return () => {
       clearInterval(pollInterval);
-      this.log("watchForChanges", { status: "stopped" });
+      this.log('watchForChanges', { status: 'stopped' });
     };
   }
 
@@ -338,9 +310,7 @@ class GoogleDriveConnector extends DriveConnector {
     const { clientId, clientSecret, refreshToken } = this.config.credentials;
 
     if (!clientId || !clientSecret || !refreshToken) {
-      throw new Error(
-        "Google Drive requires clientId, clientSecret, and refreshToken",
-      );
+      throw new Error('Google Drive requires clientId, clientSecret, and refreshToken');
     }
 
     return true;
@@ -350,7 +320,7 @@ class GoogleDriveConnector extends DriveConnector {
     this.accessToken = null;
     this.tokenExpiry = null;
     this.isAuthenticated = false;
-    this.log("cleanup", { status: "completed" });
+    this.log('cleanup', { status: 'completed' });
   }
 }
 

--- a/backend/src/integrations/sharepoint/sharepointConnector.js
+++ b/backend/src/integrations/sharepoint/sharepointConnector.js
@@ -1,79 +1,77 @@
-import DriveConnector from '../base/driveConnector.js'
-import axios from 'axios'
-import fs from 'fs-extra'
-import path from 'path'
+import DriveConnector from '../base/driveConnector.js';
+import axios from 'axios';
+import fs from 'fs-extra';
+import path from 'path';
 
 class SharePointConnector extends DriveConnector {
   constructor(config) {
-    super(config)
-    this.accessToken = null
-    this.tokenExpiry = null
-    this.isOneDrive = config.isOneDrive || false
-    this.baseUrl = 'https://graph.microsoft.com/v1.0'
-    this.siteId = null
+    super(config);
+    this.accessToken = null;
+    this.tokenExpiry = null;
+    this.isOneDrive = config.isOneDrive || false;
+    this.baseUrl = 'https://graph.microsoft.com/v1.0';
+    this.siteId = null;
   }
 
   async authenticate() {
     try {
-      this.validateConfig()
+      this.validateConfig();
 
-      const { clientId, clientSecret, tenantId } = this.config.credentials
+      const { clientId, clientSecret, tenantId } = this.config.credentials;
 
-      const tokenUrl = `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`
+      const tokenUrl = `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`;
 
-      const params = new URLSearchParams()
-      params.append('client_id', clientId)
-      params.append('client_secret', clientSecret)
-      params.append('scope', 'https://graph.microsoft.com/.default')
-      params.append('grant_type', 'client_credentials')
+      const params = new URLSearchParams();
+      params.append('client_id', clientId);
+      params.append('client_secret', clientSecret);
+      params.append('scope', 'https://graph.microsoft.com/.default');
+      params.append('grant_type', 'client_credentials');
 
-      this.log('authenticate', { tenantId, clientId: clientId.substring(0, 8) + '...' })
+      this.log('authenticate', { tenantId, clientId: clientId.substring(0, 8) + '...' });
 
       const response = await axios.post(tokenUrl, params, {
         headers: {
-          'Content-Type': 'application/x-www-form-urlencoded'
-        }
-      })
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+      });
 
-      this.accessToken = response.data.access_token
-      this.tokenExpiry = Date.now() + (response.data.expires_in * 1000)
-      this.isAuthenticated = true
+      this.accessToken = response.data.access_token;
+      this.tokenExpiry = Date.now() + response.data.expires_in * 1000;
+      this.isAuthenticated = true;
 
       if (!this.isOneDrive && this.config.siteUrl) {
-        await this.getSiteId()
+        await this.getSiteId();
       }
 
-      this.log('authenticate', { success: true, tokenExpiry: new Date(this.tokenExpiry) })
-      return true
-
+      this.log('authenticate', { success: true, tokenExpiry: new Date(this.tokenExpiry) });
+      return true;
     } catch (error) {
-      this.handleApiError(error, 'authenticate')
+      this.handleApiError(error, 'authenticate');
     }
   }
 
   async getSiteId() {
     try {
-      const siteUrl = new URL(this.config.siteUrl)
-      const hostname = siteUrl.hostname
-      const sitePath = siteUrl.pathname
+      const siteUrl = new URL(this.config.siteUrl);
+      const hostname = siteUrl.hostname;
+      const sitePath = siteUrl.pathname;
 
       const response = await this.makeAuthenticatedRequest(
-        `${this.baseUrl}/sites/${hostname}:${sitePath}`
-      )
+        `${this.baseUrl}/sites/${hostname}:${sitePath}`,
+      );
 
-      this.siteId = response.data.id
-      this.log('getSiteId', { siteId: this.siteId })
-
+      this.siteId = response.data.id;
+      this.log('getSiteId', { siteId: this.siteId });
     } catch (error) {
-      this.handleApiError(error, 'getSiteId')
+      this.handleApiError(error, 'getSiteId');
     }
   }
 
   async testConnection() {
     try {
-      await this.authenticate()
+      await this.authenticate();
 
-      const files = await this.listFiles('/', 1)
+      const files = await this.listFiles('/', 1);
 
       return {
         success: true,
@@ -81,187 +79,185 @@ class SharePointConnector extends DriveConnector {
         details: {
           platform: this.isOneDrive ? 'OneDrive' : 'SharePoint',
           filesFound: files.length,
-          authenticated: this.isAuthenticated
-        }
-      }
-
+          authenticated: this.isAuthenticated,
+        },
+      };
     } catch (error) {
       return {
         success: false,
         message: error.message,
         details: {
-          error: error.originalError?.response?.data || error.originalError?.message
-        }
-      }
+          error: error.originalError?.response?.data || error.originalError?.message,
+        },
+      };
     }
   }
 
   async listFiles(folderPath = '/', limit = null) {
     try {
-      await this.ensureAuthenticated()
+      await this.ensureAuthenticated();
 
-      let endpoint
+      let endpoint;
       if (this.isOneDrive) {
-        endpoint = folderPath === '/'
-          ? `${this.baseUrl}/me/drive/root/children`
-          : `${this.baseUrl}/me/drive/root:${folderPath}:/children`
+        endpoint =
+          folderPath === '/'
+            ? `${this.baseUrl}/me/drive/root/children`
+            : `${this.baseUrl}/me/drive/root:${folderPath}:/children`;
       } else {
-        endpoint = folderPath === '/'
-          ? `${this.baseUrl}/sites/${this.siteId}/drive/root/children`
-          : `${this.baseUrl}/sites/${this.siteId}/drive/root:${folderPath}:/children`
+        endpoint =
+          folderPath === '/'
+            ? `${this.baseUrl}/sites/${this.siteId}/drive/root/children`
+            : `${this.baseUrl}/sites/${this.siteId}/drive/root:${folderPath}:/children`;
       }
 
       const params = {
-        '$select': 'id,name,size,lastModifiedDateTime,file,webUrl,@microsoft.graph.downloadUrl',
-        '$filter': 'file ne null'
-      }
+        $select: 'id,name,size,lastModifiedDateTime,file,webUrl,@microsoft.graph.downloadUrl',
+        $filter: 'file ne null',
+      };
 
       if (limit) {
-        params['$top'] = limit
+        params['$top'] = limit;
       }
 
-      this.log('listFiles', { folderPath, limit, endpoint })
+      this.log('listFiles', { folderPath, limit, endpoint });
 
-      const response = await this.makeAuthenticatedRequest(endpoint, { params })
-      const files = response.data.value || []
+      const response = await this.makeAuthenticatedRequest(endpoint, { params });
+      const files = response.data.value || [];
 
-      return files.map(file => this.normalizeFileInfo({
-        id: file.id,
-        name: file.name,
-        path: `${folderPath}/${file.name}`.replace('//', '/'),
-        size: file.size,
-        modifiedTime: file.lastModifiedDateTime,
-        downloadUrl: file['@microsoft.graph.downloadUrl'],
-        webUrl: file.webUrl
-      }))
-
+      return files.map((file) =>
+        this.normalizeFileInfo({
+          id: file.id,
+          name: file.name,
+          path: `${folderPath}/${file.name}`.replace('//', '/'),
+          size: file.size,
+          modifiedTime: file.lastModifiedDateTime,
+          downloadUrl: file['@microsoft.graph.downloadUrl'],
+          webUrl: file.webUrl,
+        }),
+      );
     } catch (error) {
-      this.handleApiError(error, 'listFiles')
+      this.handleApiError(error, 'listFiles');
     }
   }
 
   async downloadFile(fileId, destinationDir) {
     try {
-      await this.ensureAuthenticated()
+      await this.ensureAuthenticated();
 
-      let endpoint
+      let endpoint;
       if (this.isOneDrive) {
-        endpoint = `${this.baseUrl}/me/drive/items/${fileId}`
+        endpoint = `${this.baseUrl}/me/drive/items/${fileId}`;
       } else {
-        endpoint = `${this.baseUrl}/sites/${this.siteId}/drive/items/${fileId}`
+        endpoint = `${this.baseUrl}/sites/${this.siteId}/drive/items/${fileId}`;
       }
 
-      this.log('downloadFile', { fileId, destinationDir })
+      this.log('downloadFile', { fileId, destinationDir });
 
-      const fileInfoResponse = await this.makeAuthenticatedRequest(endpoint)
-      const fileInfo = fileInfoResponse.data
-      const downloadUrl = fileInfo['@microsoft.graph.downloadUrl']
+      const fileInfoResponse = await this.makeAuthenticatedRequest(endpoint);
+      const fileInfo = fileInfoResponse.data;
+      const downloadUrl = fileInfo['@microsoft.graph.downloadUrl'];
 
       if (!downloadUrl) {
-        throw new Error('No download URL available for this file')
+        throw new Error('No download URL available for this file');
       }
 
-      await fs.ensureDir(destinationDir)
+      await fs.ensureDir(destinationDir);
 
       const response = await axios.get(downloadUrl, {
-        responseType: 'stream'
-      })
+        responseType: 'stream',
+      });
 
-      const fileName = fileInfo.name
-      const filePath = path.join(destinationDir, fileName)
-      const writer = fs.createWriteStream(filePath)
+      const fileName = fileInfo.name;
+      const filePath = path.join(destinationDir, fileName);
+      const writer = fs.createWriteStream(filePath);
 
-      response.data.pipe(writer)
+      response.data.pipe(writer);
 
       return new Promise((resolve, reject) => {
         writer.on('finish', () => {
-          this.log('downloadFile', { completed: filePath, size: fileInfo.size })
-          resolve(filePath)
-        })
-        writer.on('error', reject)
-      })
-
+          this.log('downloadFile', { completed: filePath, size: fileInfo.size });
+          resolve(filePath);
+        });
+        writer.on('error', reject);
+      });
     } catch (error) {
-      this.handleApiError(error, 'downloadFile')
+      this.handleApiError(error, 'downloadFile');
     }
   }
 
   async watchForChanges(folderPath, callback) {
     this.log('watchForChanges', {
       folderPath,
-      note: 'Using polling approach - webhooks require additional setup'
-    })
+      note: 'Using polling approach - webhooks require additional setup',
+    });
 
-    let lastCheck = new Date()
+    let lastCheck = new Date();
 
     const pollInterval = setInterval(async () => {
       try {
-        const files = await this.listFiles(folderPath)
+        const files = await this.listFiles(folderPath);
 
-        const changedFiles = files.filter(file =>
-          new Date(file.modifiedTime) > lastCheck
-        )
+        const changedFiles = files.filter((file) => new Date(file.modifiedTime) > lastCheck);
 
         if (changedFiles.length > 0) {
-          this.log('watchForChanges', { changedFiles: changedFiles.length })
-          callback(changedFiles)
+          this.log('watchForChanges', { changedFiles: changedFiles.length });
+          callback(changedFiles);
         }
 
-        lastCheck = new Date()
-
+        lastCheck = new Date();
       } catch (error) {
-        console.error('Error in watchForChanges polling:', error)
+        console.error('Error in watchForChanges polling:', error);
       }
-    }, 60000)
+    }, 60000);
 
     return () => {
-      clearInterval(pollInterval)
-      this.log('watchForChanges', { status: 'stopped' })
-    }
+      clearInterval(pollInterval);
+      this.log('watchForChanges', { status: 'stopped' });
+    };
   }
 
   async makeAuthenticatedRequest(url, config = {}) {
-    await this.ensureAuthenticated()
+    await this.ensureAuthenticated();
 
     return axios({
       url,
       headers: {
-        'Authorization': `Bearer ${this.accessToken}`,
-        ...config.headers
+        Authorization: `Bearer ${this.accessToken}`,
+        ...config.headers,
       },
-      ...config
-    })
+      ...config,
+    });
   }
 
   async ensureAuthenticated() {
     if (!this.isAuthenticated || Date.now() >= this.tokenExpiry - 30000) {
-      await this.authenticate()
+      await this.authenticate();
     }
   }
 
   validateConfig() {
-    super.validateConfig()
+    super.validateConfig();
 
-    const { clientId, clientSecret, tenantId } = this.config.credentials
+    const { clientId, clientSecret, tenantId } = this.config.credentials;
 
     if (!clientId || !clientSecret || !tenantId) {
-      throw new Error('SharePoint requires clientId, clientSecret, and tenantId')
+      throw new Error('SharePoint requires clientId, clientSecret, and tenantId');
     }
 
     if (!this.isOneDrive && !this.config.siteUrl) {
-      throw new Error('SharePoint requires siteUrl')
+      throw new Error('SharePoint requires siteUrl');
     }
 
-    return true
+    return true;
   }
 
   async cleanup() {
-    this.accessToken = null
-    this.tokenExpiry = null
-    this.isAuthenticated = false
-    this.siteId = null
-    this.log('cleanup', { status: 'completed' })
+    this.accessToken = null;
+    this.tokenExpiry = null;
+    this.isAuthenticated = false;
+    this.siteId = null;
+    this.log('cleanup', { status: 'completed' });
   }
 }
 
-export default SharePointConnector
+export default SharePointConnector;

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,20 +1,20 @@
-import jwt from "jsonwebtoken";
-import config from "../config/env.js";
+import jwt from 'jsonwebtoken';
+import config from '../config/env.js';
 
 export function authenticateToken(req, res, next) {
-  if (config.nodeEnv === "development") {
-    console.log("Authentication bypassed in development mode");
+  if (config.nodeEnv === 'development') {
+    console.log('Authentication bypassed in development mode');
     return next();
   }
 
-  const authHeader = req.headers["authorization"];
-  const token = authHeader && authHeader.split(" ")[1];
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
 
   if (!token) {
     return res.status(401).json({
       success: false,
-      message: "Access token required",
-      error: "No token provided in Authorization header",
+      message: 'Access token required',
+      error: 'No token provided in Authorization header',
     });
   }
 
@@ -23,27 +23,27 @@ export function authenticateToken(req, res, next) {
     req.user = decoded;
     next();
   } catch (error) {
-    console.error("Token verification failed:", error);
+    console.error('Token verification failed:', error);
 
-    if (error.name === "TokenExpiredError") {
+    if (error.name === 'TokenExpiredError') {
       return res.status(401).json({
         success: false,
-        message: "Token expired",
-        error: "Access token has expired",
+        message: 'Token expired',
+        error: 'Access token has expired',
       });
     }
 
     return res.status(403).json({
       success: false,
-      message: "Invalid token",
-      error: "Access token is invalid",
+      message: 'Invalid token',
+      error: 'Access token is invalid',
     });
   }
 }
 
 export function optionalAuth(req, res, next) {
-  const authHeader = req.headers["authorization"];
-  const token = authHeader && authHeader.split(" ")[1];
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
 
   if (!token) {
     req.user = null;
@@ -55,48 +55,48 @@ export function optionalAuth(req, res, next) {
     req.user = decoded;
   } catch {
     req.user = null;
-    console.warn("Optional auth: invalid token provided");
+    console.warn('Optional auth: invalid token provided');
   }
 
   next();
 }
 
-const DEFAULT_TEST_PAYLOAD = { userId: "test-user", role: "admin" };
+const DEFAULT_TEST_PAYLOAD = { userId: 'test-user', role: 'admin' };
 
 export function generateTestToken(payload) {
   const tokenPayload = payload || DEFAULT_TEST_PAYLOAD;
   return jwt.sign(tokenPayload, config.jwtSecret, {
-    expiresIn: "24h",
-    issuer: "doc2ai-backend",
-    audience: "doc2ai-frontend",
+    expiresIn: '24h',
+    issuer: 'doc2ai-backend',
+    audience: 'doc2ai-frontend',
   });
 }
 
 export function requirePermission(permission) {
   return (req, res, next) => {
-    if (config.nodeEnv === "development") {
+    if (config.nodeEnv === 'development') {
       return next();
     }
 
     if (!req.user) {
       return res.status(401).json({
         success: false,
-        message: "Authentication required",
-        error: "User must be authenticated to access this resource",
+        message: 'Authentication required',
+        error: 'User must be authenticated to access this resource',
       });
     }
 
     const userPermissions = req.user.permissions || [];
-    const userRole = req.user.role || "user";
+    const userRole = req.user.role || 'user';
 
-    if (userRole === "admin") {
+    if (userRole === 'admin') {
       return next();
     }
 
     if (!userPermissions.includes(permission)) {
       return res.status(403).json({
         success: false,
-        message: "Insufficient permissions",
+        message: 'Insufficient permissions',
         error: `Required permission: ${permission}`,
       });
     }
@@ -107,18 +107,18 @@ export function requirePermission(permission) {
 
 export function requireRole(requiredRole) {
   return (req, res, next) => {
-    if (config.nodeEnv === "development") {
+    if (config.nodeEnv === 'development') {
       return next();
     }
 
     if (!req.user) {
       return res.status(401).json({
         success: false,
-        message: "Authentication required",
+        message: 'Authentication required',
       });
     }
 
-    const userRole = req.user.role || "user";
+    const userRole = req.user.role || 'user';
     const roleHierarchy = {
       user: 1,
       moderator: 2,
@@ -131,7 +131,7 @@ export function requireRole(requiredRole) {
     if (userLevel < requiredLevel) {
       return res.status(403).json({
         success: false,
-        message: "Insufficient role",
+        message: 'Insufficient role',
         error: `Required role: ${requiredRole}, your role: ${userRole}`,
       });
     }
@@ -140,15 +140,15 @@ export function requireRole(requiredRole) {
   };
 }
 
-export const requireAdmin = requireRole("admin");
+export const requireAdmin = requireRole('admin');
 
 export function logAuthAttempts(req, res, next) {
-  const authHeader = req.headers["authorization"];
+  const authHeader = req.headers['authorization'];
   const hasToken = !!authHeader;
-  const userAgent = req.get("User-Agent");
+  const userAgent = req.get('User-Agent');
   const ip = req.ip || req.connection.remoteAddress;
 
-  console.log("Auth attempt:", {
+  console.log('Auth attempt:', {
     method: req.method,
     url: req.originalUrl,
     hasToken,
@@ -165,8 +165,8 @@ export function publicRoute(req, res, next) {
 }
 
 export function extractUserInfo(req, res, next) {
-  const authHeader = req.headers["authorization"];
-  const token = authHeader && authHeader.split(" ")[1];
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
 
   req.userInfo = {
     isAuthenticated: false,
@@ -184,7 +184,7 @@ export function extractUserInfo(req, res, next) {
         ...decoded,
       };
     } catch (error) {
-      console.warn("Token extraction failed:", error.message);
+      console.warn('Token extraction failed:', error.message);
     }
   }
 

--- a/backend/src/middleware/errorHandler.js
+++ b/backend/src/middleware/errorHandler.js
@@ -1,101 +1,98 @@
-import config from "../config/env.js";
+import config from '../config/env.js';
 
 export function errorHandler(error, req, res, _next) {
-  console.error("❌ Unhandled error:", error);
+  console.error('❌ Unhandled error:', error);
 
-  if (error.code === "P2002") {
+  if (error.code === 'P2002') {
     return res.status(409).json({
       success: false,
-      message: "Resource already exists",
-      error: "Duplicate entry detected",
+      message: 'Resource already exists',
+      error: 'Duplicate entry detected',
     });
   }
 
-  if (error.code === "P2025") {
+  if (error.code === 'P2025') {
     return res.status(404).json({
       success: false,
-      message: "Resource not found",
-      error: "The requested resource does not exist",
+      message: 'Resource not found',
+      error: 'The requested resource does not exist',
     });
   }
 
-  if (error.name === "JsonWebTokenError") {
+  if (error.name === 'JsonWebTokenError') {
     return res.status(401).json({
       success: false,
-      message: "Invalid token",
-      error: "Authentication token is invalid",
+      message: 'Invalid token',
+      error: 'Authentication token is invalid',
     });
   }
 
-  if (error.name === "TokenExpiredError") {
+  if (error.name === 'TokenExpiredError') {
     return res.status(401).json({
       success: false,
-      message: "Token expired",
-      error: "Authentication token has expired",
+      message: 'Token expired',
+      error: 'Authentication token has expired',
     });
   }
 
-  if (error.type === "entity.parse.failed") {
+  if (error.type === 'entity.parse.failed') {
     return res.status(400).json({
       success: false,
-      message: "Invalid JSON",
-      error: "Request body contains invalid JSON",
+      message: 'Invalid JSON',
+      error: 'Request body contains invalid JSON',
     });
   }
 
-  if (error.type === "entity.too.large") {
+  if (error.type === 'entity.too.large') {
     return res.status(413).json({
       success: false,
-      message: "Payload too large",
-      error: "Request payload exceeds size limit",
+      message: 'Payload too large',
+      error: 'Request payload exceeds size limit',
     });
   }
 
-  if (error.code === "ETIMEDOUT" || error.code === "ECONNRESET") {
+  if (error.code === 'ETIMEDOUT' || error.code === 'ECONNRESET') {
     return res.status(408).json({
       success: false,
-      message: "Request timeout",
-      error: "The request took too long to complete",
+      message: 'Request timeout',
+      error: 'The request took too long to complete',
     });
   }
 
-  if (error.code === "EACCES" || error.code === "EPERM") {
+  if (error.code === 'EACCES' || error.code === 'EPERM') {
     return res.status(403).json({
       success: false,
-      message: "Permission denied",
-      error: "Insufficient permissions to complete the operation",
+      message: 'Permission denied',
+      error: 'Insufficient permissions to complete the operation',
     });
   }
 
-  if (error.code === "ENOENT") {
+  if (error.code === 'ENOENT') {
     return res.status(404).json({
       success: false,
-      message: "File not found",
-      error: "The requested file or directory does not exist",
+      message: 'File not found',
+      error: 'The requested file or directory does not exist',
     });
   }
 
-  if (error.code === "ENOSPC") {
+  if (error.code === 'ENOSPC') {
     return res.status(507).json({
       success: false,
-      message: "Insufficient storage",
-      error: "Not enough disk space to complete the operation",
+      message: 'Insufficient storage',
+      error: 'Not enough disk space to complete the operation',
     });
   }
 
   const statusCode = error.statusCode || error.status || 500;
-  const message = error.message || "Internal server error";
+  const message = error.message || 'Internal server error';
 
   const errorResponse = {
     success: false,
-    message: statusCode === 500 ? "Internal server error" : message,
-    error:
-      config.nodeEnv === "development"
-        ? message
-        : "An unexpected error occurred",
+    message: statusCode === 500 ? 'Internal server error' : message,
+    error: config.nodeEnv === 'development' ? message : 'An unexpected error occurred',
   };
 
-  if (config.nodeEnv === "development") {
+  if (config.nodeEnv === 'development') {
     errorResponse.stack = error.stack;
     errorResponse.details = {
       name: error.name,
@@ -110,14 +107,14 @@ export function errorHandler(error, req, res, _next) {
 export function notFoundHandler(req, res) {
   res.status(404).json({
     success: false,
-    message: "Route not found",
+    message: 'Route not found',
     error: `Cannot ${req.method} ${req.originalUrl}`,
     availableEndpoints: {
-      api: "/api",
-      health: "/api/health",
-      sources: "/api/sources",
-      conversions: "/api/conversions",
-      monitoring: "/api/monitoring",
+      api: '/api',
+      health: '/api/health',
+      sources: '/api/sources',
+      conversions: '/api/conversions',
+      monitoring: '/api/monitoring',
     },
   });
 }
@@ -135,10 +132,10 @@ export function wrapAsync(fn) {
 }
 
 export function validationErrorHandler(error, req, res, next) {
-  if (error.name === "ValidationError") {
+  if (error.name === 'ValidationError') {
     return res.status(400).json({
       success: false,
-      message: "Validation error",
+      message: 'Validation error',
       error: error.message,
       details: error.details || {},
     });
@@ -147,12 +144,12 @@ export function validationErrorHandler(error, req, res, next) {
 }
 
 export function logError(error, req, res, next) {
-  console.error("Error details:", {
+  console.error('Error details:', {
     message: error.message,
     stack: error.stack,
     url: req.originalUrl,
     method: req.method,
-    userAgent: req.get("User-Agent"),
+    userAgent: req.get('User-Agent'),
     ip: req.ip,
     timestamp: new Date().toISOString(),
   });

--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -1,48 +1,48 @@
-import { validateDestinationPath } from "../utils/configParser.js";
+import { validateDestinationPath } from '../utils/configParser.js';
 
 export function validateSourceData(req, res, next) {
   const { name, platform, config } = req.body;
 
   const errors = [];
 
-  if (!name || typeof name !== "string" || name.trim().length === 0) {
-    errors.push("Name is required and must be a non-empty string");
+  if (!name || typeof name !== 'string' || name.trim().length === 0) {
+    errors.push('Name is required and must be a non-empty string');
   } else if (name.length > 100) {
-    errors.push("Name must be less than 100 characters");
+    errors.push('Name must be less than 100 characters');
   }
 
-  const supportedPlatforms = ["sharepoint", "googledrive", "onedrive"];
+  const supportedPlatforms = ['sharepoint', 'googledrive', 'onedrive'];
   if (!platform || !supportedPlatforms.includes(platform.toLowerCase())) {
-    errors.push(`Platform must be one of: ${supportedPlatforms.join(", ")}`);
+    errors.push(`Platform must be one of: ${supportedPlatforms.join(', ')}`);
   }
 
-  if (!config || typeof config !== "object") {
-    errors.push("Config is required and must be an object");
+  if (!config || typeof config !== 'object') {
+    errors.push('Config is required and must be an object');
   } else {
-    if (!config.credentials || typeof config.credentials !== "object") {
-      errors.push("Config.credentials is required and must be an object");
+    if (!config.credentials || typeof config.credentials !== 'object') {
+      errors.push('Config.credentials is required and must be an object');
     }
 
-    if (platform === "sharepoint" || platform === "onedrive") {
+    if (platform === 'sharepoint' || platform === 'onedrive') {
       const { clientId, clientSecret, tenantId } = config.credentials || {};
-      if (!clientId) errors.push("Microsoft clientId is required");
-      if (!clientSecret) errors.push("Microsoft clientSecret is required");
-      if (!tenantId) errors.push("Microsoft tenantId is required");
-      if (platform === "sharepoint" && !config.siteUrl) {
-        errors.push("SharePoint siteUrl is required");
+      if (!clientId) errors.push('Microsoft clientId is required');
+      if (!clientSecret) errors.push('Microsoft clientSecret is required');
+      if (!tenantId) errors.push('Microsoft tenantId is required');
+      if (platform === 'sharepoint' && !config.siteUrl) {
+        errors.push('SharePoint siteUrl is required');
       }
     }
 
-    if (platform === "googledrive") {
+    if (platform === 'googledrive') {
       const { clientId, clientSecret, refreshToken } = config.credentials || {};
-      if (!clientId) errors.push("Google clientId is required");
-      if (!clientSecret) errors.push("Google clientSecret is required");
-      if (!refreshToken) errors.push("Google refreshToken is required");
+      if (!clientId) errors.push('Google clientId is required');
+      if (!clientSecret) errors.push('Google clientSecret is required');
+      if (!refreshToken) errors.push('Google refreshToken is required');
     }
 
     if (config.destination) {
-      if (typeof config.destination !== "string") {
-        errors.push("Config.destination must be a string");
+      if (typeof config.destination !== 'string') {
+        errors.push('Config.destination must be a string');
       } else {
         try {
           validateDestinationPath(config.destination);
@@ -56,7 +56,7 @@ export function validateSourceData(req, res, next) {
   if (errors.length > 0) {
     return res.status(400).json({
       success: false,
-      message: "Validation failed",
+      message: 'Validation failed',
       errors,
     });
   }
@@ -69,47 +69,34 @@ export function validateConversionJobData(req, res, next) {
 
   const errors = [];
 
-  if (!sourceId || typeof sourceId !== "string") {
-    errors.push("sourceId is required and must be a string");
+  if (!sourceId || typeof sourceId !== 'string') {
+    errors.push('sourceId is required and must be a string');
   }
 
-  if (
-    !fileName ||
-    typeof fileName !== "string" ||
-    fileName.trim().length === 0
-  ) {
-    errors.push("fileName is required and must be a non-empty string");
+  if (!fileName || typeof fileName !== 'string' || fileName.trim().length === 0) {
+    errors.push('fileName is required and must be a non-empty string');
   } else {
-    const supportedExtensions = [".docx", ".doc", ".pdf"];
-    const extension = fileName
-      .substring(fileName.lastIndexOf("."))
-      .toLowerCase();
+    const supportedExtensions = ['.docx', '.doc', '.pdf'];
+    const extension = fileName.substring(fileName.lastIndexOf('.')).toLowerCase();
     if (!supportedExtensions.includes(extension)) {
       errors.push(
-        `Unsupported file extension: ${extension}. Supported: ${supportedExtensions.join(", ")}`,
+        `Unsupported file extension: ${extension}. Supported: ${supportedExtensions.join(', ')}`,
       );
     }
   }
 
-  if (
-    !filePath ||
-    typeof filePath !== "string" ||
-    filePath.trim().length === 0
-  ) {
-    errors.push("filePath is required and must be a non-empty string");
+  if (!filePath || typeof filePath !== 'string' || filePath.trim().length === 0) {
+    errors.push('filePath is required and must be a non-empty string');
   }
 
-  if (
-    fileSize !== undefined &&
-    (typeof fileSize !== "number" || fileSize < 0)
-  ) {
-    errors.push("fileSize must be a positive number if provided");
+  if (fileSize !== undefined && (typeof fileSize !== 'number' || fileSize < 0)) {
+    errors.push('fileSize must be a positive number if provided');
   }
 
   if (errors.length > 0) {
     return res.status(400).json({
       success: false,
-      message: "Validation failed",
+      message: 'Validation failed',
       errors,
     });
   }
@@ -125,7 +112,7 @@ export function validatePagination(req, res, next) {
     if (isNaN(pageNum) || pageNum < 1) {
       return res.status(400).json({
         success: false,
-        message: "Invalid page parameter. Must be a positive integer.",
+        message: 'Invalid page parameter. Must be a positive integer.',
       });
     }
     req.query.page = pageNum;
@@ -136,7 +123,7 @@ export function validatePagination(req, res, next) {
     if (isNaN(limitNum) || limitNum < 1 || limitNum > 100) {
       return res.status(400).json({
         success: false,
-        message: "Invalid limit parameter. Must be between 1 and 100.",
+        message: 'Invalid limit parameter. Must be between 1 and 100.',
       });
     }
     req.query.limit = limitNum;
@@ -145,7 +132,7 @@ export function validatePagination(req, res, next) {
   next();
 }
 
-export function validateId(paramName = "id") {
+export function validateId(paramName = 'id') {
   return (req, res, next) => {
     const id = req.params[paramName];
 
@@ -172,11 +159,11 @@ export function validateJobStatus(req, res, next) {
   const { status } = req.query;
 
   if (status !== undefined) {
-    const validStatuses = ["pending", "processing", "completed", "failed"];
+    const validStatuses = ['pending', 'processing', 'completed', 'failed'];
     if (!validStatuses.includes(status)) {
       return res.status(400).json({
         success: false,
-        message: `Invalid status. Must be one of: ${validStatuses.join(", ")}`,
+        message: `Invalid status. Must be one of: ${validStatuses.join(', ')}`,
       });
     }
   }
@@ -186,9 +173,9 @@ export function validateJobStatus(req, res, next) {
 
 export function sanitizeInput(req, res, next) {
   function sanitize(obj) {
-    if (typeof obj === "string") {
-      return obj.trim().replace(/[<>]/g, "");
-    } else if (typeof obj === "object" && obj !== null) {
+    if (typeof obj === 'string') {
+      return obj.trim().replace(/[<>]/g, '');
+    } else if (typeof obj === 'object' && obj !== null) {
       const sanitized = {};
       for (const [key, value] of Object.entries(obj)) {
         sanitized[key] = sanitize(value);
@@ -211,13 +198,13 @@ export function sanitizeInput(req, res, next) {
 
 export function validateRequestSize(maxSizeMB = 10) {
   return (req, res, next) => {
-    const contentLength = parseInt(req.get("content-length"));
+    const contentLength = parseInt(req.get('content-length'));
     const maxSizeBytes = maxSizeMB * 1024 * 1024;
 
     if (contentLength > maxSizeBytes) {
       return res.status(413).json({
         success: false,
-        message: "Request too large",
+        message: 'Request too large',
         error: `Request size (${Math.round(contentLength / 1024 / 1024)}MB) exceeds limit (${maxSizeMB}MB)`,
       });
     }
@@ -227,14 +214,14 @@ export function validateRequestSize(maxSizeMB = 10) {
 }
 
 export function validateContentType(req, res, next) {
-  if (["POST", "PUT", "PATCH"].includes(req.method)) {
-    const contentType = req.get("content-type");
+  if (['POST', 'PUT', 'PATCH'].includes(req.method)) {
+    const contentType = req.get('content-type');
 
-    if (!contentType || !contentType.includes("application/json")) {
+    if (!contentType || !contentType.includes('application/json')) {
       return res.status(400).json({
         success: false,
-        message: "Invalid Content-Type",
-        error: "Expected application/json",
+        message: 'Invalid Content-Type',
+        error: 'Expected application/json',
       });
     }
   }

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -1,11 +1,11 @@
-import express from 'express'
-import AuthController from '../controllers/authController.js'
+import express from 'express';
+import AuthController from '../controllers/authController.js';
 
-const router = express.Router()
-const authController = new AuthController()
+const router = express.Router();
+const authController = new AuthController();
 
 // Routes pour l'authentification Google OAuth
-router.get('/google', authController.getGoogleAuthUrl.bind(authController))
-router.get('/google/callback', authController.googleCallback.bind(authController))
+router.get('/google', authController.getGoogleAuthUrl.bind(authController));
+router.get('/google/callback', authController.googleCallback.bind(authController));
 
-export default router
+export default router;

--- a/backend/src/routes/conversions.js
+++ b/backend/src/routes/conversions.js
@@ -1,17 +1,17 @@
-import express from 'express'
-import ConversionController from '../controllers/conversionController.js'
+import express from 'express';
+import ConversionController from '../controllers/conversionController.js';
 
-const router = express.Router()
-const conversionController = new ConversionController()
+const router = express.Router();
+const conversionController = new ConversionController();
 
 // Routes pour les conversions
-router.get('/stats', conversionController.getStats.bind(conversionController))
-router.post('/cleanup', conversionController.cleanupJobs.bind(conversionController))
-router.get('/', conversionController.getAllJobs.bind(conversionController))
-router.get('/:id', conversionController.getJobById.bind(conversionController))
-router.get('/:id/progress', conversionController.getJobProgress.bind(conversionController))
-router.post('/', conversionController.createJob.bind(conversionController))
-router.post('/:id/retry', conversionController.retryJob.bind(conversionController))
-router.delete('/:id', conversionController.cancelJob.bind(conversionController))
+router.get('/stats', conversionController.getStats.bind(conversionController));
+router.post('/cleanup', conversionController.cleanupJobs.bind(conversionController));
+router.get('/', conversionController.getAllJobs.bind(conversionController));
+router.get('/:id', conversionController.getJobById.bind(conversionController));
+router.get('/:id/progress', conversionController.getJobProgress.bind(conversionController));
+router.post('/', conversionController.createJob.bind(conversionController));
+router.post('/:id/retry', conversionController.retryJob.bind(conversionController));
+router.delete('/:id', conversionController.cancelJob.bind(conversionController));
 
-export default router
+export default router;

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -1,40 +1,40 @@
-import express from "express";
-import sourcesRouter from "./sources.js";
-import conversionsRouter from "./conversions.js";
-import monitoringRouter from "./monitoring.js";
-import authRouter from "./auth.js";
+import express from 'express';
+import sourcesRouter from './sources.js';
+import conversionsRouter from './conversions.js';
+import monitoringRouter from './monitoring.js';
+import authRouter from './auth.js';
 
 const router = express.Router();
 
 // API routes
-router.use("/sources", sourcesRouter);
-router.use("/conversions", conversionsRouter);
-router.use("/monitoring", monitoringRouter);
-router.use("/auth", authRouter);
+router.use('/sources', sourcesRouter);
+router.use('/conversions', conversionsRouter);
+router.use('/monitoring', monitoringRouter);
+router.use('/auth', authRouter);
 
 // Health check route
-router.get("/health", (req, res) => {
+router.get('/health', (req, res) => {
   res.json({
     success: true,
-    message: "Doc2AI API is running",
+    message: 'Doc2AI API is running',
     timestamp: new Date().toISOString(),
-    version: "1.0.0",
+    version: '1.0.0',
   });
 });
 
 // API info route
-router.get("/", (req, res) => {
+router.get('/', (req, res) => {
   res.json({
-    name: "Doc2AI Backend API",
-    version: "1.0.0",
-    description: "API for converting documents to Markdown using AI",
+    name: 'Doc2AI Backend API',
+    version: '1.0.0',
+    description: 'API for converting documents to Markdown using AI',
     endpoints: {
-      sources: "/api/sources",
-      conversions: "/api/conversions",
-      monitoring: "/api/monitoring",
-      auth: "/api/auth",
+      sources: '/api/sources',
+      conversions: '/api/conversions',
+      monitoring: '/api/monitoring',
+      auth: '/api/auth',
     },
-    documentation: "https://github.com/yourusername/doc2ai",
+    documentation: 'https://github.com/yourusername/doc2ai',
   });
 });
 

--- a/backend/src/routes/monitoring.js
+++ b/backend/src/routes/monitoring.js
@@ -1,17 +1,20 @@
-import express from 'express'
-import MonitoringController from '../controllers/monitoringController.js'
+import express from 'express';
+import MonitoringController from '../controllers/monitoringController.js';
 
-const router = express.Router()
-const monitoringController = new MonitoringController()
+const router = express.Router();
+const monitoringController = new MonitoringController();
 
 // Routes pour le monitoring
-router.get('/status', monitoringController.getStatus.bind(monitoringController))
-router.get('/health', monitoringController.healthCheck.bind(monitoringController))
-router.get('/logs', monitoringController.getLogs.bind(monitoringController))
-router.get('/sources/:sourceId/logs', monitoringController.getSourceLogs.bind(monitoringController))
-router.post('/start', monitoringController.startMonitoring.bind(monitoringController))
-router.post('/stop', monitoringController.stopMonitoring.bind(monitoringController))
-router.post('/restart', monitoringController.restartMonitoring.bind(monitoringController))
-router.post('/sync/:sourceId', monitoringController.syncSource.bind(monitoringController))
+router.get('/status', monitoringController.getStatus.bind(monitoringController));
+router.get('/health', monitoringController.healthCheck.bind(monitoringController));
+router.get('/logs', monitoringController.getLogs.bind(monitoringController));
+router.get(
+  '/sources/:sourceId/logs',
+  monitoringController.getSourceLogs.bind(monitoringController),
+);
+router.post('/start', monitoringController.startMonitoring.bind(monitoringController));
+router.post('/stop', monitoringController.stopMonitoring.bind(monitoringController));
+router.post('/restart', monitoringController.restartMonitoring.bind(monitoringController));
+router.post('/sync/:sourceId', monitoringController.syncSource.bind(monitoringController));
 
-export default router
+export default router;

--- a/backend/src/routes/sources.js
+++ b/backend/src/routes/sources.js
@@ -1,31 +1,22 @@
-import express from "express";
-import SourceController from "../controllers/sourceController.js";
+import express from 'express';
+import SourceController from '../controllers/sourceController.js';
 
 const router = express.Router();
 const sourceController = new SourceController();
 
 // Routes pour les sources
-router.get("/stats", sourceController.getStats.bind(sourceController));
-router.get("/", sourceController.getAllSources.bind(sourceController));
-router.get("/:id", sourceController.getSourceById.bind(sourceController));
-router.post("/", sourceController.createSource.bind(sourceController));
-router.put("/:id", sourceController.updateSource.bind(sourceController));
-router.delete("/:id", sourceController.deleteSource.bind(sourceController));
+router.get('/stats', sourceController.getStats.bind(sourceController));
+router.get('/', sourceController.getAllSources.bind(sourceController));
+router.get('/:id', sourceController.getSourceById.bind(sourceController));
+router.post('/', sourceController.createSource.bind(sourceController));
+router.put('/:id', sourceController.updateSource.bind(sourceController));
+router.delete('/:id', sourceController.deleteSource.bind(sourceController));
+router.post('/test-credentials', sourceController.testCredentials.bind(sourceController));
+router.post('/:id/test', sourceController.testConnection.bind(sourceController));
+router.post('/:id/sync', sourceController.syncSource.bind(sourceController));
+router.post('/google-drive/folders', sourceController.getGoogleDriveFolders.bind(sourceController));
 router.post(
-  "/test-credentials",
-  sourceController.testCredentials.bind(sourceController),
-);
-router.post(
-  "/:id/test",
-  sourceController.testConnection.bind(sourceController),
-);
-router.post("/:id/sync", sourceController.syncSource.bind(sourceController));
-router.post(
-  "/google-drive/folders",
-  sourceController.getGoogleDriveFolders.bind(sourceController),
-);
-router.post(
-  "/google-drive/preview-files",
+  '/google-drive/preview-files',
   sourceController.previewGoogleDriveFiles.bind(sourceController),
 );
 

--- a/backend/src/services/conversionService.js
+++ b/backend/src/services/conversionService.js
@@ -1,12 +1,9 @@
-import getPrismaClient from "../config/database.js";
-import { ConverterFactory } from "../converters/converterFactory.js";
-import path from "path";
-import fs from "fs-extra";
-import config from "../config/env.js";
-import {
-  enrichSourceWithConfig,
-  getValidatedDestination,
-} from "../utils/configParser.js";
+import getPrismaClient from '../config/database.js';
+import { ConverterFactory } from '../converters/converterFactory.js';
+import path from 'path';
+import fs from 'fs-extra';
+import config from '../config/env.js';
+import { enrichSourceWithConfig, getValidatedDestination } from '../utils/configParser.js';
 
 const prisma = getPrismaClient();
 
@@ -23,7 +20,7 @@ class ConversionService {
             select: { id: true, name: true, platform: true },
           },
         },
-        orderBy: { createdAt: "desc" },
+        orderBy: { createdAt: 'desc' },
         skip,
         take: limit,
       });
@@ -40,7 +37,7 @@ class ConversionService {
         },
       };
     } catch (error) {
-      console.error("Error fetching conversion jobs:", error);
+      console.error('Error fetching conversion jobs:', error);
       throw error;
     }
   }
@@ -55,7 +52,7 @@ class ConversionService {
       });
 
       if (!job) {
-        throw new Error("Conversion job not found");
+        throw new Error('Conversion job not found');
       }
 
       if (job.source) {
@@ -64,7 +61,7 @@ class ConversionService {
 
       return job;
     } catch (error) {
-      console.error("Error fetching job:", error);
+      console.error('Error fetching job:', error);
       throw error;
     }
   }
@@ -85,7 +82,7 @@ class ConversionService {
           fileName,
           filePath,
           fileSize,
-          status: "pending",
+          status: 'pending',
         },
         include: {
           source: true,
@@ -99,7 +96,7 @@ class ConversionService {
       console.log(`Conversion job created: ${fileName}`);
       return job;
     } catch (error) {
-      console.error("Error creating job:", error);
+      console.error('Error creating job:', error);
       throw error;
     }
   }
@@ -121,7 +118,7 @@ class ConversionService {
       job = await prisma.conversionJob.update({
         where: { id: jobId },
         data: {
-          status: "processing",
+          status: 'processing',
           startedAt: new Date(),
           progress: 10,
         },
@@ -139,65 +136,44 @@ class ConversionService {
         throw new Error(`Unsupported file format: ${fileExtension}`);
       }
 
-      await this.updateJobProgress(jobId, 30, "Initializing converter");
+      await this.updateJobProgress(jobId, 30, 'Initializing converter');
 
       await fs.ensureDir(config.storagePath);
       await fs.ensureDir(config.tempPath);
 
-      const outputFileName = path.basename(job.fileName, fileExtension) + ".md";
-      const destinationFolder = getValidatedDestination(
-        job.source.config,
-        job.source.name,
-      );
-      const outputPath = path.join(
-        config.storagePath,
-        destinationFolder,
-        outputFileName,
-      );
+      const outputFileName = path.basename(job.fileName, fileExtension) + '.md';
+      const destinationFolder = getValidatedDestination(job.source.config, job.source.name);
+      const outputPath = path.join(config.storagePath, destinationFolder, outputFileName);
 
       await fs.ensureDir(path.dirname(outputPath));
 
-      await this.updateJobProgress(jobId, 50, "Converting file");
+      await this.updateJobProgress(jobId, 50, 'Converting file');
       const result = await converter.convert(job.filePath, outputPath);
 
       if (!result.success) {
-        throw new Error(result.error || "Conversion failed");
+        throw new Error(result.error || 'Conversion failed');
       }
 
-      await this.updateJobProgress(
-        jobId,
-        80,
-        "Exporting to configured destination",
-      );
+      await this.updateJobProgress(jobId, 80, 'Exporting to configured destination');
 
       try {
         await fs.ensureDir(config.exportPath);
 
-        const destination = getValidatedDestination(
-          job.source.config,
-          job.source.name,
-        );
+        const destination = getValidatedDestination(job.source.config, job.source.name);
 
-        const exportFilePath = path.join(
-          config.exportPath,
-          destination,
-          outputFileName,
-        );
+        const exportFilePath = path.join(config.exportPath, destination, outputFileName);
 
         await fs.ensureDir(path.dirname(exportFilePath));
         await fs.copy(outputPath, exportFilePath);
         console.log(`File exported to: ${exportFilePath}`);
       } catch (error) {
-        console.warn(
-          `Warning: Failed to export to configured destination:`,
-          error.message,
-        );
+        console.warn(`Warning: Failed to export to configured destination:`, error.message);
       }
 
       const completedJob = await prisma.conversionJob.update({
         where: { id: jobId },
         data: {
-          status: "completed",
+          status: 'completed',
           progress: 100,
           outputPath,
           completedAt: new Date(),
@@ -211,7 +187,7 @@ class ConversionService {
           fileName: outputFileName,
           fileType: fileExtension,
           platform: job.source.platform,
-          checksum: result.checksum || "unknown",
+          checksum: result.checksum || 'unknown',
         },
       });
 
@@ -224,7 +200,7 @@ class ConversionService {
         .update({
           where: { id: jobId },
           data: {
-            status: "failed",
+            status: 'failed',
             error: error.message,
             completedAt: new Date(),
           },
@@ -248,7 +224,7 @@ class ConversionService {
         console.log(`Job ${jobId}: ${progress}% - ${message}`);
       }
     } catch (error) {
-      console.error("Error updating job progress:", error);
+      console.error('Error updating job progress:', error);
     }
   }
 
@@ -257,11 +233,11 @@ class ConversionService {
       const job = await prisma.conversionJob.update({
         where: {
           id: jobId,
-          status: { in: ["pending", "processing"] },
+          status: { in: ['pending', 'processing'] },
         },
         data: {
-          status: "failed",
-          error: "Cancelled by user",
+          status: 'failed',
+          error: 'Cancelled by user',
           completedAt: new Date(),
         },
       });
@@ -269,7 +245,7 @@ class ConversionService {
       console.log(`Job cancelled: ${job.fileName}`);
       return job;
     } catch (error) {
-      console.error("Error cancelling job:", error);
+      console.error('Error cancelling job:', error);
       throw error;
     }
   }
@@ -277,7 +253,7 @@ class ConversionService {
   async getJobStats() {
     try {
       const stats = await prisma.conversionJob.groupBy({
-        by: ["status"],
+        by: ['status'],
         _count: {
           _all: true,
         },
@@ -299,7 +275,7 @@ class ConversionService {
         recent,
       };
     } catch (error) {
-      console.error("Error fetching job stats:", error);
+      console.error('Error fetching job stats:', error);
       throw error;
     }
   }
@@ -311,7 +287,7 @@ class ConversionService {
 
       const result = await prisma.conversionJob.deleteMany({
         where: {
-          status: "completed",
+          status: 'completed',
           completedAt: {
             lt: cutoffDate,
           },
@@ -321,7 +297,7 @@ class ConversionService {
       console.log(`Cleaned up ${result.count} old conversion jobs`);
       return result.count;
     } catch (error) {
-      console.error("Error cleaning up jobs:", error);
+      console.error('Error cleaning up jobs:', error);
       throw error;
     }
   }

--- a/backend/src/services/monitoringService.js
+++ b/backend/src/services/monitoringService.js
@@ -1,10 +1,10 @@
-import getPrismaClient from "../config/database.js";
-import { DriveConnectorFactory } from "../integrations/base/driveConnectorFactory.js";
-import ConversionService from "./conversionService.js";
-import queueService from "./queueService.js";
-import { decryptCredentials } from "../utils/encryption.js";
-import cron from "node-cron";
-import config from "../config/env.js";
+import getPrismaClient from '../config/database.js';
+import { DriveConnectorFactory } from '../integrations/base/driveConnectorFactory.js';
+import ConversionService from './conversionService.js';
+import queueService from './queueService.js';
+import { decryptCredentials } from '../utils/encryption.js';
+import cron from 'node-cron';
+import config from '../config/env.js';
 
 const prisma = getPrismaClient();
 
@@ -19,15 +19,11 @@ class MonitoringService {
 
   _parseAndDecryptConfig(source) {
     const parsedConfig =
-      typeof source.config === "string"
-        ? JSON.parse(source.config)
-        : source.config;
+      typeof source.config === 'string' ? JSON.parse(source.config) : source.config;
 
     const decryptedConfig = {
       ...parsedConfig,
-      credentials: parsedConfig.credentials
-        ? decryptCredentials(parsedConfig.credentials)
-        : null,
+      credentials: parsedConfig.credentials ? decryptCredentials(parsedConfig.credentials) : null,
     };
 
     return { parsedConfig, decryptedConfig };
@@ -39,14 +35,14 @@ class MonitoringService {
   async start() {
     try {
       if (this.isRunning) {
-        console.warn("⚠️ Monitoring service is already running");
+        console.warn('⚠️ Monitoring service is already running');
         return;
       }
 
-      console.log("Starting monitoring service...");
+      console.log('Starting monitoring service...');
 
       const activeSources = await prisma.source.findMany({
-        where: { status: "active" },
+        where: { status: 'active' },
       });
 
       for (const source of activeSources) {
@@ -58,14 +54,14 @@ class MonitoringService {
       this.isRunning = true;
       console.log(`Monitoring service started for ${activeSources.length} sources`);
     } catch (error) {
-      console.error("❌ Failed to start monitoring service:", error);
+      console.error('❌ Failed to start monitoring service:', error);
       throw error;
     }
   }
 
   async stop() {
     try {
-      console.log("Stopping monitoring service...");
+      console.log('Stopping monitoring service...');
 
       for (const [sourceId] of this.activeMonitors) {
         await this.stopSourceMonitoring(sourceId);
@@ -77,9 +73,9 @@ class MonitoringService {
       }
 
       this.isRunning = false;
-      console.log("Monitoring service stopped");
+      console.log('Monitoring service stopped');
     } catch (error) {
-      console.error("❌ Failed to stop monitoring service:", error);
+      console.error('❌ Failed to stop monitoring service:', error);
       throw error;
     }
   }
@@ -90,12 +86,12 @@ class MonitoringService {
     this.cronJob = cron.schedule(
       cronExpression,
       async () => {
-        console.log("Running scheduled sync...");
+        console.log('Running scheduled sync...');
         await this.syncAllActiveSources();
       },
       {
         scheduled: true,
-        timezone: "Europe/Paris",
+        timezone: 'Europe/Paris',
       },
     );
 
@@ -112,10 +108,7 @@ class MonitoringService {
 
       const { decryptedConfig } = this._parseAndDecryptConfig(source);
 
-      const connector = DriveConnectorFactory.createConnector(
-        source.platform,
-        decryptedConfig,
-      );
+      const connector = DriveConnectorFactory.createConnector(source.platform, decryptedConfig);
 
       const connectionTest = await connector.testConnection();
       if (!connectionTest.success) {
@@ -131,9 +124,9 @@ class MonitoringService {
       await prisma.syncLog.create({
         data: {
           sourceId: source.id,
-          action: "monitor_start",
-          status: "success",
-          message: "Monitoring started successfully",
+          action: 'monitor_start',
+          status: 'success',
+          message: 'Monitoring started successfully',
         },
       });
     } catch (error) {
@@ -142,8 +135,8 @@ class MonitoringService {
       await prisma.syncLog.create({
         data: {
           sourceId: source.id,
-          action: "monitor_start",
-          status: "error",
+          action: 'monitor_start',
+          status: 'error',
           message: error.message,
           details: JSON.stringify({ error: error.stack }),
         },
@@ -160,10 +153,7 @@ class MonitoringService {
 
       console.log(`Stopping monitoring for: ${monitor.source.name}`);
 
-      if (
-        monitor.connector &&
-        typeof monitor.connector.cleanup === "function"
-      ) {
+      if (monitor.connector && typeof monitor.connector.cleanup === 'function') {
         await monitor.connector.cleanup();
       }
 
@@ -172,16 +162,13 @@ class MonitoringService {
       await prisma.syncLog.create({
         data: {
           sourceId,
-          action: "monitor_stop",
-          status: "success",
-          message: "Monitoring stopped",
+          action: 'monitor_stop',
+          status: 'success',
+          message: 'Monitoring stopped',
         },
       });
     } catch (error) {
-      console.error(
-        `❌ Error stopping monitoring for source ${sourceId}:`,
-        error,
-      );
+      console.error(`❌ Error stopping monitoring for source ${sourceId}:`, error);
     }
   }
 
@@ -219,11 +206,11 @@ class MonitoringService {
       });
 
       if (!source) {
-        throw new Error("Source not found");
+        throw new Error('Source not found');
       }
 
-      if (source.status !== "active") {
-        throw new Error("Source must be active to sync");
+      if (source.status !== 'active') {
+        throw new Error('Source must be active to sync');
       }
 
       let connector;
@@ -236,10 +223,7 @@ class MonitoringService {
 
         const { decryptedConfig } = this._parseAndDecryptConfig(source);
 
-        connector = DriveConnectorFactory.createConnector(
-          source.platform,
-          decryptedConfig,
-        );
+        connector = DriveConnectorFactory.createConnector(source.platform, decryptedConfig);
         await connector.authenticate();
       }
 
@@ -247,29 +231,29 @@ class MonitoringService {
 
       const { parsedConfig } = this._parseAndDecryptConfig(source);
 
-      const sourcePath = parsedConfig.sourcePath || "/";
+      const sourcePath = parsedConfig.sourcePath || '/';
       const files = await connector.listFiles(sourcePath);
 
       // Normalize filters (may be objects {"0":".docx",...} instead of arrays)
       const rawExtensions = parsedConfig.filters?.extensions;
       const supportedExtensions = Array.isArray(rawExtensions)
         ? rawExtensions
-        : rawExtensions && typeof rawExtensions === "object"
+        : rawExtensions && typeof rawExtensions === 'object'
           ? Object.values(rawExtensions)
-          : [".docx", ".pdf", ".doc"];
+          : ['.docx', '.pdf', '.doc'];
 
       const rawExclude = parsedConfig.filters?.excludePatterns;
       const excludePatterns = Array.isArray(rawExclude)
         ? rawExclude
-        : rawExclude && typeof rawExclude === "object"
+        : rawExclude && typeof rawExclude === 'object'
           ? Object.values(rawExclude)
           : [];
 
       // Map Google Apps mimeTypes to their equivalent extensions
       const googleMimeToExt = {
-        "application/vnd.google-apps.document": ".docx",
-        "application/vnd.google-apps.spreadsheet": ".xlsx",
-        "application/vnd.google-apps.presentation": ".pptx",
+        'application/vnd.google-apps.document': '.docx',
+        'application/vnd.google-apps.spreadsheet': '.xlsx',
+        'application/vnd.google-apps.presentation': '.pptx',
       };
 
       const filteredFiles = files.filter((file) => {
@@ -280,15 +264,13 @@ class MonitoringService {
 
         // Or by Google Apps mimeType (these files have no extension in their name)
         const googleExt = googleMimeToExt[file.mimeType];
-        const matchesGoogleType = googleExt &&
-          supportedExtensions.some((ext) => ext.toLowerCase() === googleExt);
+        const matchesGoogleType =
+          googleExt && supportedExtensions.some((ext) => ext.toLowerCase() === googleExt);
 
         if (!hasValidExtension && !matchesGoogleType) return false;
 
         // Check exclusion patterns
-        const isExcluded = excludePatterns.some((pattern) =>
-          file.name.match(new RegExp(pattern)),
-        );
+        const isExcluded = excludePatterns.some((pattern) => file.name.match(new RegExp(pattern)));
 
         return !isExcluded;
       });
@@ -311,8 +293,8 @@ class MonitoringService {
       await prisma.syncLog.create({
         data: {
           sourceId,
-          action: "sync",
-          status: "success",
+          action: 'sync',
+          status: 'success',
           message: `Processed ${filteredFiles.length} files`,
           details: JSON.stringify({ fileCount: filteredFiles.length }),
         },
@@ -324,14 +306,14 @@ class MonitoringService {
         await prisma.syncLog.create({
           data: {
             sourceId,
-            action: "sync",
-            status: "error",
+            action: 'sync',
+            status: 'error',
             message: error.message,
             details: JSON.stringify({ error: error.stack }),
           },
         });
       } catch (dbError) {
-        console.error("Failed to log sync error:", dbError);
+        console.error('Failed to log sync error:', dbError);
       }
 
       throw error;
@@ -345,7 +327,7 @@ class MonitoringService {
       const existingFile = await prisma.convertedFile.findFirst({
         where: {
           originalPath: file.path,
-          platform: file.platform || "unknown",
+          platform: file.platform || 'unknown',
         },
       });
 
@@ -357,12 +339,7 @@ class MonitoringService {
 
       const tempPath = await connector.downloadFile(file.id, config.tempPath);
 
-      const job = await this.conversionService.createJob(
-        sourceId,
-        file.name,
-        tempPath,
-        file.size,
-      );
+      const job = await this.conversionService.createJob(sourceId, file.name, tempPath, file.size);
 
       await queueService.enqueueConversion(job.id, file.name);
 
@@ -373,8 +350,8 @@ class MonitoringService {
       await prisma.syncLog.create({
         data: {
           sourceId,
-          action: "file_process",
-          status: "error",
+          action: 'file_process',
+          status: 'error',
           message: `Failed to process ${file.name}: ${error.message}`,
           details: JSON.stringify({
             fileName: file.name,
@@ -389,12 +366,12 @@ class MonitoringService {
     try {
       const activeSourceCount = this.activeMonitors.size;
       const totalSources = await prisma.source.count({
-        where: { status: "active" },
+        where: { status: 'active' },
       });
 
       const recentLogs = await prisma.syncLog.findMany({
         take: 10,
-        orderBy: { createdAt: "desc" },
+        orderBy: { createdAt: 'desc' },
         include: {
           source: {
             select: { name: true },
@@ -413,7 +390,7 @@ class MonitoringService {
         recentLogs,
       };
     } catch (error) {
-      console.error("Error getting monitoring status:", error);
+      console.error('Error getting monitoring status:', error);
       throw error;
     }
   }
@@ -425,7 +402,7 @@ class MonitoringService {
       const logs = await prisma.syncLog.findMany({
         where,
         take: limit,
-        orderBy: { createdAt: "desc" },
+        orderBy: { createdAt: 'desc' },
         include: {
           source: {
             select: { name: true, platform: true },
@@ -435,7 +412,7 @@ class MonitoringService {
 
       return logs;
     } catch (error) {
-      console.error("Error fetching logs:", error);
+      console.error('Error fetching logs:', error);
       throw error;
     }
   }

--- a/backend/src/services/queueService.js
+++ b/backend/src/services/queueService.js
@@ -1,16 +1,16 @@
-import Queue from "bull";
-import config from "../config/env.js";
-import ConversionService from "./conversionService.js";
+import Queue from 'bull';
+import config from '../config/env.js';
+import ConversionService from './conversionService.js';
 
 class QueueService {
   constructor() {
     this.conversionService = new ConversionService();
 
-    this.conversionQueue = new Queue("document-conversion", config.redisUrl, {
+    this.conversionQueue = new Queue('document-conversion', config.redisUrl, {
       defaultJobOptions: {
         attempts: 3,
         backoff: {
-          type: "exponential",
+          type: 'exponential',
           delay: 2000,
         },
         removeOnComplete: 100,
@@ -22,24 +22,24 @@ class QueueService {
   }
 
   setupEventHandlers() {
-    this.conversionQueue.on("completed", (job, result) => {
+    this.conversionQueue.on('completed', (job, result) => {
       console.log(`Job ${job.id} completed: ${result.fileName}`);
     });
 
-    this.conversionQueue.on("failed", (job, error) => {
+    this.conversionQueue.on('failed', (job, error) => {
       console.error(`❌ Job ${job.id} failed:`, error.message);
     });
 
-    this.conversionQueue.on("active", (job) => {
+    this.conversionQueue.on('active', (job) => {
       console.log(`Processing job ${job.id}: ${job.data.fileName}`);
     });
 
-    this.conversionQueue.on("progress", (job, progress) => {
+    this.conversionQueue.on('progress', (job, progress) => {
       console.log(`Job ${job.id} progress: ${progress}%`);
     });
 
-    this.conversionQueue.on("error", (error) => {
-      console.error("❌ Queue error:", error);
+    this.conversionQueue.on('error', (error) => {
+      console.error('❌ Queue error:', error);
     });
   }
 
@@ -94,7 +94,7 @@ class QueueService {
       console.log(`Job enqueued: ${fileName} (ID: ${job.id})`);
       return job;
     } catch (error) {
-      console.error("❌ Error enqueuing job:", error);
+      console.error('❌ Error enqueuing job:', error);
       throw error;
     }
   }
@@ -118,7 +118,7 @@ class QueueService {
         total: waiting + active + completed + failed + delayed,
       };
     } catch (error) {
-      console.error("❌ Error fetching stats:", error);
+      console.error('❌ Error fetching stats:', error);
       throw error;
     }
   }
@@ -133,7 +133,7 @@ class QueueService {
         timestamp: job.timestamp,
       }));
     } catch (error) {
-      console.error("❌ Error fetching active jobs:", error);
+      console.error('❌ Error fetching active jobs:', error);
       throw error;
     }
   }
@@ -147,7 +147,7 @@ class QueueService {
         timestamp: job.timestamp,
       }));
     } catch (error) {
-      console.error("❌ Error fetching waiting jobs:", error);
+      console.error('❌ Error fetching waiting jobs:', error);
       throw error;
     }
   }
@@ -164,18 +164,18 @@ class QueueService {
         attemptsMade: job.attemptsMade,
       }));
     } catch (error) {
-      console.error("❌ Error fetching failed jobs:", error);
+      console.error('❌ Error fetching failed jobs:', error);
       throw error;
     }
   }
 
   async cleanOldJobs(grace = 24 * 60 * 60 * 1000) {
     try {
-      await this.conversionQueue.clean(grace, "completed");
-      await this.conversionQueue.clean(grace, "failed");
+      await this.conversionQueue.clean(grace, 'completed');
+      await this.conversionQueue.clean(grace, 'failed');
       console.log(`Cleaned jobs older than ${grace / 1000 / 60 / 60}h`);
     } catch (error) {
-      console.error("❌ Error cleaning jobs:", error);
+      console.error('❌ Error cleaning jobs:', error);
       throw error;
     }
   }
@@ -183,9 +183,9 @@ class QueueService {
   async emptyQueue() {
     try {
       await this.conversionQueue.empty();
-      console.log("Queue emptied");
+      console.log('Queue emptied');
     } catch (error) {
-      console.error("❌ Error emptying queue:", error);
+      console.error('❌ Error emptying queue:', error);
       throw error;
     }
   }
@@ -193,9 +193,9 @@ class QueueService {
   async pause() {
     try {
       await this.conversionQueue.pause();
-      console.log("Queue paused");
+      console.log('Queue paused');
     } catch (error) {
-      console.error("❌ Error pausing queue:", error);
+      console.error('❌ Error pausing queue:', error);
       throw error;
     }
   }
@@ -203,9 +203,9 @@ class QueueService {
   async resume() {
     try {
       await this.conversionQueue.resume();
-      console.log("Queue resumed");
+      console.log('Queue resumed');
     } catch (error) {
-      console.error("❌ Error resuming queue:", error);
+      console.error('❌ Error resuming queue:', error);
       throw error;
     }
   }
@@ -213,9 +213,9 @@ class QueueService {
   async close() {
     try {
       await this.conversionQueue.close();
-      console.log("Queue closed");
+      console.log('Queue closed');
     } catch (error) {
-      console.error("❌ Error closing queue:", error);
+      console.error('❌ Error closing queue:', error);
       throw error;
     }
   }

--- a/backend/src/services/sourceService.js
+++ b/backend/src/services/sourceService.js
@@ -1,8 +1,8 @@
-import getPrismaClient from "../config/database.js";
-import { encryptCredentials, decryptCredentials } from "../utils/encryption.js";
-import { DriveConnectorFactory } from "../integrations/base/driveConnectorFactory.js";
-import ConversionService from "./conversionService.js";
-import config from "../config/env.js";
+import getPrismaClient from '../config/database.js';
+import { encryptCredentials, decryptCredentials } from '../utils/encryption.js';
+import { DriveConnectorFactory } from '../integrations/base/driveConnectorFactory.js';
+import ConversionService from './conversionService.js';
+import config from '../config/env.js';
 
 const prisma = getPrismaClient();
 
@@ -13,11 +13,11 @@ class SourceService {
         include: {
           jobs: {
             take: 5,
-            orderBy: { createdAt: "desc" },
+            orderBy: { createdAt: 'desc' },
           },
           syncLogs: {
             take: 10,
-            orderBy: { createdAt: "desc" },
+            orderBy: { createdAt: 'desc' },
           },
         },
       });
@@ -28,13 +28,13 @@ class SourceService {
           ...source,
           config: {
             ...parsedConfig,
-            credentials: parsedConfig.credentials ? "***encrypted***" : null,
+            credentials: parsedConfig.credentials ? '***encrypted***' : null,
           },
         };
       });
     } catch (error) {
-      console.error("Error fetching sources:", error);
-      throw new Error("Failed to fetch sources");
+      console.error('Error fetching sources:', error);
+      throw new Error('Failed to fetch sources');
     }
   }
 
@@ -44,16 +44,16 @@ class SourceService {
         where: { id },
         include: {
           jobs: {
-            orderBy: { createdAt: "desc" },
+            orderBy: { createdAt: 'desc' },
           },
           syncLogs: {
-            orderBy: { createdAt: "desc" },
+            orderBy: { createdAt: 'desc' },
           },
         },
       });
 
       if (!source) {
-        throw new Error("Source not found");
+        throw new Error('Source not found');
       }
 
       return {
@@ -61,7 +61,7 @@ class SourceService {
         config: JSON.parse(source.config),
       };
     } catch (error) {
-      console.error("Error fetching source:", error);
+      console.error('Error fetching source:', error);
       throw error;
     }
   }
@@ -76,14 +76,12 @@ class SourceService {
       const { name, platform, config } = sourceData;
 
       if (!name || !platform || !config) {
-        throw new Error("Missing required fields: name, platform, config");
+        throw new Error('Missing required fields: name, platform, config');
       }
 
       const encryptedConfig = {
         ...config,
-        credentials: config.credentials
-          ? encryptCredentials(config.credentials)
-          : null,
+        credentials: config.credentials ? encryptCredentials(config.credentials) : null,
       };
 
       const source = await prisma.source.create({
@@ -91,14 +89,14 @@ class SourceService {
           name,
           platform,
           config: JSON.stringify(encryptedConfig),
-          status: "active",
+          status: 'active',
         },
       });
 
       console.log(`Source created: ${name} (${platform})`);
       return source;
     } catch (error) {
-      console.error("Error creating source:", error);
+      console.error('Error creating source:', error);
       throw error;
     }
   }
@@ -129,7 +127,7 @@ class SourceService {
       console.log(`Source updated: ${source.name}`);
       return source;
     } catch (error) {
-      console.error("Error updating source:", error);
+      console.error('Error updating source:', error);
       throw error;
     }
   }
@@ -143,7 +141,7 @@ class SourceService {
       console.log(`Source deleted: ${id}`);
       return { success: true };
     } catch (error) {
-      console.error("Error deleting source:", error);
+      console.error('Error deleting source:', error);
       throw error;
     }
   }
@@ -159,29 +157,26 @@ class SourceService {
 
       const testConfig = {
         credentials,
-        sourcePath: sourcePath || "/",
+        sourcePath: sourcePath || '/',
         ...(siteUrl && { siteUrl }),
       };
 
-      const connector = DriveConnectorFactory.createConnector(
-        platform,
-        testConfig,
-      );
+      const connector = DriveConnectorFactory.createConnector(platform, testConfig);
 
       const result = await connector.testConnection();
 
-      console.log(`Credentials test for ${platform}: ${result.success ? "success" : "failed"}`);
+      console.log(`Credentials test for ${platform}: ${result.success ? 'success' : 'failed'}`);
 
       return result;
     } catch (error) {
-      console.error("Credentials test failed:", error);
+      console.error('Credentials test failed:', error);
 
       return {
         success: false,
-        message: error.message || "Credentials test failed",
+        message: error.message || 'Credentials test failed',
         details: {
           platform: testData.platform,
-          error: error.name || "Unknown error",
+          error: error.name || 'Unknown error',
         },
       };
     }
@@ -198,18 +193,15 @@ class SourceService {
           : null,
       };
 
-      const connector = DriveConnectorFactory.createConnector(
-        source.platform,
-        decryptedConfig,
-      );
+      const connector = DriveConnectorFactory.createConnector(source.platform, decryptedConfig);
 
       const result = await connector.testConnection();
 
       await prisma.syncLog.create({
         data: {
           sourceId: id,
-          action: "test_connection",
-          status: result.success ? "success" : "error",
+          action: 'test_connection',
+          status: result.success ? 'success' : 'error',
           message: result.message,
           details: JSON.stringify(result.details || {}),
         },
@@ -217,13 +209,13 @@ class SourceService {
 
       return result;
     } catch (error) {
-      console.error("Connection test failed:", error);
+      console.error('Connection test failed:', error);
 
       await prisma.syncLog.create({
         data: {
           sourceId: id,
-          action: "test_connection",
-          status: "error",
+          action: 'test_connection',
+          status: 'error',
           message: error.message,
           details: JSON.stringify({ error: error.stack }),
         },
@@ -236,17 +228,16 @@ class SourceService {
   async syncSource(id) {
     try {
       // Dynamic import to avoid circular dependencies
-      const monitoringService = (await import("./monitoringService.js"))
-        .default;
+      const monitoringService = (await import('./monitoringService.js')).default;
 
       await monitoringService.syncSource(id);
 
       return {
         success: true,
-        message: "Sync completed successfully",
+        message: 'Sync completed successfully',
       };
     } catch (error) {
-      console.error("Sync failed:", error);
+      console.error('Sync failed:', error);
       throw error;
     }
   }
@@ -260,7 +251,7 @@ class SourceService {
       });
 
       const activeCount = await prisma.source.count({
-        where: { status: "active" },
+        where: { status: 'active' },
       });
 
       const recentJobs = await prisma.conversionJob.count({
@@ -277,7 +268,7 @@ class SourceService {
         recentJobs,
       };
     } catch (error) {
-      console.error("Error fetching stats:", error);
+      console.error('Error fetching stats:', error);
       throw error;
     }
   }
@@ -299,10 +290,7 @@ class SourceService {
         filters: { extensions: [], excludePatterns: [] },
       };
 
-      const connector = DriveConnectorFactory.createConnector(
-        "googledrive",
-        config,
-      );
+      const connector = DriveConnectorFactory.createConnector('googledrive', config);
       await connector.authenticate();
 
       const folders = await connector.listFolders(parentId);
@@ -312,7 +300,7 @@ class SourceService {
       console.log(`Found ${folders.length} folders`);
       return folders;
     } catch (error) {
-      console.error("Error fetching Google Drive folders:", error);
+      console.error('Error fetching Google Drive folders:', error);
       throw error;
     }
   }
@@ -331,10 +319,7 @@ class SourceService {
       let extensionsArray;
       if (Array.isArray(allowedExtensions)) {
         extensionsArray = allowedExtensions;
-      } else if (
-        typeof allowedExtensions === "object" &&
-        allowedExtensions !== null
-      ) {
+      } else if (typeof allowedExtensions === 'object' && allowedExtensions !== null) {
         extensionsArray = Object.values(allowedExtensions);
       } else {
         extensionsArray = [allowedExtensions];
@@ -347,10 +332,7 @@ class SourceService {
         filters: { extensions: extensionsArray, excludePatterns: [] },
       };
 
-      const connector = DriveConnectorFactory.createConnector(
-        "googledrive",
-        config,
-      );
+      const connector = DriveConnectorFactory.createConnector('googledrive', config);
       await connector.authenticate();
 
       const files = await connector.listFiles(folderId);
@@ -360,14 +342,12 @@ class SourceService {
           return false;
         }
         const fileName = file.name.toLowerCase();
-        const mimeType = file.mimeType || "";
+        const mimeType = file.mimeType || '';
 
         // Check for Google native docs (will be exported as DOCX/PDF)
-        const isGoogleDoc = mimeType === "application/vnd.google-apps.document";
-        const isGoogleSheet =
-          mimeType === "application/vnd.google-apps.spreadsheet";
-        const isGoogleSlide =
-          mimeType === "application/vnd.google-apps.presentation";
+        const isGoogleDoc = mimeType === 'application/vnd.google-apps.document';
+        const isGoogleSheet = mimeType === 'application/vnd.google-apps.spreadsheet';
+        const isGoogleSlide = mimeType === 'application/vnd.google-apps.presentation';
 
         if (isGoogleDoc || isGoogleSheet || isGoogleSlide) {
           return true;
@@ -375,7 +355,7 @@ class SourceService {
 
         // Check if the file matches an allowed extension
         const matches = extensionsArray.some((ext) => {
-          const extension = ext.toLowerCase().startsWith(".")
+          const extension = ext.toLowerCase().startsWith('.')
             ? ext.toLowerCase()
             : `.${ext.toLowerCase()}`;
           return fileName.endsWith(extension);
@@ -400,7 +380,7 @@ class SourceService {
         })),
       };
     } catch (error) {
-      console.error("Error previewing Google Drive files:", error);
+      console.error('Error previewing Google Drive files:', error);
       throw error;
     }
   }
@@ -420,7 +400,7 @@ class SourceService {
               originalPath: file.path || file.id,
               platform: source.platform,
             },
-            orderBy: { createdAt: "desc" },
+            orderBy: { createdAt: 'desc' },
           });
 
           if (existingFile && file.modifiedTime) {
@@ -433,17 +413,9 @@ class SourceService {
 
           console.log(`Processing file: ${file.name}`);
 
-          const tempPath = await connector.downloadFile(
-            file.id,
-            config.tempPath,
-          );
+          const tempPath = await connector.downloadFile(file.id, config.tempPath);
 
-          const job = await conversionService.createJob(
-            source.id,
-            file.name,
-            tempPath,
-            file.size,
-          );
+          const job = await conversionService.createJob(source.id, file.name, tempPath, file.size);
 
           console.log(`Created conversion job for: ${file.name}`);
 
@@ -458,8 +430,8 @@ class SourceService {
           await prisma.syncLog.create({
             data: {
               sourceId: source.id,
-              action: "file_process",
-              status: "error",
+              action: 'file_process',
+              status: 'error',
               message: `Failed to process ${file.name}: ${error.message}`,
               details: JSON.stringify({
                 fileName: file.name,
@@ -473,7 +445,7 @@ class SourceService {
       await prisma.syncLog.update({
         where: { id: syncLogId },
         data: {
-          status: errorCount === 0 ? "success" : "partial_success",
+          status: errorCount === 0 ? 'success' : 'partial_success',
           message: `Sync completed - processed ${processedCount}/${files.length} files (${errorCount} errors)`,
           details: JSON.stringify({
             processedFiles: processedCount,
@@ -485,17 +457,16 @@ class SourceService {
         },
       });
 
-      console.log(`Processing completed for source: ${source.name} (${processedCount}/${files.length} files converted)`);
-    } catch (error) {
-      console.error(
-        `❌ Critical error during file processing for source ${source.name}:`,
-        error,
+      console.log(
+        `Processing completed for source: ${source.name} (${processedCount}/${files.length} files converted)`,
       );
+    } catch (error) {
+      console.error(`❌ Critical error during file processing for source ${source.name}:`, error);
 
       await prisma.syncLog.update({
         where: { id: syncLogId },
         data: {
-          status: "error",
+          status: 'error',
           message: `Sync failed: ${error.message}`,
           details: JSON.stringify({
             error: error.stack,

--- a/backend/src/utils/configParser.js
+++ b/backend/src/utils/configParser.js
@@ -1,44 +1,44 @@
 export function parseSourceConfig(source) {
   if (!source || !source.config) {
-    throw new Error("Source configuration is missing");
+    throw new Error('Source configuration is missing');
   }
 
-  if (typeof source.config === "object") {
+  if (typeof source.config === 'object') {
     return source.config;
   }
 
-  if (typeof source.config === "string") {
+  if (typeof source.config === 'string') {
     try {
       return JSON.parse(source.config);
     } catch (error) {
-      console.error("Failed to parse source config JSON:", error);
+      console.error('Failed to parse source config JSON:', error);
       throw new Error(`Invalid source configuration JSON: ${error.message}`);
     }
   }
 
-  throw new Error("Source configuration must be an object or valid JSON string");
+  throw new Error('Source configuration must be an object or valid JSON string');
 }
 
 export function validateDestinationPath(destination) {
-  if (!destination || typeof destination !== "string") {
-    throw new Error("Destination must be a non-empty string");
+  if (!destination || typeof destination !== 'string') {
+    throw new Error('Destination must be a non-empty string');
   }
 
   const trimmed = destination.trim();
 
   if (trimmed.length === 0) {
-    throw new Error("Destination cannot be empty");
+    throw new Error('Destination cannot be empty');
   }
 
-  if (trimmed.includes("..")) {
+  if (trimmed.includes('..')) {
     throw new Error("Destination cannot contain '..' (path traversal prevention)");
   }
 
-  if (trimmed.startsWith("/") || trimmed.startsWith("\\")) {
+  if (trimmed.startsWith('/') || trimmed.startsWith('\\')) {
     throw new Error("Destination cannot start with '/' or '\\' (must be relative)");
   }
 
-  const dangerousChars = ["<", ">", ":", '"', "|", "?", "*"];
+  const dangerousChars = ['<', '>', ':', '"', '|', '?', '*'];
   for (const char of dangerousChars) {
     if (trimmed.includes(char)) {
       throw new Error(`Destination cannot contain '${char}' character`);
@@ -46,13 +46,13 @@ export function validateDestinationPath(destination) {
   }
 
   if (trimmed.length > 200) {
-    throw new Error("Destination path too long (max 200 characters)");
+    throw new Error('Destination path too long (max 200 characters)');
   }
 
   return trimmed;
 }
 
-export function getValidatedDestination(config, fallback = "default") {
+export function getValidatedDestination(config, fallback = 'default') {
   const destination = config.destination || fallback;
   return validateDestinationPath(destination);
 }
@@ -68,7 +68,7 @@ export function enrichSourceWithConfig(source) {
 
     return {
       ...source,
-      config: parsedConfig
+      config: parsedConfig,
     };
   } catch (error) {
     console.error(`Failed to enrich source ${source.id || 'unknown'}:`, error);

--- a/backend/src/utils/encryption.js
+++ b/backend/src/utils/encryption.js
@@ -1,55 +1,49 @@
-import crypto from "crypto";
-import fs from "fs";
-import config from "../config/env.js";
+import crypto from 'crypto';
+import fs from 'fs';
+import config from '../config/env.js';
 
-const ALGORITHM = "aes-256-gcm";
+const ALGORITHM = 'aes-256-gcm';
 const IV_LENGTH = 12; // Pour GCM
 const TAG_LENGTH = 16;
-const ENCODING = "base64";
+const ENCODING = 'base64';
 
 export function encryptCredentials(data) {
   try {
-    const text = typeof data === "string" ? data : JSON.stringify(data);
+    const text = typeof data === 'string' ? data : JSON.stringify(data);
 
     const iv = crypto.randomBytes(IV_LENGTH);
     const cipher = crypto.createCipheriv(ALGORITHM, config.encryptionKey, iv);
 
-    let encrypted = cipher.update(text, "utf8", ENCODING);
+    let encrypted = cipher.update(text, 'utf8', ENCODING);
     encrypted += cipher.final(ENCODING);
 
     const tag = cipher.getAuthTag();
 
-    const result = Buffer.concat([
-      iv,
-      tag,
-      Buffer.from(encrypted, ENCODING),
-    ]).toString(ENCODING);
+    const result = Buffer.concat([iv, tag, Buffer.from(encrypted, ENCODING)]).toString(ENCODING);
 
     return result;
   } catch (error) {
-    console.error("Encryption failed:", error);
-    throw new Error("Failed to encrypt credentials");
+    console.error('Encryption failed:', error);
+    throw new Error('Failed to encrypt credentials');
   }
 }
 
 export function decryptCredentials(encryptedData) {
   try {
     if (!encryptedData) {
-      throw new Error("No encrypted data provided");
+      throw new Error('No encrypted data provided');
     }
 
     const buffer = Buffer.from(encryptedData, ENCODING);
     const iv = buffer.subarray(0, IV_LENGTH);
     const tag = buffer.subarray(IV_LENGTH, IV_LENGTH + TAG_LENGTH);
-    const encrypted = buffer
-      .subarray(IV_LENGTH + TAG_LENGTH)
-      .toString(ENCODING);
+    const encrypted = buffer.subarray(IV_LENGTH + TAG_LENGTH).toString(ENCODING);
 
     const decipher = crypto.createDecipheriv(ALGORITHM, config.encryptionKey, iv);
     decipher.setAuthTag(tag);
 
-    let decrypted = decipher.update(encrypted, ENCODING, "utf8");
-    decrypted += decipher.final("utf8");
+    let decrypted = decipher.update(encrypted, ENCODING, 'utf8');
+    decrypted += decipher.final('utf8');
 
     try {
       return JSON.parse(decrypted);
@@ -57,51 +51,47 @@ export function decryptCredentials(encryptedData) {
       return decrypted;
     }
   } catch (error) {
-    console.error("Decryption failed:", error);
-    throw new Error("Failed to decrypt credentials");
+    console.error('Decryption failed:', error);
+    throw new Error('Failed to decrypt credentials');
   }
 }
 
 export function generateEncryptionKey() {
-  return crypto.randomBytes(32).toString("hex");
+  return crypto.randomBytes(32).toString('hex');
 }
 
 export function hashPassword(password) {
-  const salt = crypto.randomBytes(16).toString("hex");
-  const hash = crypto
-    .pbkdf2Sync(password, salt, 10000, 64, "sha512")
-    .toString("hex");
+  const salt = crypto.randomBytes(16).toString('hex');
+  const hash = crypto.pbkdf2Sync(password, salt, 10000, 64, 'sha512').toString('hex');
   return `${salt}:${hash}`;
 }
 
 export function verifyPassword(password, hashedPassword) {
   try {
-    const [salt, hash] = hashedPassword.split(":");
-    const verifyHash = crypto
-      .pbkdf2Sync(password, salt, 10000, 64, "sha512")
-      .toString("hex");
+    const [salt, hash] = hashedPassword.split(':');
+    const verifyHash = crypto.pbkdf2Sync(password, salt, 10000, 64, 'sha512').toString('hex');
     return hash === verifyHash;
   } catch (error) {
-    console.error("Password verification failed:", error);
+    console.error('Password verification failed:', error);
     return false;
   }
 }
 
 export async function generateFileChecksum(filePath) {
   return new Promise((resolve, reject) => {
-    const hash = crypto.createHash("md5");
+    const hash = crypto.createHash('md5');
 
     const stream = fs.createReadStream(filePath);
 
-    stream.on("data", (data) => {
+    stream.on('data', (data) => {
       hash.update(data);
     });
 
-    stream.on("end", () => {
-      resolve(hash.digest("hex"));
+    stream.on('end', () => {
+      resolve(hash.digest('hex'));
     });
 
-    stream.on("error", (error) => {
+    stream.on('error', (error) => {
       reject(error);
     });
   });

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,18 +1,18 @@
-import js from "@eslint/js";
-import globals from "globals";
-import reactHooks from "eslint-plugin-react-hooks";
-import reactRefresh from "eslint-plugin-react-refresh";
-import tseslint from "typescript-eslint";
-import { globalIgnores } from "eslint/config";
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import tseslint from 'typescript-eslint';
+import { globalIgnores } from 'eslint/config';
 
 export default tseslint.config([
-  globalIgnores(["dist"]),
+  globalIgnores(['dist']),
   {
-    files: ["**/*.{ts,tsx}"],
+    files: ['**/*.{ts,tsx}'],
     extends: [
       js.configs.recommended,
       tseslint.configs.recommended,
-      reactHooks.configs["recommended-latest"],
+      reactHooks.configs['recommended-latest'],
       reactRefresh.configs.vite,
     ],
     languageOptions: {
@@ -20,12 +20,12 @@ export default tseslint.config([
       globals: globals.browser,
     },
     rules: {
-      "@typescript-eslint/no-unused-vars": [
-        "error",
-        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
       ],
-      "@typescript-eslint/no-explicit-any": "off",
-      "react-refresh/only-export-components": "off",
+      '@typescript-eslint/no-explicit-any': 'off',
+      'react-refresh/only-export-components': 'off',
     },
   },
 ]);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -66,6 +66,7 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.3.0",
+        "prettier": "^3.8.3",
         "tw-animate-css": "^1.3.8",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.39.1",
@@ -5210,6 +5211,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prop-types": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -68,6 +70,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
+    "prettier": "^3.8.3",
     "tw-animate-css": "^1.3.8",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,19 +1,19 @@
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Settings } from "lucide-react";
-import "./App.css";
-import Doc2aiLogoUrl from "./assets/doc2ai-full.svg";
-import { useMonitoring } from "./hooks/useMonitoring";
-import AuthCallback from "./pages/AuthCallback";
-import Dashboard from "./pages/Dashboard";
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Settings } from 'lucide-react';
+import './App.css';
+import Doc2aiLogoUrl from './assets/doc2ai-full.svg';
+import { useMonitoring } from './hooks/useMonitoring';
+import AuthCallback from './pages/AuthCallback';
+import Dashboard from './pages/Dashboard';
 
 function App() {
   const { status: monitoringStatus } = useMonitoring();
 
   const isAuthCallback =
-    window.location.pathname === "/auth/callback" ||
-    window.location.search.includes("success=true") ||
-    window.location.search.includes("data=");
+    window.location.pathname === '/auth/callback' ||
+    window.location.search.includes('success=true') ||
+    window.location.search.includes('data=');
 
   return (
     <div className="min-h-screen bg-background flex flex-col">
@@ -38,9 +38,7 @@ function App() {
       <footer className="border-t">
         <div className="container mx-auto px-6 py-4">
           <div className="flex items-center justify-between text-sm text-muted-foreground">
-            <p>
-              Doc2AI - Automatic documentation converter for developers
-            </p>
+            <p>Doc2AI - Automatic documentation converter for developers</p>
             {monitoringStatus?.isRunning && (
               <div className="flex items-center gap-1">
                 <div className="h-2 w-2 bg-green-500 rounded-full animate-pulse" />

--- a/frontend/src/components/auth/GoogleAuthButton.tsx
+++ b/frontend/src/components/auth/GoogleAuthButton.tsx
@@ -1,26 +1,22 @@
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Button } from "@/components/ui/button";
-import { Loader2, LogOut } from "lucide-react";
-import React from "react";
-import { useGoogleAuth } from "../../hooks/useGoogleAuth";
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import { Loader2, LogOut } from 'lucide-react';
+import React from 'react';
+import { useGoogleAuth } from '../../hooks/useGoogleAuth';
 
 interface GoogleAuthButtonProps {
   onAuthSuccess?: (refreshToken: string, userEmail: string) => void;
   onAuthError?: (error: string) => void;
 }
 
-export function GoogleAuthButton({
-  onAuthSuccess,
-  onAuthError,
-}: GoogleAuthButtonProps) {
+export function GoogleAuthButton({ onAuthSuccess, onAuthError }: GoogleAuthButtonProps) {
   const { isConnecting, user, connect, disconnect, error } = useGoogleAuth();
 
   const handleConnect = async () => {
     try {
       await connect();
     } catch (err) {
-      const errorMessage =
-        err instanceof Error ? err.message : "Connection error";
+      const errorMessage = err instanceof Error ? err.message : 'Connection error';
       onAuthError?.(errorMessage);
     }
   };
@@ -49,9 +45,9 @@ export function GoogleAuthButton({
             <AvatarImage src={user.photoLink || undefined} alt={user.name} />
             <AvatarFallback className="bg-green-100 text-green-700">
               {user.name
-                .split(" ")
+                .split(' ')
                 .map((n) => n[0])
-                .join("")
+                .join('')
                 .slice(0, 2)}
             </AvatarFallback>
           </Avatar>

--- a/frontend/src/components/dashboard/SourceCard.tsx
+++ b/frontend/src/components/dashboard/SourceCard.tsx
@@ -7,24 +7,18 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+} from '@/components/ui/alert-dialog';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { format } from "date-fns";
+} from '@/components/ui/dropdown-menu';
+import { format } from 'date-fns';
 import {
   Calendar,
   CheckCircle,
@@ -37,10 +31,10 @@ import {
   TestTube,
   Trash2,
   XCircle,
-} from "lucide-react";
-import { useState } from "react";
-import { useSources } from "../../hooks/useSources";
-import type { Source } from "../../types/api";
+} from 'lucide-react';
+import { useState } from 'react';
+import { useSources } from '../../hooks/useSources';
+import type { Source } from '../../types/api';
 
 interface SourceCardProps {
   source: Source;
@@ -68,7 +62,7 @@ export function SourceCard({ source, onSync, onDelete }: SourceCardProps) {
     } catch (error) {
       setConnectionResult({
         success: false,
-        message: error instanceof Error ? error.message : "Test error",
+        message: error instanceof Error ? error.message : 'Test error',
       });
     } finally {
       setIsTestingConnection(false);
@@ -81,7 +75,7 @@ export function SourceCard({ source, onSync, onDelete }: SourceCardProps) {
       await syncSource(source.id);
       onSync?.(source.id);
     } catch (error) {
-      console.error("Sync failed:", error);
+      console.error('Sync failed:', error);
     } finally {
       setIsSyncing(false);
     }
@@ -93,17 +87,17 @@ export function SourceCard({ source, onSync, onDelete }: SourceCardProps) {
       setShowDeleteDialog(false);
       onDelete?.(source.id);
     } catch (error) {
-      console.error("Delete failed:", error);
+      console.error('Delete failed:', error);
     }
   };
 
   const getStatusBadge = (status: string) => {
     switch (status) {
-      case "active":
+      case 'active':
         return <Badge className="bg-green-100 text-green-800">Active</Badge>;
-      case "inactive":
+      case 'inactive':
         return <Badge variant="secondary">Inactive</Badge>;
-      case "error":
+      case 'error':
         return <Badge variant="destructive">Error</Badge>;
       default:
         return <Badge variant="outline">{status}</Badge>;
@@ -116,24 +110,24 @@ export function SourceCard({ source, onSync, onDelete }: SourceCardProps) {
 
   const getPlatformLabel = (platform: string) => {
     switch (platform) {
-      case "sharepoint":
-        return "Microsoft SharePoint";
-      case "onedrive":
-        return "Microsoft OneDrive";
-      case "googledrive":
-        return "Google Drive";
+      case 'sharepoint':
+        return 'Microsoft SharePoint';
+      case 'onedrive':
+        return 'Microsoft OneDrive';
+      case 'googledrive':
+        return 'Google Drive';
       default:
         return platform;
     }
   };
 
   const formatDate = (dateString?: string) => {
-    if (!dateString) return "Never";
+    if (!dateString) return 'Never';
     try {
       const date = new Date(dateString);
-      return format(date, "PPp");
+      return format(date, 'PPp');
     } catch {
-      return "Invalid date";
+      return 'Invalid date';
     }
   };
 
@@ -146,9 +140,7 @@ export function SourceCard({ source, onSync, onDelete }: SourceCardProps) {
               {getPlatformIcon(source.platform)}
               <div>
                 <CardTitle className="text-lg">{source.name}</CardTitle>
-                <CardDescription>
-                  {getPlatformLabel(source.platform)}
-                </CardDescription>
+                <CardDescription>{getPlatformLabel(source.platform)}</CardDescription>
               </div>
             </div>
             <div className="flex items-center gap-2">
@@ -160,10 +152,7 @@ export function SourceCard({ source, onSync, onDelete }: SourceCardProps) {
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
-                  <DropdownMenuItem
-                    onClick={handleTestConnection}
-                    disabled={isTestingConnection}
-                  >
+                  <DropdownMenuItem onClick={handleTestConnection} disabled={isTestingConnection}>
                     {isTestingConnection ? (
                       <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                     ) : (
@@ -202,8 +191,8 @@ export function SourceCard({ source, onSync, onDelete }: SourceCardProps) {
             <div
               className={`p-3 rounded-lg border text-sm ${
                 connectionResult.success
-                  ? "bg-green-50 border-green-200 text-green-800"
-                  : "bg-red-50 border-red-200 text-red-800"
+                  ? 'bg-green-50 border-green-200 text-green-800'
+                  : 'bg-red-50 border-red-200 text-red-800'
               }`}
             >
               <div className="flex items-center gap-2">
@@ -213,9 +202,7 @@ export function SourceCard({ source, onSync, onDelete }: SourceCardProps) {
                   <XCircle className="h-4 w-4" />
                 )}
                 <span className="font-medium">
-                  {connectionResult.success
-                    ? "Connection OK"
-                    : "Connection failed"}
+                  {connectionResult.success ? 'Connection OK' : 'Connection failed'}
                 </span>
               </div>
               <p className="mt-1">{connectionResult.message}</p>
@@ -228,9 +215,7 @@ export function SourceCard({ source, onSync, onDelete }: SourceCardProps) {
                 <FolderOpen className="h-4 w-4" />
                 <span>Source path:</span>
               </div>
-              <code className="bg-muted px-2 py-1 rounded text-xs">
-                {source.config.sourcePath}
-              </code>
+              <code className="bg-muted px-2 py-1 rounded text-xs">{source.config.sourcePath}</code>
             </div>
 
             {source.config.destination && (
@@ -254,40 +239,33 @@ export function SourceCard({ source, onSync, onDelete }: SourceCardProps) {
             </div>
           </div>
 
-          {source.config.filters?.extensions && (() => {
-            const exts = Array.isArray(source.config.filters.extensions)
-              ? source.config.filters.extensions
-              : Object.values(source.config.filters.extensions);
-            return exts.length > 0 ? (
-              <div>
-                <span className="text-xs text-muted-foreground">
-                  Extensions:
-                </span>
-                <div className="flex flex-wrap gap-1 mt-1">
-                  {exts.map((ext, index) => (
-                    <Badge
-                      key={index}
-                      variant="outline"
-                      className="text-xs"
-                    >
-                      {ext as string}
-                    </Badge>
-                  ))}
+          {source.config.filters?.extensions &&
+            (() => {
+              const exts = Array.isArray(source.config.filters.extensions)
+                ? source.config.filters.extensions
+                : Object.values(source.config.filters.extensions);
+              return exts.length > 0 ? (
+                <div>
+                  <span className="text-xs text-muted-foreground">Extensions:</span>
+                  <div className="flex flex-wrap gap-1 mt-1">
+                    {exts.map((ext, index) => (
+                      <Badge key={index} variant="outline" className="text-xs">
+                        {ext as string}
+                      </Badge>
+                    ))}
+                  </div>
                 </div>
-              </div>
-            ) : null;
-          })()}
+              ) : null;
+            })()}
 
           {source.jobs && source.jobs.length > 0 && (
             <div>
-              <span className="text-xs text-muted-foreground">
-                Recent jobs:
-              </span>
+              <span className="text-xs text-muted-foreground">Recent jobs:</span>
               <div className="flex items-center gap-2 mt-1">
                 <Badge variant="outline" className="text-xs">
-                  {source.jobs.length} job{source.jobs.length > 1 ? "s" : ""}
+                  {source.jobs.length} job{source.jobs.length > 1 ? 's' : ''}
                 </Badge>
-                {source.jobs.some((job) => job.status === "failed") && (
+                {source.jobs.some((job) => job.status === 'failed') && (
                   <Badge variant="destructive" className="text-xs">
                     Errors
                   </Badge>
@@ -303,17 +281,13 @@ export function SourceCard({ source, onSync, onDelete }: SourceCardProps) {
           <AlertDialogHeader>
             <AlertDialogTitle>Delete source?</AlertDialogTitle>
             <AlertDialogDescription>
-              This action is irreversible. All data associated with the
-              source "{source.name}" will be deleted, including conversion
-              history.
+              This action is irreversible. All data associated with the source "{source.name}" will
+              be deleted, including conversion history.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleDelete}
-              className="bg-red-600 hover:bg-red-700"
-            >
+            <AlertDialogAction onClick={handleDelete} className="bg-red-600 hover:bg-red-700">
               Delete
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/frontend/src/components/forms/AddSourceDialog.tsx
+++ b/frontend/src/components/forms/AddSourceDialog.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@/components/ui/button";
+import { Button } from '@/components/ui/button';
 import {
   Dialog,
   DialogContent,
@@ -6,7 +6,7 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
-} from "@/components/ui/dialog";
+} from '@/components/ui/dialog';
 import {
   Form,
   FormControl,
@@ -15,29 +15,29 @@ import {
   FormItem,
   FormLabel,
   FormMessage,
-} from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@/components/ui/select";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { CheckCircle, FileText, FolderOpen, Loader2, Plus } from "lucide-react";
-import React, { useState } from "react";
-import { useForm } from "react-hook-form";
-import * as z from "zod";
-import GoogleDriveIconUrl from "../../assets/GoogleDrive.svg";
-import OneDriveIconUrl from "../../assets/OneDrive.svg";
-import SharePointIconUrl from "../../assets/Sharepoint.svg";
-import { useGoogleAuth } from "../../hooks/useGoogleAuth";
-import { useSources } from "../../hooks/useSources";
-import type { CreateSourceRequest } from "../../types/api";
-import { GoogleAuthButton } from "../auth/GoogleAuthButton";
-import FilePreview from "./FilePreview";
-import GoogleDriveFolderPicker from "./GoogleDriveFolderPicker";
+} from '@/components/ui/select';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { CheckCircle, FileText, FolderOpen, Loader2, Plus } from 'lucide-react';
+import React, { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import * as z from 'zod';
+import GoogleDriveIconUrl from '../../assets/GoogleDrive.svg';
+import OneDriveIconUrl from '../../assets/OneDrive.svg';
+import SharePointIconUrl from '../../assets/Sharepoint.svg';
+import { useGoogleAuth } from '../../hooks/useGoogleAuth';
+import { useSources } from '../../hooks/useSources';
+import type { CreateSourceRequest } from '../../types/api';
+import { GoogleAuthButton } from '../auth/GoogleAuthButton';
+import FilePreview from './FilePreview';
+import GoogleDriveFolderPicker from './GoogleDriveFolderPicker';
 
 const GoogleDriveIcon = ({ className }: { className?: string }) => (
   <img src={GoogleDriveIconUrl} className={className} alt="Google Drive" />
@@ -52,30 +52,24 @@ const SharePointIcon = ({ className }: { className?: string }) => (
 );
 
 const sourceFormSchema = z.object({
-  name: z
-    .string()
-    .min(1, "Give your source a name")
-    .max(100, "Name is too long"),
-  platform: z.enum(["sharepoint", "googledrive", "onedrive"], {
-    message: "Choose your platform",
+  name: z.string().min(1, 'Give your source a name').max(100, 'Name is too long'),
+  platform: z.enum(['sharepoint', 'googledrive', 'onedrive'], {
+    message: 'Choose your platform',
   }),
-  sourcePath: z.string().min(1, "Specify the folder to monitor"),
-  siteUrl: z.string().url("Invalid URL").optional().or(z.literal("")),
+  sourcePath: z.string().min(1, 'Specify the folder to monitor'),
+  siteUrl: z.string().url('Invalid URL').optional().or(z.literal('')),
   destination: z
     .string()
-    .min(1, "Where do you want to save your files?")
-    .max(200, "Destination path is too long (max 200 characters)")
+    .min(1, 'Where do you want to save your files?')
+    .max(200, 'Destination path is too long (max 200 characters)')
     .regex(
       /^[a-zA-Z0-9/_-]+$/,
-      "Path can only contain letters, numbers, dashes, underscores, and slashes",
+      'Path can only contain letters, numbers, dashes, underscores, and slashes',
     )
+    .refine((val) => !val.includes('..'), "Path cannot contain '..' (security)")
     .refine(
-      (val) => !val.includes(".."),
-      "Path cannot contain '..' (security)",
-    )
-    .refine(
-      (val) => !val.startsWith("/") && !val.startsWith("\\"),
-      "Path must be relative (cannot start with / or \\)",
+      (val) => !val.startsWith('/') && !val.startsWith('\\'),
+      'Path must be relative (cannot start with / or \\)',
     ),
   extensions: z.string().optional(),
   excludePatterns: z.string().optional(),
@@ -88,10 +82,7 @@ interface AddSourceDialogProps {
   onSourceAdded?: () => void;
 }
 
-export function AddSourceDialog({
-  children,
-  onSourceAdded,
-}: AddSourceDialogProps) {
+export function AddSourceDialog({ children, onSourceAdded }: AddSourceDialogProps) {
   const [open, setOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showFolderPicker, setShowFolderPicker] = useState(false);
@@ -107,37 +98,33 @@ export function AddSourceDialog({
   const form = useForm<SourceFormData>({
     resolver: zodResolver(sourceFormSchema),
     defaultValues: {
-      name: "",
+      name: '',
       platform: undefined,
-      sourcePath: "/",
-      siteUrl: "",
-      destination: "",
-      extensions: ".docx,.pdf,.doc,.txt",
-      excludePatterns: "temp,~$,draft",
+      sourcePath: '/',
+      siteUrl: '',
+      destination: '',
+      extensions: '.docx,.pdf,.doc,.txt',
+      excludePatterns: 'temp,~$,draft',
     },
   });
 
-  const selectedPlatform = form.watch("platform");
+  const selectedPlatform = form.watch('platform');
 
   React.useEffect(() => {
-    if (selectedPlatform !== "googledrive") {
+    if (selectedPlatform !== 'googledrive') {
       setSelectedFolder(null);
     }
   }, [selectedPlatform]);
 
-  const handleFolderSelect = (folder: {
-    id: string;
-    name: string;
-    path: string;
-  }) => {
+  const handleFolderSelect = (folder: { id: string; name: string; path: string }) => {
     setSelectedFolder(folder);
-    form.setValue("sourcePath", folder.id);
+    form.setValue('sourcePath', folder.id);
     setShowFolderPicker(false);
   };
 
   const openFolderPicker = () => {
     if (!googleUser?.refreshToken) {
-      alert("Please connect with Google first");
+      alert('Please connect with Google first');
       return;
     }
     setShowFolderPicker(true);
@@ -147,13 +134,13 @@ export function AddSourceDialog({
     try {
       setIsSubmitting(true);
 
-      if (data.platform === "googledrive" && !googleUser?.refreshToken) {
-        alert("Please connect with Google first");
+      if (data.platform === 'googledrive' && !googleUser?.refreshToken) {
+        alert('Please connect with Google first');
         return;
       }
 
       let credentials: any = {};
-      if (data.platform === "googledrive") {
+      if (data.platform === 'googledrive') {
         credentials = {
           clientId: import.meta.env.VITE_DEFAULT_GOOGLE_CLIENT_ID,
           clientSecret: import.meta.env.VITE_DEFAULT_GOOGLE_CLIENT_SECRET,
@@ -170,13 +157,13 @@ export function AddSourceDialog({
       const destination = data.destination.trim();
 
       const extensions = data.extensions
-        ?.split(",")
+        ?.split(',')
         .map((e) => e.trim())
-        .filter((e) => e.length > 0) || [".docx", ".pdf", ".doc"];
+        .filter((e) => e.length > 0) || ['.docx', '.pdf', '.doc'];
 
       const excludePatterns =
         data.excludePatterns
-          ?.split(",")
+          ?.split(',')
           .map((p) => p.trim())
           .filter((p) => p.length > 0) || [];
 
@@ -186,8 +173,7 @@ export function AddSourceDialog({
         config: {
           credentials,
           sourcePath: data.sourcePath,
-          ...(data.platform === "sharepoint" &&
-            data.siteUrl && { siteUrl: data.siteUrl }),
+          ...(data.platform === 'sharepoint' && data.siteUrl && { siteUrl: data.siteUrl }),
           destination,
           filters: {
             extensions,
@@ -203,10 +189,9 @@ export function AddSourceDialog({
       setSelectedFolder(null);
       onSourceAdded?.();
     } catch (error) {
-      console.error("Error creating source:", error);
-      form.setError("platform", {
-        message:
-          error instanceof Error ? error.message : "Error creating source",
+      console.error('Error creating source:', error);
+      form.setError('platform', {
+        message: error instanceof Error ? error.message : 'Error creating source',
       });
     } finally {
       setIsSubmitting(false);
@@ -215,14 +200,14 @@ export function AddSourceDialog({
 
   const getPlatformIcon = (platform: string) => {
     switch (platform) {
-      case "googledrive":
+      case 'googledrive':
         return <GoogleDriveIcon className="w-5 h-5" />;
-      case "sharepoint":
+      case 'sharepoint':
         return <SharePointIcon className="w-5 h-5" />;
-      case "onedrive":
+      case 'onedrive':
         return <OneDriveIcon className="w-5 h-5" />;
       default:
-        return "📁";
+        return '📁';
     }
   };
 
@@ -236,8 +221,7 @@ export function AddSourceDialog({
             Add a document source
           </DialogTitle>
           <DialogDescription>
-            Connect your storage platform to automatically convert your
-            documents to Markdown
+            Connect your storage platform to automatically convert your documents to Markdown
           </DialogDescription>
         </DialogHeader>
 
@@ -259,10 +243,7 @@ export function AddSourceDialog({
                   render={({ field }) => (
                     <FormItem className="">
                       <FormLabel>Storage platform</FormLabel>
-                      <Select
-                        onValueChange={field.onChange}
-                        defaultValue={field.value}
-                      >
+                      <Select onValueChange={field.onChange} defaultValue={field.value}>
                         <FormControl>
                           <SelectTrigger>
                             <SelectValue placeholder="Where are your documents stored?" />
@@ -271,8 +252,7 @@ export function AddSourceDialog({
                         <SelectContent>
                           <SelectItem value="googledrive">
                             <span className="flex items-center gap-2">
-                              <GoogleDriveIcon className="w-4 h-4" /> Google
-                              Drive
+                              <GoogleDriveIcon className="w-4 h-4" /> Google Drive
                             </span>
                           </SelectItem>
                           <SelectItem value="sharepoint">
@@ -305,10 +285,7 @@ export function AddSourceDialog({
                     <FormItem className="flex-1">
                       <FormLabel>Source name</FormLabel>
                       <FormControl>
-                        <Input
-                          placeholder="e.g. Team Documents, User Guides..."
-                          {...field}
-                        />
+                        <Input placeholder="e.g. Team Documents, User Guides..." {...field} />
                       </FormControl>
                       <FormMessage />
                     </FormItem>
@@ -326,15 +303,15 @@ export function AddSourceDialog({
                   </div>
                   <h3 className="text-lg font-medium flex items-center gap-2">
                     Connect to {getPlatformIcon(selectedPlatform)}
-                    {selectedPlatform === "googledrive"
-                      ? "Google Drive"
-                      : selectedPlatform === "sharepoint"
-                        ? "SharePoint"
-                        : "OneDrive"}
+                    {selectedPlatform === 'googledrive'
+                      ? 'Google Drive'
+                      : selectedPlatform === 'sharepoint'
+                        ? 'SharePoint'
+                        : 'OneDrive'}
                   </h3>
                 </div>
 
-                {selectedPlatform === "googledrive" ? (
+                {selectedPlatform === 'googledrive' ? (
                   <GoogleAuthButton />
                 ) : (
                   <div className="p-4 bg-blue-50 border border-blue-200 rounded-lg">
@@ -345,8 +322,7 @@ export function AddSourceDialog({
                       </span>
                     </div>
                     <p className="text-sm text-blue-700">
-                      Microsoft authentication is already configured in
-                      the application
+                      Microsoft authentication is already configured in the application
                     </p>
                   </div>
                 )}
@@ -360,210 +336,181 @@ export function AddSourceDialog({
             )}
 
             {/* 3. Folder configuration */}
-            {selectedPlatform &&
-              (googleUser?.email || selectedPlatform !== "googledrive") && (
-                <div className="space-y-4">
-                  <div className="flex items-center gap-2">
-                    <div className="flex items-center justify-center w-6 h-6 bg-orange-100 text-orange-600 rounded-full text-sm font-semibold">
-                      3
-                    </div>
-                    <h3 className="text-lg font-medium">
-                      Folder configuration
-                    </h3>
+            {selectedPlatform && (googleUser?.email || selectedPlatform !== 'googledrive') && (
+              <div className="space-y-4">
+                <div className="flex items-center gap-2">
+                  <div className="flex items-center justify-center w-6 h-6 bg-orange-100 text-orange-600 rounded-full text-sm font-semibold">
+                    3
                   </div>
+                  <h3 className="text-lg font-medium">Folder configuration</h3>
+                </div>
 
+                <FormField
+                  control={form.control}
+                  name="sourcePath"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="flex items-center gap-2">
+                        <FolderOpen className="h-4 w-4" />
+                        Folder to monitor
+                      </FormLabel>
+                      <FormControl>
+                        {selectedPlatform === 'googledrive' ? (
+                          <div className="space-y-2">
+                            <div className="flex gap-2">
+                              <Input
+                                placeholder={
+                                  selectedFolder ? selectedFolder.name : 'Click to choose a folder'
+                                }
+                                value={selectedFolder ? selectedFolder.name : ''}
+                                readOnly
+                                onClick={openFolderPicker}
+                                className="cursor-pointer"
+                              />
+                              <Button
+                                type="button"
+                                variant="outline"
+                                onClick={openFolderPicker}
+                                disabled={!googleUser?.refreshToken}
+                              >
+                                <FolderOpen className="h-4 w-4" />
+                              </Button>
+                            </div>
+                            {selectedFolder && (
+                              <p className="text-sm text-muted-foreground">
+                                Path: {selectedFolder.path || '/'}
+                              </p>
+                            )}
+                          </div>
+                        ) : (
+                          <Input placeholder="/ (for entire drive)" {...field} />
+                        )}
+                      </FormControl>
+                      <FormDescription>
+                        {selectedPlatform === 'googledrive'
+                          ? 'Choose the folder to monitor in your Google Drive'
+                          : 'The folder whose documents you want to convert. "/" to monitor the entire drive.'}
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                {selectedPlatform === 'sharepoint' && (
                   <FormField
                     control={form.control}
-                    name="sourcePath"
+                    name="siteUrl"
                     render={({ field }) => (
                       <FormItem>
-                        <FormLabel className="flex items-center gap-2">
-                          <FolderOpen className="h-4 w-4" />
-                          Folder to monitor
-                        </FormLabel>
+                        <FormLabel>SharePoint site URL</FormLabel>
                         <FormControl>
-                          {selectedPlatform === "googledrive" ? (
-                            <div className="space-y-2">
-                              <div className="flex gap-2">
-                                <Input
-                                  placeholder={
-                                    selectedFolder
-                                      ? selectedFolder.name
-                                      : "Click to choose a folder"
-                                  }
-                                  value={
-                                    selectedFolder ? selectedFolder.name : ""
-                                  }
-                                  readOnly
-                                  onClick={openFolderPicker}
-                                  className="cursor-pointer"
-                                />
-                                <Button
-                                  type="button"
-                                  variant="outline"
-                                  onClick={openFolderPicker}
-                                  disabled={!googleUser?.refreshToken}
-                                >
-                                  <FolderOpen className="h-4 w-4" />
-                                </Button>
-                              </div>
-                              {selectedFolder && (
-                                <p className="text-sm text-muted-foreground">
-                                  Path: {selectedFolder.path || "/"}
-                                </p>
-                              )}
-                            </div>
-                          ) : (
-                            <Input
-                              placeholder="/ (for entire drive)"
-                              {...field}
-                            />
-                          )}
+                          <Input
+                            placeholder="https://mycompany.sharepoint.com/sites/documents"
+                            {...field}
+                          />
                         </FormControl>
-                        <FormDescription>
-                          {selectedPlatform === "googledrive"
-                            ? "Choose the folder to monitor in your Google Drive"
-                            : 'The folder whose documents you want to convert. "/" to monitor the entire drive.'}
-                        </FormDescription>
+                        <FormDescription>The full URL of your SharePoint site</FormDescription>
                         <FormMessage />
                       </FormItem>
                     )}
                   />
+                )}
 
-                  {selectedPlatform === "sharepoint" && (
-                    <FormField
-                      control={form.control}
-                      name="siteUrl"
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormLabel>SharePoint site URL</FormLabel>
-                          <FormControl>
-                            <Input
-                              placeholder="https://mycompany.sharepoint.com/sites/documents"
-                              {...field}
-                            />
-                          </FormControl>
-                          <FormDescription>
-                            The full URL of your SharePoint site
-                          </FormDescription>
-                          <FormMessage />
-                        </FormItem>
-                      )}
+                <FormField
+                  control={form.control}
+                  name="destination"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Where to save converted files</FormLabel>
+                      <FormControl>
+                        <div className="flex items-center">
+                          <div className="px-3 py-2 bg-muted border border-r-0 rounded-l-md text-sm text-muted-foreground font-mono">
+                            {import.meta.env.VITE_EXPORT_PATH || './exports'}/
+                          </div>
+                          <Input
+                            placeholder="doc2ai-exports"
+                            {...field}
+                            className="rounded-l-none border-l-0"
+                          />
+                        </div>
+                      </FormControl>
+                      <FormDescription>
+                        Relative folder within your EXPORT_PATH for converted files. Example:
+                        "doc2ai-exports"
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                {selectedPlatform === 'googledrive' &&
+                  selectedFolder &&
+                  googleUser?.refreshToken && (
+                    <FilePreview
+                      folderId={selectedFolder.id}
+                      folderName={selectedFolder.name}
+                      credentials={{
+                        clientId: import.meta.env.VITE_DEFAULT_GOOGLE_CLIENT_ID,
+                        clientSecret: import.meta.env.VITE_DEFAULT_GOOGLE_CLIENT_SECRET,
+                        refreshToken: googleUser.refreshToken,
+                      }}
+                      extensions={
+                        form
+                          .watch('extensions')
+                          ?.split(',')
+                          .map((e) => e.trim())
+                          .filter((e) => e.length > 0) || ['.docx', '.pdf', '.doc', '.txt']
+                      }
                     />
                   )}
+              </div>
+            )}
 
+            {/* 4. Advanced filters (optional) */}
+            {selectedPlatform && (googleUser?.email || selectedPlatform !== 'googledrive') && (
+              <details className="space-y-4">
+                <summary className="flex items-center gap-2 cursor-pointer">
+                  <div className="flex items-center justify-center w-6 h-6 bg-gray-100 text-gray-600 rounded-full text-sm font-semibold">
+                    4
+                  </div>
+                  <h3 className="text-lg font-medium">Advanced filters (optional)</h3>
+                </summary>
+
+                <div className="ml-8 space-y-4">
                   <FormField
                     control={form.control}
-                    name="destination"
+                    name="extensions"
                     render={({ field }) => (
                       <FormItem>
-                        <FormLabel>
-                          Where to save converted files
-                        </FormLabel>
+                        <FormLabel>File types to process</FormLabel>
                         <FormControl>
-                          <div className="flex items-center">
-                            <div className="px-3 py-2 bg-muted border border-r-0 rounded-l-md text-sm text-muted-foreground font-mono">
-                              {import.meta.env.VITE_EXPORT_PATH || "./exports"}/
-                            </div>
-                            <Input
-                              placeholder="doc2ai-exports"
-                              {...field}
-                              className="rounded-l-none border-l-0"
-                            />
-                          </div>
+                          <Input placeholder=".docx,.pdf,.doc,.txt" {...field} />
                         </FormControl>
-                        <FormDescription>
-                          Relative folder within your EXPORT_PATH for converted
-                          files. Example: "doc2ai-exports"
-                        </FormDescription>
+                        <FormDescription>File extensions (comma-separated)</FormDescription>
                         <FormMessage />
                       </FormItem>
                     )}
                   />
 
-                  {selectedPlatform === "googledrive" &&
-                    selectedFolder &&
-                    googleUser?.refreshToken && (
-                      <FilePreview
-                        folderId={selectedFolder.id}
-                        folderName={selectedFolder.name}
-                        credentials={{
-                          clientId: import.meta.env
-                            .VITE_DEFAULT_GOOGLE_CLIENT_ID,
-                          clientSecret: import.meta.env
-                            .VITE_DEFAULT_GOOGLE_CLIENT_SECRET,
-                          refreshToken: googleUser.refreshToken,
-                        }}
-                        extensions={
-                          form
-                            .watch("extensions")
-                            ?.split(",")
-                            .map((e) => e.trim())
-                            .filter((e) => e.length > 0) || [
-                            ".docx",
-                            ".pdf",
-                            ".doc",
-                            ".txt",
-                          ]
-                        }
-                      />
+                  <FormField
+                    control={form.control}
+                    name="excludePatterns"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Files to ignore</FormLabel>
+                        <FormControl>
+                          <Input placeholder="temp,draft,~$" {...field} />
+                        </FormControl>
+                        <FormDescription>
+                          Words in file names to exclude (comma-separated)
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
                     )}
+                  />
                 </div>
-              )}
-
-            {/* 4. Advanced filters (optional) */}
-            {selectedPlatform &&
-              (googleUser?.email || selectedPlatform !== "googledrive") && (
-                <details className="space-y-4">
-                  <summary className="flex items-center gap-2 cursor-pointer">
-                    <div className="flex items-center justify-center w-6 h-6 bg-gray-100 text-gray-600 rounded-full text-sm font-semibold">
-                      4
-                    </div>
-                    <h3 className="text-lg font-medium">
-                      Advanced filters (optional)
-                    </h3>
-                  </summary>
-
-                  <div className="ml-8 space-y-4">
-                    <FormField
-                      control={form.control}
-                      name="extensions"
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormLabel>File types to process</FormLabel>
-                          <FormControl>
-                            <Input
-                              placeholder=".docx,.pdf,.doc,.txt"
-                              {...field}
-                            />
-                          </FormControl>
-                          <FormDescription>
-                            File extensions (comma-separated)
-                          </FormDescription>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-
-                    <FormField
-                      control={form.control}
-                      name="excludePatterns"
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormLabel>Files to ignore</FormLabel>
-                          <FormControl>
-                            <Input placeholder="temp,draft,~$" {...field} />
-                          </FormControl>
-                          <FormDescription>
-                            Words in file names to exclude (comma-separated)
-                          </FormDescription>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-                  </div>
-                </details>
-              )}
+              </details>
+            )}
 
             {/* Action buttons */}
             <div className="flex gap-3 pt-4">
@@ -578,8 +525,7 @@ export function AddSourceDialog({
               <Button
                 type="submit"
                 disabled={
-                  isSubmitting ||
-                  (selectedPlatform === "googledrive" && !googleUser?.email)
+                  isSubmitting || (selectedPlatform === 'googledrive' && !googleUser?.email)
                 }
                 className="flex-1"
               >
@@ -599,7 +545,7 @@ export function AddSourceDialog({
           </form>
         </Form>
 
-        {selectedPlatform === "googledrive" && googleUser?.refreshToken && (
+        {selectedPlatform === 'googledrive' && googleUser?.refreshToken && (
           <GoogleDriveFolderPicker
             isOpen={showFolderPicker}
             onClose={() => setShowFolderPicker(false)}

--- a/frontend/src/components/forms/FilePreview.tsx
+++ b/frontend/src/components/forms/FilePreview.tsx
@@ -1,16 +1,10 @@
-import { Badge } from "@/components/ui/badge";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { ScrollArea } from "@/components/ui/scroll-area";
-import { FileText, Loader2 } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
-import { toast } from "sonner";
-import { sourcesApi } from "../../services/api";
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { FileText, Loader2 } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import { sourcesApi } from '../../services/api';
 
 interface FilePreviewItem {
   id: string;
@@ -37,12 +31,7 @@ interface FilePreviewProps {
   extensions: string[];
 }
 
-export function FilePreview({
-  folderId,
-  folderName,
-  credentials,
-  extensions,
-}: FilePreviewProps) {
+export function FilePreview({ folderId, folderName, credentials, extensions }: FilePreviewProps) {
   const [previewData, setPreviewData] = useState<FilePreviewData | null>(null);
   const [loading, setLoading] = useState(false);
 
@@ -53,15 +42,11 @@ export function FilePreview({
 
     setLoading(true);
     try {
-      const data = await sourcesApi.previewGoogleDriveFiles(
-        folderId,
-        credentials,
-        extensions,
-      );
+      const data = await sourcesApi.previewGoogleDriveFiles(folderId, credentials, extensions);
       setPreviewData(data);
     } catch (error) {
-      console.error("Error fetching file preview:", error);
-      toast.error("Error loading file preview");
+      console.error('Error fetching file preview:', error);
+      toast.error('Error loading file preview');
       setPreviewData(null);
     } finally {
       setLoading(false);
@@ -75,20 +60,20 @@ export function FilePreview({
   }, [folderId, credentials?.refreshToken, extensions, fetchFilePreview]);
 
   const formatFileSize = (bytes: number) => {
-    if (bytes === 0) return "0 B";
+    if (bytes === 0) return '0 B';
     const k = 1024;
-    const sizes = ["B", "KB", "MB", "GB"];
+    const sizes = ['B', 'KB', 'MB', 'GB'];
     const i = Math.floor(Math.log(bytes) / Math.log(k));
-    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + " " + sizes[i];
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
   };
 
   const getFileIcon = (mimeType: string) => {
-    if (!mimeType) return "📄";
-    if (mimeType.includes("pdf")) return "📄";
-    if (mimeType.includes("word")) return "📝";
-    if (mimeType.includes("document")) return "📝";
-    if (mimeType.includes("text")) return "📄";
-    return "📄";
+    if (!mimeType) return '📄';
+    if (mimeType.includes('pdf')) return '📄';
+    if (mimeType.includes('word')) return '📝';
+    if (mimeType.includes('document')) return '📝';
+    if (mimeType.includes('text')) return '📄';
+    return '📄';
   };
 
   if (!folderId) {
@@ -103,8 +88,7 @@ export function FilePreview({
           File preview
         </CardTitle>
         <CardDescription>
-          Files that will be automatically converted from the "{folderName}"
-          folder
+          Files that will be automatically converted from the "{folderName}" folder
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -118,15 +102,11 @@ export function FilePreview({
             <div className="flex gap-4">
               <Badge variant="outline">
                 {previewData.totalFiles} file
-                {previewData.totalFiles > 1 ? "s" : ""} total
+                {previewData.totalFiles > 1 ? 's' : ''} total
               </Badge>
-              <Badge
-                variant={
-                  previewData.convertibleFiles > 0 ? "default" : "secondary"
-                }
-              >
+              <Badge variant={previewData.convertibleFiles > 0 ? 'default' : 'secondary'}>
                 {previewData.convertibleFiles} convertible file
-                {previewData.convertibleFiles > 1 ? "s" : ""}
+                {previewData.convertibleFiles > 1 ? 's' : ''}
               </Badge>
             </div>
 
@@ -139,34 +119,25 @@ export function FilePreview({
                       className="flex items-center justify-between p-2 rounded-lg border bg-background"
                     >
                       <div className="flex items-center space-x-3">
-                        <span className="text-lg">
-                          {getFileIcon(file.mimeType)}
-                        </span>
+                        <span className="text-lg">{getFileIcon(file.mimeType)}</span>
                         <div>
-                          <p className="font-medium text-sm">
-                            {file.name || "Unnamed file"}
-                          </p>
+                          <p className="font-medium text-sm">{file.name || 'Unnamed file'}</p>
                           <p className="text-xs text-muted-foreground">
-                            {file.size
-                              ? formatFileSize(file.size)
-                              : "Unknown size"}{" "}
-                            • Modified{" "}
+                            {file.size ? formatFileSize(file.size) : 'Unknown size'} • Modified{' '}
                             {file.modifiedTime
-                              ? new Date(file.modifiedTime).toLocaleDateString(
-                                  "en-US",
-                                )
-                              : "Unknown date"}
+                              ? new Date(file.modifiedTime).toLocaleDateString('en-US')
+                              : 'Unknown date'}
                           </p>
                         </div>
                       </div>
                       <Badge variant="outline" className="text-xs">
-                        {file.mimeType?.includes("pdf")
-                          ? "PDF"
-                          : file.mimeType?.includes("word")
-                            ? "Word"
-                            : file.mimeType?.includes("document")
-                              ? "Google Docs"
-                              : "Document"}
+                        {file.mimeType?.includes('pdf')
+                          ? 'PDF'
+                          : file.mimeType?.includes('word')
+                            ? 'Word'
+                            : file.mimeType?.includes('document')
+                              ? 'Google Docs'
+                              : 'Document'}
                       </Badge>
                     </div>
                   ))}
@@ -176,9 +147,7 @@ export function FilePreview({
               <div className="text-center py-6 text-muted-foreground">
                 <FileText className="h-12 w-12 mx-auto mb-2 opacity-50" />
                 <p>No convertible files found</p>
-                <p className="text-sm">
-                  Supported formats: {extensions.join(", ")}
-                </p>
+                <p className="text-sm">Supported formats: {extensions.join(', ')}</p>
               </div>
             )}
           </div>

--- a/frontend/src/components/forms/GoogleDriveFolderPicker.tsx
+++ b/frontend/src/components/forms/GoogleDriveFolderPicker.tsx
@@ -1,17 +1,17 @@
-import { Button } from "@/components/ui/button";
+import { Button } from '@/components/ui/button';
 import {
   Dialog,
   DialogContent,
   DialogDescription,
   DialogHeader,
   DialogTitle,
-} from "@/components/ui/dialog";
-import { ScrollArea } from "@/components/ui/scroll-area";
-import { Separator } from "@/components/ui/separator";
-import { ChevronRight, Folder, FolderOpen, Loader2 } from "lucide-react";
-import React, { useCallback, useEffect, useState } from "react";
-import { toast } from "sonner";
-import { sourcesApi } from "../../services/api";
+} from '@/components/ui/dialog';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Separator } from '@/components/ui/separator';
+import { ChevronRight, Folder, FolderOpen, Loader2 } from 'lucide-react';
+import React, { useCallback, useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import { sourcesApi } from '../../services/api';
 
 interface GoogleDriveFolder {
   id: string;
@@ -19,7 +19,7 @@ interface GoogleDriveFolder {
   path: string;
   modifiedTime: string;
   parents?: string[];
-  type: "folder";
+  type: 'folder';
 }
 
 interface GoogleDriveFolderPickerProps {
@@ -46,28 +46,25 @@ export function GoogleDriveFolderPicker({
 }: GoogleDriveFolderPickerProps) {
   const [folders, setFolders] = useState<GoogleDriveFolder[]>([]);
   const [loading, setLoading] = useState(false);
-  const [currentFolderId, setCurrentFolderId] = useState("root");
+  const [currentFolderId, setCurrentFolderId] = useState('root');
   const [breadcrumbs, setBreadcrumbs] = useState<BreadcrumbItem[]>([
-    { id: "root", name: "My Drive" },
+    { id: 'root', name: 'My Drive' },
   ]);
 
   const fetchFolders = useCallback(
     async (folderId: string) => {
       if (!credentials?.refreshToken) {
-        toast.error("Google Drive credentials missing");
+        toast.error('Google Drive credentials missing');
         return;
       }
 
       setLoading(true);
       try {
-        const folders = await sourcesApi.getGoogleDriveFolders(
-          folderId,
-          credentials,
-        );
+        const folders = await sourcesApi.getGoogleDriveFolders(folderId, credentials);
         setFolders(folders);
       } catch (error) {
-        console.error("Error fetching folders:", error);
-        toast.error("Error loading Google Drive folders");
+        console.error('Error fetching folders:', error);
+        toast.error('Error loading Google Drive folders');
         setFolders([]);
       } finally {
         setLoading(false);
@@ -101,9 +98,9 @@ export function GoogleDriveFolderPicker({
       path: `/${breadcrumbs
         .slice(1)
         .map((b) => b.name)
-        .join("/")}`,
+        .join('/')}`,
       modifiedTime: new Date().toISOString(),
-      type: "folder",
+      type: 'folder',
     });
     onClose();
   };
@@ -137,9 +134,7 @@ export function GoogleDriveFolderPicker({
                 >
                   {breadcrumb.name}
                 </button>
-                {index < breadcrumbs.length - 1 && (
-                  <ChevronRight className="h-4 w-4" />
-                )}
+                {index < breadcrumbs.length - 1 && <ChevronRight className="h-4 w-4" />}
               </React.Fragment>
             ))}
           </div>
@@ -148,16 +143,10 @@ export function GoogleDriveFolderPicker({
 
           <div className="flex justify-between items-center">
             <div className="text-sm text-muted-foreground">
-              Current folder:{" "}
-              <span className="font-medium">
-                {breadcrumbs[breadcrumbs.length - 1].name}
-              </span>
+              Current folder:{' '}
+              <span className="font-medium">{breadcrumbs[breadcrumbs.length - 1].name}</span>
             </div>
-            <Button
-              onClick={handleSelectCurrentFolder}
-              variant="outline"
-              size="sm"
-            >
+            <Button onClick={handleSelectCurrentFolder} variant="outline" size="sm">
               Select this folder
             </Button>
           </div>
@@ -174,9 +163,7 @@ export function GoogleDriveFolderPicker({
               <div className="text-center py-8 text-muted-foreground">
                 <Folder className="h-12 w-12 mx-auto mb-2 opacity-50" />
                 <p>No subfolders found</p>
-                <p className="text-sm">
-                  You can select the current folder above
-                </p>
+                <p className="text-sm">You can select the current folder above</p>
               </div>
             ) : (
               <div className="space-y-2">
@@ -193,10 +180,7 @@ export function GoogleDriveFolderPicker({
                       <div>
                         <p className="font-medium">{folder.name}</p>
                         <p className="text-sm text-muted-foreground">
-                          Modified{" "}
-                          {new Date(folder.modifiedTime).toLocaleDateString(
-                            "en-US",
-                          )}
+                          Modified {new Date(folder.modifiedTime).toLocaleDateString('en-US')}
                         </p>
                       </div>
                     </div>
@@ -211,11 +195,7 @@ export function GoogleDriveFolderPicker({
                       >
                         Select
                       </Button>
-                      <Button
-                        onClick={() => handleFolderClick(folder)}
-                        variant="ghost"
-                        size="sm"
-                      >
+                      <Button onClick={() => handleFolderClick(folder)} variant="ghost" size="sm">
                         <ChevronRight className="h-4 w-4" />
                       </Button>
                     </div>

--- a/frontend/src/components/ui/accordion.tsx
+++ b/frontend/src/components/ui/accordion.tsx
@@ -1,13 +1,11 @@
-import * as React from "react"
-import * as AccordionPrimitive from "@radix-ui/react-accordion"
-import { ChevronDownIcon } from "lucide-react"
+import * as React from 'react';
+import * as AccordionPrimitive from '@radix-ui/react-accordion';
+import { ChevronDownIcon } from 'lucide-react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-function Accordion({
-  ...props
-}: React.ComponentProps<typeof AccordionPrimitive.Root>) {
-  return <AccordionPrimitive.Root data-slot="accordion" {...props} />
+function Accordion({ ...props }: React.ComponentProps<typeof AccordionPrimitive.Root>) {
+  return <AccordionPrimitive.Root data-slot="accordion" {...props} />;
 }
 
 function AccordionItem({
@@ -17,10 +15,10 @@ function AccordionItem({
   return (
     <AccordionPrimitive.Item
       data-slot="accordion-item"
-      className={cn("border-b last:border-b-0", className)}
+      className={cn('border-b last:border-b-0', className)}
       {...props}
     />
-  )
+  );
 }
 
 function AccordionTrigger({
@@ -33,8 +31,8 @@ function AccordionTrigger({
       <AccordionPrimitive.Trigger
         data-slot="accordion-trigger"
         className={cn(
-          "focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",
-          className
+          'focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180',
+          className,
         )}
         {...props}
       >
@@ -42,7 +40,7 @@ function AccordionTrigger({
         <ChevronDownIcon className="text-muted-foreground pointer-events-none size-4 shrink-0 translate-y-0.5 transition-transform duration-200" />
       </AccordionPrimitive.Trigger>
     </AccordionPrimitive.Header>
-  )
+  );
 }
 
 function AccordionContent({
@@ -56,9 +54,9 @@ function AccordionContent({
       className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm"
       {...props}
     >
-      <div className={cn("pt-0 pb-4", className)}>{children}</div>
+      <div className={cn('pt-0 pb-4', className)}>{children}</div>
     </AccordionPrimitive.Content>
-  )
+  );
 }
 
-export { Accordion, AccordionItem, AccordionTrigger, AccordionContent }
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent };

--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -1,29 +1,21 @@
-import * as React from "react"
-import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+import * as React from 'react';
+import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
 
-import { cn } from "@/lib/utils"
-import { buttonVariants } from "@/components/ui/button"
+import { cn } from '@/lib/utils';
+import { buttonVariants } from '@/components/ui/button';
 
-function AlertDialog({
-  ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
-  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+function AlertDialog({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
 }
 
 function AlertDialogTrigger({
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
-  return (
-    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
-  )
+  return <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />;
 }
 
-function AlertDialogPortal({
-  ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
-  return (
-    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
-  )
+function AlertDialogPortal({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />;
 }
 
 function AlertDialogOverlay({
@@ -34,12 +26,12 @@ function AlertDialogOverlay({
     <AlertDialogPrimitive.Overlay
       data-slot="alert-dialog-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
-        className
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function AlertDialogContent({
@@ -52,42 +44,33 @@ function AlertDialogContent({
       <AlertDialogPrimitive.Content
         data-slot="alert-dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
-          className
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          className,
         )}
         {...props}
       />
     </AlertDialogPortal>
-  )
+  );
 }
 
-function AlertDialogHeader({
-  className,
-  ...props
-}: React.ComponentProps<"div">) {
+function AlertDialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="alert-dialog-header"
-      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
       {...props}
     />
-  )
+  );
 }
 
-function AlertDialogFooter({
-  className,
-  ...props
-}: React.ComponentProps<"div">) {
+function AlertDialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="alert-dialog-footer"
-      className={cn(
-        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
-        className
-      )}
+      className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
       {...props}
     />
-  )
+  );
 }
 
 function AlertDialogTitle({
@@ -97,10 +80,10 @@ function AlertDialogTitle({
   return (
     <AlertDialogPrimitive.Title
       data-slot="alert-dialog-title"
-      className={cn("text-lg font-semibold", className)}
+      className={cn('text-lg font-semibold', className)}
       {...props}
     />
-  )
+  );
 }
 
 function AlertDialogDescription({
@@ -110,22 +93,17 @@ function AlertDialogDescription({
   return (
     <AlertDialogPrimitive.Description
       data-slot="alert-dialog-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn('text-muted-foreground text-sm', className)}
       {...props}
     />
-  )
+  );
 }
 
 function AlertDialogAction({
   className,
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
-  return (
-    <AlertDialogPrimitive.Action
-      className={cn(buttonVariants(), className)}
-      {...props}
-    />
-  )
+  return <AlertDialogPrimitive.Action className={cn(buttonVariants(), className)} {...props} />;
 }
 
 function AlertDialogCancel({
@@ -134,10 +112,10 @@ function AlertDialogCancel({
 }: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
   return (
     <AlertDialogPrimitive.Cancel
-      className={cn(buttonVariants({ variant: "outline" }), className)}
+      className={cn(buttonVariants({ variant: 'outline' }), className)}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -152,4 +130,4 @@ export {
   AlertDialogDescription,
   AlertDialogAction,
   AlertDialogCancel,
-}
+};

--- a/frontend/src/components/ui/alert.tsx
+++ b/frontend/src/components/ui/alert.tsx
@@ -1,29 +1,29 @@
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 const alertVariants = cva(
-  "relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
+  'relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current',
   {
     variants: {
       variant: {
-        default: "bg-card text-card-foreground",
+        default: 'bg-card text-card-foreground',
         destructive:
-          "text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90",
+          'text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90',
       },
     },
     defaultVariants: {
-      variant: "default",
+      variant: 'default',
     },
-  }
-)
+  },
+);
 
 function Alert({
   className,
   variant,
   ...props
-}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+}: React.ComponentProps<'div'> & VariantProps<typeof alertVariants>) {
   return (
     <div
       data-slot="alert"
@@ -31,36 +31,30 @@ function Alert({
       className={cn(alertVariants({ variant }), className)}
       {...props}
     />
-  )
+  );
 }
 
-function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+function AlertTitle({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="alert-title"
-      className={cn(
-        "col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight",
-        className
-      )}
+      className={cn('col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight', className)}
       {...props}
     />
-  )
+  );
 }
 
-function AlertDescription({
-  className,
-  ...props
-}: React.ComponentProps<"div">) {
+function AlertDescription({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="alert-description"
       className={cn(
-        "text-muted-foreground col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed",
-        className
+        'text-muted-foreground col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Alert, AlertTitle, AlertDescription }
+export { Alert, AlertTitle, AlertDescription };

--- a/frontend/src/components/ui/aspect-ratio.tsx
+++ b/frontend/src/components/ui/aspect-ratio.tsx
@@ -1,11 +1,9 @@
-"use client"
+'use client';
 
-import * as AspectRatioPrimitive from "@radix-ui/react-aspect-ratio"
+import * as AspectRatioPrimitive from '@radix-ui/react-aspect-ratio';
 
-function AspectRatio({
-  ...props
-}: React.ComponentProps<typeof AspectRatioPrimitive.Root>) {
-  return <AspectRatioPrimitive.Root data-slot="aspect-ratio" {...props} />
+function AspectRatio({ ...props }: React.ComponentProps<typeof AspectRatioPrimitive.Root>) {
+  return <AspectRatioPrimitive.Root data-slot="aspect-ratio" {...props} />;
 }
 
-export { AspectRatio }
+export { AspectRatio };

--- a/frontend/src/components/ui/avatar.tsx
+++ b/frontend/src/components/ui/avatar.tsx
@@ -1,35 +1,26 @@
-import * as React from "react"
-import * as AvatarPrimitive from "@radix-ui/react-avatar"
+import * as React from 'react';
+import * as AvatarPrimitive from '@radix-ui/react-avatar';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-function Avatar({
-  className,
-  ...props
-}: React.ComponentProps<typeof AvatarPrimitive.Root>) {
+function Avatar({ className, ...props }: React.ComponentProps<typeof AvatarPrimitive.Root>) {
   return (
     <AvatarPrimitive.Root
       data-slot="avatar"
-      className={cn(
-        "relative flex size-8 shrink-0 overflow-hidden rounded-full",
-        className
-      )}
+      className={cn('relative flex size-8 shrink-0 overflow-hidden rounded-full', className)}
       {...props}
     />
-  )
+  );
 }
 
-function AvatarImage({
-  className,
-  ...props
-}: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+function AvatarImage({ className, ...props }: React.ComponentProps<typeof AvatarPrimitive.Image>) {
   return (
     <AvatarPrimitive.Image
       data-slot="avatar-image"
-      className={cn("aspect-square size-full", className)}
+      className={cn('aspect-square size-full', className)}
       {...props}
     />
-  )
+  );
 }
 
 function AvatarFallback({
@@ -39,13 +30,10 @@ function AvatarFallback({
   return (
     <AvatarPrimitive.Fallback
       data-slot="avatar-fallback"
-      className={cn(
-        "bg-muted flex size-full items-center justify-center rounded-full",
-        className
-      )}
+      className={cn('bg-muted flex size-full items-center justify-center rounded-full', className)}
       {...props}
     />
-  )
+  );
 }
 
-export { Avatar, AvatarImage, AvatarFallback }
+export { Avatar, AvatarImage, AvatarFallback };

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -1,46 +1,39 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 const badgeVariants = cva(
-  "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  'inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden',
   {
     variants: {
       variant: {
-        default:
-          "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        default: 'border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90',
         secondary:
-          "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+          'border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
         destructive:
-          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
-        outline:
-          "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+          'border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+        outline: 'text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
       },
     },
     defaultVariants: {
-      variant: "default",
+      variant: 'default',
     },
-  }
-)
+  },
+);
 
 function Badge({
   className,
   variant,
   asChild = false,
   ...props
-}: React.ComponentProps<"span"> &
-  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
-  const Comp = asChild ? Slot : "span"
+}: React.ComponentProps<'span'> & VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : 'span';
 
   return (
-    <Comp
-      data-slot="badge"
-      className={cn(badgeVariants({ variant }), className)}
-      {...props}
-    />
-  )
+    <Comp data-slot="badge" className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
 }
 
-export { Badge, badgeVariants }
+export { Badge, badgeVariants };

--- a/frontend/src/components/ui/breadcrumb.tsx
+++ b/frontend/src/components/ui/breadcrumb.tsx
@@ -1,101 +1,94 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { ChevronRight, MoreHorizontal } from "lucide-react"
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { ChevronRight, MoreHorizontal } from 'lucide-react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-function Breadcrumb({ ...props }: React.ComponentProps<"nav">) {
-  return <nav aria-label="breadcrumb" data-slot="breadcrumb" {...props} />
+function Breadcrumb({ ...props }: React.ComponentProps<'nav'>) {
+  return <nav aria-label="breadcrumb" data-slot="breadcrumb" {...props} />;
 }
 
-function BreadcrumbList({ className, ...props }: React.ComponentProps<"ol">) {
+function BreadcrumbList({ className, ...props }: React.ComponentProps<'ol'>) {
   return (
     <ol
       data-slot="breadcrumb-list"
       className={cn(
-        "text-muted-foreground flex flex-wrap items-center gap-1.5 text-sm break-words sm:gap-2.5",
-        className
+        'text-muted-foreground flex flex-wrap items-center gap-1.5 text-sm break-words sm:gap-2.5',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-function BreadcrumbItem({ className, ...props }: React.ComponentProps<"li">) {
+function BreadcrumbItem({ className, ...props }: React.ComponentProps<'li'>) {
   return (
     <li
       data-slot="breadcrumb-item"
-      className={cn("inline-flex items-center gap-1.5", className)}
+      className={cn('inline-flex items-center gap-1.5', className)}
       {...props}
     />
-  )
+  );
 }
 
 function BreadcrumbLink({
   asChild,
   className,
   ...props
-}: React.ComponentProps<"a"> & {
-  asChild?: boolean
+}: React.ComponentProps<'a'> & {
+  asChild?: boolean;
 }) {
-  const Comp = asChild ? Slot : "a"
+  const Comp = asChild ? Slot : 'a';
 
   return (
     <Comp
       data-slot="breadcrumb-link"
-      className={cn("hover:text-foreground transition-colors", className)}
+      className={cn('hover:text-foreground transition-colors', className)}
       {...props}
     />
-  )
+  );
 }
 
-function BreadcrumbPage({ className, ...props }: React.ComponentProps<"span">) {
+function BreadcrumbPage({ className, ...props }: React.ComponentProps<'span'>) {
   return (
     <span
       data-slot="breadcrumb-page"
       role="link"
       aria-disabled="true"
       aria-current="page"
-      className={cn("text-foreground font-normal", className)}
+      className={cn('text-foreground font-normal', className)}
       {...props}
     />
-  )
+  );
 }
 
-function BreadcrumbSeparator({
-  children,
-  className,
-  ...props
-}: React.ComponentProps<"li">) {
+function BreadcrumbSeparator({ children, className, ...props }: React.ComponentProps<'li'>) {
   return (
     <li
       data-slot="breadcrumb-separator"
       role="presentation"
       aria-hidden="true"
-      className={cn("[&>svg]:size-3.5", className)}
+      className={cn('[&>svg]:size-3.5', className)}
       {...props}
     >
       {children ?? <ChevronRight />}
     </li>
-  )
+  );
 }
 
-function BreadcrumbEllipsis({
-  className,
-  ...props
-}: React.ComponentProps<"span">) {
+function BreadcrumbEllipsis({ className, ...props }: React.ComponentProps<'span'>) {
   return (
     <span
       data-slot="breadcrumb-ellipsis"
       role="presentation"
       aria-hidden="true"
-      className={cn("flex size-9 items-center justify-center", className)}
+      className={cn('flex size-9 items-center justify-center', className)}
       {...props}
     >
       <MoreHorizontal className="size-4" />
       <span className="sr-only">More</span>
     </span>
-  )
+  );
 }
 
 export {
@@ -106,4 +99,4 @@ export {
   BreadcrumbPage,
   BreadcrumbSeparator,
   BreadcrumbEllipsis,
-}
+};

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,39 +1,36 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
-        default:
-          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+        default: 'bg-primary text-primary-foreground shadow-xs hover:bg-primary/90',
         destructive:
-          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          'bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
-        secondary:
-          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
-        ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
+          'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50',
+        secondary: 'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
+        link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-        icon: "size-9",
+        default: 'h-9 px-4 py-2 has-[>svg]:px-3',
+        sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
+        lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
+        icon: 'size-9',
       },
     },
     defaultVariants: {
-      variant: "default",
-      size: "default",
+      variant: 'default',
+      size: 'default',
     },
-  }
-)
+  },
+);
 
 function Button({
   className,
@@ -41,11 +38,11 @@ function Button({
   size,
   asChild = false,
   ...props
-}: React.ComponentProps<"button"> &
+}: React.ComponentProps<'button'> &
   VariantProps<typeof buttonVariants> & {
-    asChild?: boolean
+    asChild?: boolean;
   }) {
-  const Comp = asChild ? Slot : "button"
+  const Comp = asChild ? Slot : 'button';
 
   return (
     <Comp
@@ -53,7 +50,7 @@ function Button({
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
-  )
+  );
 }
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/frontend/src/components/ui/calendar.tsx
+++ b/frontend/src/components/ui/calendar.tsx
@@ -1,159 +1,123 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import {
-  ChevronDownIcon,
-  ChevronLeftIcon,
-  ChevronRightIcon,
-} from "lucide-react"
-import { DayButton, DayPicker, getDefaultClassNames } from "react-day-picker"
+import * as React from 'react';
+import { ChevronDownIcon, ChevronLeftIcon, ChevronRightIcon } from 'lucide-react';
+import { DayButton, DayPicker, getDefaultClassNames } from 'react-day-picker';
 
-import { cn } from "@/lib/utils"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { cn } from '@/lib/utils';
+import { Button, buttonVariants } from '@/components/ui/button';
 
 function Calendar({
   className,
   classNames,
   showOutsideDays = true,
-  captionLayout = "label",
-  buttonVariant = "ghost",
+  captionLayout = 'label',
+  buttonVariant = 'ghost',
   formatters,
   components,
   ...props
 }: React.ComponentProps<typeof DayPicker> & {
-  buttonVariant?: React.ComponentProps<typeof Button>["variant"]
+  buttonVariant?: React.ComponentProps<typeof Button>['variant'];
 }) {
-  const defaultClassNames = getDefaultClassNames()
+  const defaultClassNames = getDefaultClassNames();
 
   return (
     <DayPicker
       showOutsideDays={showOutsideDays}
       className={cn(
-        "bg-background group/calendar p-3 [--cell-size:--spacing(8)] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent",
+        'bg-background group/calendar p-3 [--cell-size:--spacing(8)] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent',
         String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,
         String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
-        className
+        className,
       )}
       captionLayout={captionLayout}
       formatters={{
-        formatMonthDropdown: (date) =>
-          date.toLocaleString("default", { month: "short" }),
+        formatMonthDropdown: (date) => date.toLocaleString('default', { month: 'short' }),
         ...formatters,
       }}
       classNames={{
-        root: cn("w-fit", defaultClassNames.root),
-        months: cn(
-          "flex gap-4 flex-col md:flex-row relative",
-          defaultClassNames.months
-        ),
-        month: cn("flex flex-col w-full gap-4", defaultClassNames.month),
+        root: cn('w-fit', defaultClassNames.root),
+        months: cn('flex gap-4 flex-col md:flex-row relative', defaultClassNames.months),
+        month: cn('flex flex-col w-full gap-4', defaultClassNames.month),
         nav: cn(
-          "flex items-center gap-1 w-full absolute top-0 inset-x-0 justify-between",
-          defaultClassNames.nav
+          'flex items-center gap-1 w-full absolute top-0 inset-x-0 justify-between',
+          defaultClassNames.nav,
         ),
         button_previous: cn(
           buttonVariants({ variant: buttonVariant }),
-          "size-(--cell-size) aria-disabled:opacity-50 p-0 select-none",
-          defaultClassNames.button_previous
+          'size-(--cell-size) aria-disabled:opacity-50 p-0 select-none',
+          defaultClassNames.button_previous,
         ),
         button_next: cn(
           buttonVariants({ variant: buttonVariant }),
-          "size-(--cell-size) aria-disabled:opacity-50 p-0 select-none",
-          defaultClassNames.button_next
+          'size-(--cell-size) aria-disabled:opacity-50 p-0 select-none',
+          defaultClassNames.button_next,
         ),
         month_caption: cn(
-          "flex items-center justify-center h-(--cell-size) w-full px-(--cell-size)",
-          defaultClassNames.month_caption
+          'flex items-center justify-center h-(--cell-size) w-full px-(--cell-size)',
+          defaultClassNames.month_caption,
         ),
         dropdowns: cn(
-          "w-full flex items-center text-sm font-medium justify-center h-(--cell-size) gap-1.5",
-          defaultClassNames.dropdowns
+          'w-full flex items-center text-sm font-medium justify-center h-(--cell-size) gap-1.5',
+          defaultClassNames.dropdowns,
         ),
         dropdown_root: cn(
-          "relative has-focus:border-ring border border-input shadow-xs has-focus:ring-ring/50 has-focus:ring-[3px] rounded-md",
-          defaultClassNames.dropdown_root
+          'relative has-focus:border-ring border border-input shadow-xs has-focus:ring-ring/50 has-focus:ring-[3px] rounded-md',
+          defaultClassNames.dropdown_root,
         ),
-        dropdown: cn(
-          "absolute bg-popover inset-0 opacity-0",
-          defaultClassNames.dropdown
-        ),
+        dropdown: cn('absolute bg-popover inset-0 opacity-0', defaultClassNames.dropdown),
         caption_label: cn(
-          "select-none font-medium",
-          captionLayout === "label"
-            ? "text-sm"
-            : "rounded-md pl-2 pr-1 flex items-center gap-1 text-sm h-8 [&>svg]:text-muted-foreground [&>svg]:size-3.5",
-          defaultClassNames.caption_label
+          'select-none font-medium',
+          captionLayout === 'label'
+            ? 'text-sm'
+            : 'rounded-md pl-2 pr-1 flex items-center gap-1 text-sm h-8 [&>svg]:text-muted-foreground [&>svg]:size-3.5',
+          defaultClassNames.caption_label,
         ),
-        table: "w-full border-collapse",
-        weekdays: cn("flex", defaultClassNames.weekdays),
+        table: 'w-full border-collapse',
+        weekdays: cn('flex', defaultClassNames.weekdays),
         weekday: cn(
-          "text-muted-foreground rounded-md flex-1 font-normal text-[0.8rem] select-none",
-          defaultClassNames.weekday
+          'text-muted-foreground rounded-md flex-1 font-normal text-[0.8rem] select-none',
+          defaultClassNames.weekday,
         ),
-        week: cn("flex w-full mt-2", defaultClassNames.week),
-        week_number_header: cn(
-          "select-none w-(--cell-size)",
-          defaultClassNames.week_number_header
-        ),
+        week: cn('flex w-full mt-2', defaultClassNames.week),
+        week_number_header: cn('select-none w-(--cell-size)', defaultClassNames.week_number_header),
         week_number: cn(
-          "text-[0.8rem] select-none text-muted-foreground",
-          defaultClassNames.week_number
+          'text-[0.8rem] select-none text-muted-foreground',
+          defaultClassNames.week_number,
         ),
         day: cn(
-          "relative w-full h-full p-0 text-center [&:first-child[data-selected=true]_button]:rounded-l-md [&:last-child[data-selected=true]_button]:rounded-r-md group/day aspect-square select-none",
-          defaultClassNames.day
+          'relative w-full h-full p-0 text-center [&:first-child[data-selected=true]_button]:rounded-l-md [&:last-child[data-selected=true]_button]:rounded-r-md group/day aspect-square select-none',
+          defaultClassNames.day,
         ),
-        range_start: cn(
-          "rounded-l-md bg-accent",
-          defaultClassNames.range_start
-        ),
-        range_middle: cn("rounded-none", defaultClassNames.range_middle),
-        range_end: cn("rounded-r-md bg-accent", defaultClassNames.range_end),
+        range_start: cn('rounded-l-md bg-accent', defaultClassNames.range_start),
+        range_middle: cn('rounded-none', defaultClassNames.range_middle),
+        range_end: cn('rounded-r-md bg-accent', defaultClassNames.range_end),
         today: cn(
-          "bg-accent text-accent-foreground rounded-md data-[selected=true]:rounded-none",
-          defaultClassNames.today
+          'bg-accent text-accent-foreground rounded-md data-[selected=true]:rounded-none',
+          defaultClassNames.today,
         ),
         outside: cn(
-          "text-muted-foreground aria-selected:text-muted-foreground",
-          defaultClassNames.outside
+          'text-muted-foreground aria-selected:text-muted-foreground',
+          defaultClassNames.outside,
         ),
-        disabled: cn(
-          "text-muted-foreground opacity-50",
-          defaultClassNames.disabled
-        ),
-        hidden: cn("invisible", defaultClassNames.hidden),
+        disabled: cn('text-muted-foreground opacity-50', defaultClassNames.disabled),
+        hidden: cn('invisible', defaultClassNames.hidden),
         ...classNames,
       }}
       components={{
         Root: ({ className, rootRef, ...props }) => {
-          return (
-            <div
-              data-slot="calendar"
-              ref={rootRef}
-              className={cn(className)}
-              {...props}
-            />
-          )
+          return <div data-slot="calendar" ref={rootRef} className={cn(className)} {...props} />;
         },
         Chevron: ({ className, orientation, ...props }) => {
-          if (orientation === "left") {
-            return (
-              <ChevronLeftIcon className={cn("size-4", className)} {...props} />
-            )
+          if (orientation === 'left') {
+            return <ChevronLeftIcon className={cn('size-4', className)} {...props} />;
           }
 
-          if (orientation === "right") {
-            return (
-              <ChevronRightIcon
-                className={cn("size-4", className)}
-                {...props}
-              />
-            )
+          if (orientation === 'right') {
+            return <ChevronRightIcon className={cn('size-4', className)} {...props} />;
           }
 
-          return (
-            <ChevronDownIcon className={cn("size-4", className)} {...props} />
-          )
+          return <ChevronDownIcon className={cn('size-4', className)} {...props} />;
         },
         DayButton: CalendarDayButton,
         WeekNumber: ({ children, ...props }) => {
@@ -163,13 +127,13 @@ function Calendar({
                 {children}
               </div>
             </td>
-          )
+          );
         },
         ...components,
       }}
       {...props}
     />
-  )
+  );
 }
 
 function CalendarDayButton({
@@ -178,12 +142,12 @@ function CalendarDayButton({
   modifiers,
   ...props
 }: React.ComponentProps<typeof DayButton>) {
-  const defaultClassNames = getDefaultClassNames()
+  const defaultClassNames = getDefaultClassNames();
 
-  const ref = React.useRef<HTMLButtonElement>(null)
+  const ref = React.useRef<HTMLButtonElement>(null);
   React.useEffect(() => {
-    if (modifiers.focused) ref.current?.focus()
-  }, [modifiers.focused])
+    if (modifiers.focused) ref.current?.focus();
+  }, [modifiers.focused]);
 
   return (
     <Button
@@ -201,13 +165,13 @@ function CalendarDayButton({
       data-range-end={modifiers.range_end}
       data-range-middle={modifiers.range_middle}
       className={cn(
-        "data-[selected-single=true]:bg-primary data-[selected-single=true]:text-primary-foreground data-[range-middle=true]:bg-accent data-[range-middle=true]:text-accent-foreground data-[range-start=true]:bg-primary data-[range-start=true]:text-primary-foreground data-[range-end=true]:bg-primary data-[range-end=true]:text-primary-foreground group-data-[focused=true]/day:border-ring group-data-[focused=true]/day:ring-ring/50 dark:hover:text-accent-foreground flex aspect-square size-auto w-full min-w-(--cell-size) flex-col gap-1 leading-none font-normal group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 group-data-[focused=true]/day:ring-[3px] data-[range-end=true]:rounded-md data-[range-end=true]:rounded-r-md data-[range-middle=true]:rounded-none data-[range-start=true]:rounded-md data-[range-start=true]:rounded-l-md [&>span]:text-xs [&>span]:opacity-70",
+        'data-[selected-single=true]:bg-primary data-[selected-single=true]:text-primary-foreground data-[range-middle=true]:bg-accent data-[range-middle=true]:text-accent-foreground data-[range-start=true]:bg-primary data-[range-start=true]:text-primary-foreground data-[range-end=true]:bg-primary data-[range-end=true]:text-primary-foreground group-data-[focused=true]/day:border-ring group-data-[focused=true]/day:ring-ring/50 dark:hover:text-accent-foreground flex aspect-square size-auto w-full min-w-(--cell-size) flex-col gap-1 leading-none font-normal group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 group-data-[focused=true]/day:ring-[3px] data-[range-end=true]:rounded-md data-[range-end=true]:rounded-r-md data-[range-middle=true]:rounded-none data-[range-start=true]:rounded-md data-[range-start=true]:rounded-l-md [&>span]:text-xs [&>span]:opacity-70',
         defaultClassNames.day,
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Calendar, CalendarDayButton }
+export { Calendar, CalendarDayButton };

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -1,92 +1,75 @@
-import * as React from "react"
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-function Card({ className, ...props }: React.ComponentProps<"div">) {
+function Card({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
-        className
+        'bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-header"
       className={cn(
-        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
-        className
+        '@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-title"
-      className={cn("leading-none font-semibold", className)}
+      className={cn('leading-none font-semibold', className)}
       {...props}
     />
-  )
+  );
 }
 
-function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+function CardDescription({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn('text-muted-foreground text-sm', className)}
       {...props}
     />
-  )
+  );
 }
 
-function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+function CardAction({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-action"
-      className={cn(
-        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
-        className
-      )}
+      className={cn('col-start-2 row-span-2 row-start-1 self-start justify-self-end', className)}
       {...props}
     />
-  )
+  );
 }
 
-function CardContent({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="card-content"
-      className={cn("px-6", className)}
-      {...props}
-    />
-  )
+function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="card-content" className={cn('px-6', className)} {...props} />;
 }
 
-function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+function CardFooter({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="card-footer"
-      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      className={cn('flex items-center px-6 [.border-t]:pt-6', className)}
       {...props}
     />
-  )
+  );
 }
 
-export {
-  Card,
-  CardHeader,
-  CardFooter,
-  CardTitle,
-  CardAction,
-  CardDescription,
-  CardContent,
-}
+export { Card, CardHeader, CardFooter, CardTitle, CardAction, CardDescription, CardContent };

--- a/frontend/src/components/ui/carousel.tsx
+++ b/frontend/src/components/ui/carousel.tsx
@@ -1,106 +1,104 @@
-import * as React from "react"
-import useEmblaCarousel, {
-  type UseEmblaCarouselType,
-} from "embla-carousel-react"
-import { ArrowLeft, ArrowRight } from "lucide-react"
+import * as React from 'react';
+import useEmblaCarousel, { type UseEmblaCarouselType } from 'embla-carousel-react';
+import { ArrowLeft, ArrowRight } from 'lucide-react';
 
-import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
 
-type CarouselApi = UseEmblaCarouselType[1]
-type UseCarouselParameters = Parameters<typeof useEmblaCarousel>
-type CarouselOptions = UseCarouselParameters[0]
-type CarouselPlugin = UseCarouselParameters[1]
+type CarouselApi = UseEmblaCarouselType[1];
+type UseCarouselParameters = Parameters<typeof useEmblaCarousel>;
+type CarouselOptions = UseCarouselParameters[0];
+type CarouselPlugin = UseCarouselParameters[1];
 
 type CarouselProps = {
-  opts?: CarouselOptions
-  plugins?: CarouselPlugin
-  orientation?: "horizontal" | "vertical"
-  setApi?: (api: CarouselApi) => void
-}
+  opts?: CarouselOptions;
+  plugins?: CarouselPlugin;
+  orientation?: 'horizontal' | 'vertical';
+  setApi?: (api: CarouselApi) => void;
+};
 
 type CarouselContextProps = {
-  carouselRef: ReturnType<typeof useEmblaCarousel>[0]
-  api: ReturnType<typeof useEmblaCarousel>[1]
-  scrollPrev: () => void
-  scrollNext: () => void
-  canScrollPrev: boolean
-  canScrollNext: boolean
-} & CarouselProps
+  carouselRef: ReturnType<typeof useEmblaCarousel>[0];
+  api: ReturnType<typeof useEmblaCarousel>[1];
+  scrollPrev: () => void;
+  scrollNext: () => void;
+  canScrollPrev: boolean;
+  canScrollNext: boolean;
+} & CarouselProps;
 
-const CarouselContext = React.createContext<CarouselContextProps | null>(null)
+const CarouselContext = React.createContext<CarouselContextProps | null>(null);
 
 function useCarousel() {
-  const context = React.useContext(CarouselContext)
+  const context = React.useContext(CarouselContext);
 
   if (!context) {
-    throw new Error("useCarousel must be used within a <Carousel />")
+    throw new Error('useCarousel must be used within a <Carousel />');
   }
 
-  return context
+  return context;
 }
 
 function Carousel({
-  orientation = "horizontal",
+  orientation = 'horizontal',
   opts,
   setApi,
   plugins,
   className,
   children,
   ...props
-}: React.ComponentProps<"div"> & CarouselProps) {
+}: React.ComponentProps<'div'> & CarouselProps) {
   const [carouselRef, api] = useEmblaCarousel(
     {
       ...opts,
-      axis: orientation === "horizontal" ? "x" : "y",
+      axis: orientation === 'horizontal' ? 'x' : 'y',
     },
-    plugins
-  )
-  const [canScrollPrev, setCanScrollPrev] = React.useState(false)
-  const [canScrollNext, setCanScrollNext] = React.useState(false)
+    plugins,
+  );
+  const [canScrollPrev, setCanScrollPrev] = React.useState(false);
+  const [canScrollNext, setCanScrollNext] = React.useState(false);
 
   const onSelect = React.useCallback((api: CarouselApi) => {
-    if (!api) return
-    setCanScrollPrev(api.canScrollPrev())
-    setCanScrollNext(api.canScrollNext())
-  }, [])
+    if (!api) return;
+    setCanScrollPrev(api.canScrollPrev());
+    setCanScrollNext(api.canScrollNext());
+  }, []);
 
   const scrollPrev = React.useCallback(() => {
-    api?.scrollPrev()
-  }, [api])
+    api?.scrollPrev();
+  }, [api]);
 
   const scrollNext = React.useCallback(() => {
-    api?.scrollNext()
-  }, [api])
+    api?.scrollNext();
+  }, [api]);
 
   const handleKeyDown = React.useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
-      if (event.key === "ArrowLeft") {
-        event.preventDefault()
-        scrollPrev()
-      } else if (event.key === "ArrowRight") {
-        event.preventDefault()
-        scrollNext()
+      if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        scrollPrev();
+      } else if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        scrollNext();
       }
     },
-    [scrollPrev, scrollNext]
-  )
+    [scrollPrev, scrollNext],
+  );
 
   React.useEffect(() => {
-    if (!api || !setApi) return
-    setApi(api)
-  }, [api, setApi])
+    if (!api || !setApi) return;
+    setApi(api);
+  }, [api, setApi]);
 
   React.useEffect(() => {
-    if (!api) return
-    onSelect(api)
-    api.on("reInit", onSelect)
-    api.on("select", onSelect)
+    if (!api) return;
+    onSelect(api);
+    api.on('reInit', onSelect);
+    api.on('select', onSelect);
 
     return () => {
-      api?.off("select", onSelect)
-    }
-  }, [api, onSelect])
+      api?.off('select', onSelect);
+    };
+  }, [api, onSelect]);
 
   return (
     <CarouselContext.Provider
@@ -108,8 +106,7 @@ function Carousel({
         carouselRef,
         api: api,
         opts,
-        orientation:
-          orientation || (opts?.axis === "y" ? "vertical" : "horizontal"),
+        orientation: orientation || (opts?.axis === 'y' ? 'vertical' : 'horizontal'),
         scrollPrev,
         scrollNext,
         canScrollPrev,
@@ -118,7 +115,7 @@ function Carousel({
     >
       <div
         onKeyDownCapture={handleKeyDown}
-        className={cn("relative", className)}
+        className={cn('relative', className)}
         role="region"
         aria-roledescription="carousel"
         data-slot="carousel"
@@ -127,32 +124,24 @@ function Carousel({
         {children}
       </div>
     </CarouselContext.Provider>
-  )
+  );
 }
 
-function CarouselContent({ className, ...props }: React.ComponentProps<"div">) {
-  const { carouselRef, orientation } = useCarousel()
+function CarouselContent({ className, ...props }: React.ComponentProps<'div'>) {
+  const { carouselRef, orientation } = useCarousel();
 
   return (
-    <div
-      ref={carouselRef}
-      className="overflow-hidden"
-      data-slot="carousel-content"
-    >
+    <div ref={carouselRef} className="overflow-hidden" data-slot="carousel-content">
       <div
-        className={cn(
-          "flex",
-          orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
-          className
-        )}
+        className={cn('flex', orientation === 'horizontal' ? '-ml-4' : '-mt-4 flex-col', className)}
         {...props}
       />
     </div>
-  )
+  );
 }
 
-function CarouselItem({ className, ...props }: React.ComponentProps<"div">) {
-  const { orientation } = useCarousel()
+function CarouselItem({ className, ...props }: React.ComponentProps<'div'>) {
+  const { orientation } = useCarousel();
 
   return (
     <div
@@ -160,22 +149,22 @@ function CarouselItem({ className, ...props }: React.ComponentProps<"div">) {
       aria-roledescription="slide"
       data-slot="carousel-item"
       className={cn(
-        "min-w-0 shrink-0 grow-0 basis-full",
-        orientation === "horizontal" ? "pl-4" : "pt-4",
-        className
+        'min-w-0 shrink-0 grow-0 basis-full',
+        orientation === 'horizontal' ? 'pl-4' : 'pt-4',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CarouselPrevious({
   className,
-  variant = "outline",
-  size = "icon",
+  variant = 'outline',
+  size = 'icon',
   ...props
 }: React.ComponentProps<typeof Button>) {
-  const { orientation, scrollPrev, canScrollPrev } = useCarousel()
+  const { orientation, scrollPrev, canScrollPrev } = useCarousel();
 
   return (
     <Button
@@ -183,11 +172,11 @@ function CarouselPrevious({
       variant={variant}
       size={size}
       className={cn(
-        "absolute size-8 rounded-full",
-        orientation === "horizontal"
-          ? "top-1/2 -left-12 -translate-y-1/2"
-          : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
-        className
+        'absolute size-8 rounded-full',
+        orientation === 'horizontal'
+          ? 'top-1/2 -left-12 -translate-y-1/2'
+          : '-top-12 left-1/2 -translate-x-1/2 rotate-90',
+        className,
       )}
       disabled={!canScrollPrev}
       onClick={scrollPrev}
@@ -196,16 +185,16 @@ function CarouselPrevious({
       <ArrowLeft />
       <span className="sr-only">Previous slide</span>
     </Button>
-  )
+  );
 }
 
 function CarouselNext({
   className,
-  variant = "outline",
-  size = "icon",
+  variant = 'outline',
+  size = 'icon',
   ...props
 }: React.ComponentProps<typeof Button>) {
-  const { orientation, scrollNext, canScrollNext } = useCarousel()
+  const { orientation, scrollNext, canScrollNext } = useCarousel();
 
   return (
     <Button
@@ -213,11 +202,11 @@ function CarouselNext({
       variant={variant}
       size={size}
       className={cn(
-        "absolute size-8 rounded-full",
-        orientation === "horizontal"
-          ? "top-1/2 -right-12 -translate-y-1/2"
-          : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
-        className
+        'absolute size-8 rounded-full',
+        orientation === 'horizontal'
+          ? 'top-1/2 -right-12 -translate-y-1/2'
+          : '-bottom-12 left-1/2 -translate-x-1/2 rotate-90',
+        className,
       )}
       disabled={!canScrollNext}
       onClick={scrollNext}
@@ -226,7 +215,7 @@ function CarouselNext({
       <ArrowRight />
       <span className="sr-only">Next slide</span>
     </Button>
-  )
+  );
 }
 
 export {
@@ -236,4 +225,4 @@ export {
   CarouselItem,
   CarouselPrevious,
   CarouselNext,
-}
+};

--- a/frontend/src/components/ui/chart.tsx
+++ b/frontend/src/components/ui/chart.tsx
@@ -1,37 +1,37 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import * as RechartsPrimitive from "recharts"
+import * as React from 'react';
+import * as RechartsPrimitive from 'recharts';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 // Format: { THEME_NAME: CSS_SELECTOR }
-const THEMES = { light: "", dark: ".dark" } as const
+const THEMES = { light: '', dark: '.dark' } as const;
 
 export type ChartConfig = {
   [k in string]: {
-    label?: React.ReactNode
-    icon?: React.ComponentType
+    label?: React.ReactNode;
+    icon?: React.ComponentType;
   } & (
     | { color?: string; theme?: never }
     | { color?: never; theme: Record<keyof typeof THEMES, string> }
-  )
-}
+  );
+};
 
 type ChartContextProps = {
-  config: ChartConfig
-}
+  config: ChartConfig;
+};
 
-const ChartContext = React.createContext<ChartContextProps | null>(null)
+const ChartContext = React.createContext<ChartContextProps | null>(null);
 
 function useChart() {
-  const context = React.useContext(ChartContext)
+  const context = React.useContext(ChartContext);
 
   if (!context) {
-    throw new Error("useChart must be used within a <ChartContainer />")
+    throw new Error('useChart must be used within a <ChartContainer />');
   }
 
-  return context
+  return context;
 }
 
 function ChartContainer({
@@ -40,14 +40,12 @@ function ChartContainer({
   children,
   config,
   ...props
-}: React.ComponentProps<"div"> & {
-  config: ChartConfig
-  children: React.ComponentProps<
-    typeof RechartsPrimitive.ResponsiveContainer
-  >["children"]
+}: React.ComponentProps<'div'> & {
+  config: ChartConfig;
+  children: React.ComponentProps<typeof RechartsPrimitive.ResponsiveContainer>['children'];
 }) {
-  const uniqueId = React.useId()
-  const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`
+  const uniqueId = React.useId();
+  const chartId = `chart-${id || uniqueId.replace(/:/g, '')}`;
 
   return (
     <ChartContext.Provider value={{ config }}>
@@ -56,26 +54,22 @@ function ChartContainer({
         data-chart={chartId}
         className={cn(
           "[&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border flex aspect-video justify-center text-xs [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
-          className
+          className,
         )}
         {...props}
       >
         <ChartStyle id={chartId} config={config} />
-        <RechartsPrimitive.ResponsiveContainer>
-          {children}
-        </RechartsPrimitive.ResponsiveContainer>
+        <RechartsPrimitive.ResponsiveContainer>{children}</RechartsPrimitive.ResponsiveContainer>
       </div>
     </ChartContext.Provider>
-  )
+  );
 }
 
 const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
-  const colorConfig = Object.entries(config).filter(
-    ([, config]) => config.theme || config.color
-  )
+  const colorConfig = Object.entries(config).filter(([, config]) => config.theme || config.color);
 
   if (!colorConfig.length) {
-    return null
+    return null;
   }
 
   return (
@@ -87,28 +81,26 @@ const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
 ${prefix} [data-chart=${id}] {
 ${colorConfig
   .map(([key, itemConfig]) => {
-    const color =
-      itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
-      itemConfig.color
-    return color ? `  --color-${key}: ${color};` : null
+    const color = itemConfig.theme?.[theme as keyof typeof itemConfig.theme] || itemConfig.color;
+    return color ? `  --color-${key}: ${color};` : null;
   })
-  .join("\n")}
+  .join('\n')}
 }
-`
+`,
           )
-          .join("\n"),
+          .join('\n'),
       }}
     />
-  )
-}
+  );
+};
 
-const ChartTooltip = RechartsPrimitive.Tooltip
+const ChartTooltip = RechartsPrimitive.Tooltip;
 
 function ChartTooltipContent({
   active,
   payload,
   className,
-  indicator = "dot",
+  indicator = 'dot',
   hideLabel = false,
   hideIndicator = false,
   label,
@@ -119,77 +111,67 @@ function ChartTooltipContent({
   nameKey,
   labelKey,
 }: React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
-  React.ComponentProps<"div"> & {
-    hideLabel?: boolean
-    hideIndicator?: boolean
-    indicator?: "line" | "dot" | "dashed"
-    nameKey?: string
-    labelKey?: string
+  React.ComponentProps<'div'> & {
+    hideLabel?: boolean;
+    hideIndicator?: boolean;
+    indicator?: 'line' | 'dot' | 'dashed';
+    nameKey?: string;
+    labelKey?: string;
   }) {
-  const { config } = useChart()
+  const { config } = useChart();
 
   const tooltipLabel = React.useMemo(() => {
     if (hideLabel || !payload?.length) {
-      return null
+      return null;
     }
 
-    const [item] = payload
-    const key = `${labelKey || item?.dataKey || item?.name || "value"}`
-    const itemConfig = getPayloadConfigFromPayload(config, item, key)
+    const [item] = payload;
+    const key = `${labelKey || item?.dataKey || item?.name || 'value'}`;
+    const itemConfig = getPayloadConfigFromPayload(config, item, key);
     const value =
-      !labelKey && typeof label === "string"
+      !labelKey && typeof label === 'string'
         ? config[label as keyof typeof config]?.label || label
-        : itemConfig?.label
+        : itemConfig?.label;
 
     if (labelFormatter) {
       return (
-        <div className={cn("font-medium", labelClassName)}>
-          {labelFormatter(value, payload)}
-        </div>
-      )
+        <div className={cn('font-medium', labelClassName)}>{labelFormatter(value, payload)}</div>
+      );
     }
 
     if (!value) {
-      return null
+      return null;
     }
 
-    return <div className={cn("font-medium", labelClassName)}>{value}</div>
-  }, [
-    label,
-    labelFormatter,
-    payload,
-    hideLabel,
-    labelClassName,
-    config,
-    labelKey,
-  ])
+    return <div className={cn('font-medium', labelClassName)}>{value}</div>;
+  }, [label, labelFormatter, payload, hideLabel, labelClassName, config, labelKey]);
 
   if (!active || !payload?.length) {
-    return null
+    return null;
   }
 
-  const nestLabel = payload.length === 1 && indicator !== "dot"
+  const nestLabel = payload.length === 1 && indicator !== 'dot';
 
   return (
     <div
       className={cn(
-        "border-border/50 bg-background grid min-w-[8rem] items-start gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl",
-        className
+        'border-border/50 bg-background grid min-w-[8rem] items-start gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl',
+        className,
       )}
     >
       {!nestLabel ? tooltipLabel : null}
       <div className="grid gap-1.5">
         {payload.map((item, index) => {
-          const key = `${nameKey || item.name || item.dataKey || "value"}`
-          const itemConfig = getPayloadConfigFromPayload(config, item, key)
-          const indicatorColor = color || item.payload.fill || item.color
+          const key = `${nameKey || item.name || item.dataKey || 'value'}`;
+          const itemConfig = getPayloadConfigFromPayload(config, item, key);
+          const indicatorColor = color || item.payload.fill || item.color;
 
           return (
             <div
               key={item.dataKey}
               className={cn(
-                "[&>svg]:text-muted-foreground flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5",
-                indicator === "dot" && "items-center"
+                '[&>svg]:text-muted-foreground flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5',
+                indicator === 'dot' && 'items-center',
               )}
             >
               {formatter && item?.value !== undefined && item.name ? (
@@ -202,19 +184,19 @@ function ChartTooltipContent({
                     !hideIndicator && (
                       <div
                         className={cn(
-                          "shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)",
+                          'shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)',
                           {
-                            "h-2.5 w-2.5": indicator === "dot",
-                            "w-1": indicator === "line",
-                            "w-0 border-[1.5px] border-dashed bg-transparent":
-                              indicator === "dashed",
-                            "my-0.5": nestLabel && indicator === "dashed",
-                          }
+                            'h-2.5 w-2.5': indicator === 'dot',
+                            'w-1': indicator === 'line',
+                            'w-0 border-[1.5px] border-dashed bg-transparent':
+                              indicator === 'dashed',
+                            'my-0.5': nestLabel && indicator === 'dashed',
+                          },
                         )}
                         style={
                           {
-                            "--color-bg": indicatorColor,
-                            "--color-border": indicatorColor,
+                            '--color-bg': indicatorColor,
+                            '--color-border': indicatorColor,
                           } as React.CSSProperties
                         }
                       />
@@ -222,8 +204,8 @@ function ChartTooltipContent({
                   )}
                   <div
                     className={cn(
-                      "flex flex-1 justify-between leading-none",
-                      nestLabel ? "items-end" : "items-center"
+                      'flex flex-1 justify-between leading-none',
+                      nestLabel ? 'items-end' : 'items-center',
                     )}
                   >
                     <div className="grid gap-1.5">
@@ -241,49 +223,49 @@ function ChartTooltipContent({
                 </>
               )}
             </div>
-          )
+          );
         })}
       </div>
     </div>
-  )
+  );
 }
 
-const ChartLegend = RechartsPrimitive.Legend
+const ChartLegend = RechartsPrimitive.Legend;
 
 function ChartLegendContent({
   className,
   hideIcon = false,
   payload,
-  verticalAlign = "bottom",
+  verticalAlign = 'bottom',
   nameKey,
-}: React.ComponentProps<"div"> &
-  Pick<RechartsPrimitive.LegendProps, "payload" | "verticalAlign"> & {
-    hideIcon?: boolean
-    nameKey?: string
+}: React.ComponentProps<'div'> &
+  Pick<RechartsPrimitive.LegendProps, 'payload' | 'verticalAlign'> & {
+    hideIcon?: boolean;
+    nameKey?: string;
   }) {
-  const { config } = useChart()
+  const { config } = useChart();
 
   if (!payload?.length) {
-    return null
+    return null;
   }
 
   return (
     <div
       className={cn(
-        "flex items-center justify-center gap-4",
-        verticalAlign === "top" ? "pb-3" : "pt-3",
-        className
+        'flex items-center justify-center gap-4',
+        verticalAlign === 'top' ? 'pb-3' : 'pt-3',
+        className,
       )}
     >
       {payload.map((item) => {
-        const key = `${nameKey || item.dataKey || "value"}`
-        const itemConfig = getPayloadConfigFromPayload(config, item, key)
+        const key = `${nameKey || item.dataKey || 'value'}`;
+        const itemConfig = getPayloadConfigFromPayload(config, item, key);
 
         return (
           <div
             key={item.value}
             className={cn(
-              "[&>svg]:text-muted-foreground flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3"
+              '[&>svg]:text-muted-foreground flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3',
             )}
           >
             {itemConfig?.icon && !hideIcon ? (
@@ -298,49 +280,36 @@ function ChartLegendContent({
             )}
             {itemConfig?.label}
           </div>
-        )
+        );
       })}
     </div>
-  )
+  );
 }
 
 // Helper to extract item config from a payload.
-function getPayloadConfigFromPayload(
-  config: ChartConfig,
-  payload: unknown,
-  key: string
-) {
-  if (typeof payload !== "object" || payload === null) {
-    return undefined
+function getPayloadConfigFromPayload(config: ChartConfig, payload: unknown, key: string) {
+  if (typeof payload !== 'object' || payload === null) {
+    return undefined;
   }
 
   const payloadPayload =
-    "payload" in payload &&
-    typeof payload.payload === "object" &&
-    payload.payload !== null
+    'payload' in payload && typeof payload.payload === 'object' && payload.payload !== null
       ? payload.payload
-      : undefined
+      : undefined;
 
-  let configLabelKey: string = key
+  let configLabelKey: string = key;
 
-  if (
-    key in payload &&
-    typeof payload[key as keyof typeof payload] === "string"
-  ) {
-    configLabelKey = payload[key as keyof typeof payload] as string
+  if (key in payload && typeof payload[key as keyof typeof payload] === 'string') {
+    configLabelKey = payload[key as keyof typeof payload] as string;
   } else if (
     payloadPayload &&
     key in payloadPayload &&
-    typeof payloadPayload[key as keyof typeof payloadPayload] === "string"
+    typeof payloadPayload[key as keyof typeof payloadPayload] === 'string'
   ) {
-    configLabelKey = payloadPayload[
-      key as keyof typeof payloadPayload
-    ] as string
+    configLabelKey = payloadPayload[key as keyof typeof payloadPayload] as string;
   }
 
-  return configLabelKey in config
-    ? config[configLabelKey]
-    : config[key as keyof typeof config]
+  return configLabelKey in config ? config[configLabelKey] : config[key as keyof typeof config];
 }
 
 export {
@@ -350,4 +319,4 @@ export {
   ChartLegend,
   ChartLegendContent,
   ChartStyle,
-}
+};

--- a/frontend/src/components/ui/checkbox.tsx
+++ b/frontend/src/components/ui/checkbox.tsx
@@ -1,21 +1,18 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
-import { CheckIcon } from "lucide-react"
+import * as React from 'react';
+import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
+import { CheckIcon } from 'lucide-react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-function Checkbox({
-  className,
-  ...props
-}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
   return (
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
-        className
+        'peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+        className,
       )}
       {...props}
     >
@@ -26,7 +23,7 @@ function Checkbox({
         <CheckIcon className="size-3.5" />
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
-  )
+  );
 }
 
-export { Checkbox }
+export { Checkbox };

--- a/frontend/src/components/ui/collapsible.tsx
+++ b/frontend/src/components/ui/collapsible.tsx
@@ -1,31 +1,19 @@
-import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
+import * as CollapsiblePrimitive from '@radix-ui/react-collapsible';
 
-function Collapsible({
-  ...props
-}: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
-  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />
+function Collapsible({ ...props }: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />;
 }
 
 function CollapsibleTrigger({
   ...props
 }: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleTrigger>) {
-  return (
-    <CollapsiblePrimitive.CollapsibleTrigger
-      data-slot="collapsible-trigger"
-      {...props}
-    />
-  )
+  return <CollapsiblePrimitive.CollapsibleTrigger data-slot="collapsible-trigger" {...props} />;
 }
 
 function CollapsibleContent({
   ...props
 }: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>) {
-  return (
-    <CollapsiblePrimitive.CollapsibleContent
-      data-slot="collapsible-content"
-      {...props}
-    />
-  )
+  return <CollapsiblePrimitive.CollapsibleContent data-slot="collapsible-content" {...props} />;
 }
 
-export { Collapsible, CollapsibleTrigger, CollapsibleContent }
+export { Collapsible, CollapsibleTrigger, CollapsibleContent };

--- a/frontend/src/components/ui/command.tsx
+++ b/frontend/src/components/ui/command.tsx
@@ -1,44 +1,41 @@
-import * as React from "react"
-import { Command as CommandPrimitive } from "cmdk"
-import { SearchIcon } from "lucide-react"
+import * as React from 'react';
+import { Command as CommandPrimitive } from 'cmdk';
+import { SearchIcon } from 'lucide-react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 import {
   Dialog,
   DialogContent,
   DialogDescription,
   DialogHeader,
   DialogTitle,
-} from "@/components/ui/dialog"
+} from '@/components/ui/dialog';
 
-function Command({
-  className,
-  ...props
-}: React.ComponentProps<typeof CommandPrimitive>) {
+function Command({ className, ...props }: React.ComponentProps<typeof CommandPrimitive>) {
   return (
     <CommandPrimitive
       data-slot="command"
       className={cn(
-        "bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md",
-        className
+        'bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CommandDialog({
-  title = "Command Palette",
-  description = "Search for a command to run...",
+  title = 'Command Palette',
+  description = 'Search for a command to run...',
   children,
   className,
   showCloseButton = true,
   ...props
 }: React.ComponentProps<typeof Dialog> & {
-  title?: string
-  description?: string
-  className?: string
-  showCloseButton?: boolean
+  title?: string;
+  description?: string;
+  className?: string;
+  showCloseButton?: boolean;
 }) {
   return (
     <Dialog {...props}>
@@ -47,7 +44,7 @@ function CommandDialog({
         <DialogDescription>{description}</DialogDescription>
       </DialogHeader>
       <DialogContent
-        className={cn("overflow-hidden p-0", className)}
+        className={cn('overflow-hidden p-0', className)}
         showCloseButton={showCloseButton}
       >
         <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
@@ -55,7 +52,7 @@ function CommandDialog({
         </Command>
       </DialogContent>
     </Dialog>
-  )
+  );
 }
 
 function CommandInput({
@@ -63,49 +60,38 @@ function CommandInput({
   ...props
 }: React.ComponentProps<typeof CommandPrimitive.Input>) {
   return (
-    <div
-      data-slot="command-input-wrapper"
-      className="flex h-9 items-center gap-2 border-b px-3"
-    >
+    <div data-slot="command-input-wrapper" className="flex h-9 items-center gap-2 border-b px-3">
       <SearchIcon className="size-4 shrink-0 opacity-50" />
       <CommandPrimitive.Input
         data-slot="command-input"
         className={cn(
-          "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
-          className
+          'placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
+          className,
         )}
         {...props}
       />
     </div>
-  )
+  );
 }
 
-function CommandList({
-  className,
-  ...props
-}: React.ComponentProps<typeof CommandPrimitive.List>) {
+function CommandList({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.List>) {
   return (
     <CommandPrimitive.List
       data-slot="command-list"
-      className={cn(
-        "max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto",
-        className
-      )}
+      className={cn('max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto', className)}
       {...props}
     />
-  )
+  );
 }
 
-function CommandEmpty({
-  ...props
-}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+function CommandEmpty({ ...props }: React.ComponentProps<typeof CommandPrimitive.Empty>) {
   return (
     <CommandPrimitive.Empty
       data-slot="command-empty"
       className="py-6 text-center text-sm"
       {...props}
     />
-  )
+  );
 }
 
 function CommandGroup({
@@ -116,12 +102,12 @@ function CommandGroup({
     <CommandPrimitive.Group
       data-slot="command-group"
       className={cn(
-        "text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium",
-        className
+        'text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CommandSeparator({
@@ -131,42 +117,33 @@ function CommandSeparator({
   return (
     <CommandPrimitive.Separator
       data-slot="command-separator"
-      className={cn("bg-border -mx-1 h-px", className)}
+      className={cn('bg-border -mx-1 h-px', className)}
       {...props}
     />
-  )
+  );
 }
 
-function CommandItem({
-  className,
-  ...props
-}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+function CommandItem({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.Item>) {
   return (
     <CommandPrimitive.Item
       data-slot="command-item"
       className={cn(
         "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-function CommandShortcut({
-  className,
-  ...props
-}: React.ComponentProps<"span">) {
+function CommandShortcut({ className, ...props }: React.ComponentProps<'span'>) {
   return (
     <span
       data-slot="command-shortcut"
-      className={cn(
-        "text-muted-foreground ml-auto text-xs tracking-widest",
-        className
-      )}
+      className={cn('text-muted-foreground ml-auto text-xs tracking-widest', className)}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -179,4 +156,4 @@ export {
   CommandItem,
   CommandShortcut,
   CommandSeparator,
-}
+};

--- a/frontend/src/components/ui/context-menu.tsx
+++ b/frontend/src/components/ui/context-menu.tsx
@@ -1,56 +1,37 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import * as ContextMenuPrimitive from "@radix-ui/react-context-menu"
-import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
+import * as React from 'react';
+import * as ContextMenuPrimitive from '@radix-ui/react-context-menu';
+import { CheckIcon, ChevronRightIcon, CircleIcon } from 'lucide-react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-function ContextMenu({
-  ...props
-}: React.ComponentProps<typeof ContextMenuPrimitive.Root>) {
-  return <ContextMenuPrimitive.Root data-slot="context-menu" {...props} />
+function ContextMenu({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Root>) {
+  return <ContextMenuPrimitive.Root data-slot="context-menu" {...props} />;
 }
 
 function ContextMenuTrigger({
   ...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.Trigger>) {
-  return (
-    <ContextMenuPrimitive.Trigger data-slot="context-menu-trigger" {...props} />
-  )
+  return <ContextMenuPrimitive.Trigger data-slot="context-menu-trigger" {...props} />;
 }
 
-function ContextMenuGroup({
-  ...props
-}: React.ComponentProps<typeof ContextMenuPrimitive.Group>) {
-  return (
-    <ContextMenuPrimitive.Group data-slot="context-menu-group" {...props} />
-  )
+function ContextMenuGroup({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Group>) {
+  return <ContextMenuPrimitive.Group data-slot="context-menu-group" {...props} />;
 }
 
-function ContextMenuPortal({
-  ...props
-}: React.ComponentProps<typeof ContextMenuPrimitive.Portal>) {
-  return (
-    <ContextMenuPrimitive.Portal data-slot="context-menu-portal" {...props} />
-  )
+function ContextMenuPortal({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Portal>) {
+  return <ContextMenuPrimitive.Portal data-slot="context-menu-portal" {...props} />;
 }
 
-function ContextMenuSub({
-  ...props
-}: React.ComponentProps<typeof ContextMenuPrimitive.Sub>) {
-  return <ContextMenuPrimitive.Sub data-slot="context-menu-sub" {...props} />
+function ContextMenuSub({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Sub>) {
+  return <ContextMenuPrimitive.Sub data-slot="context-menu-sub" {...props} />;
 }
 
 function ContextMenuRadioGroup({
   ...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.RadioGroup>) {
-  return (
-    <ContextMenuPrimitive.RadioGroup
-      data-slot="context-menu-radio-group"
-      {...props}
-    />
-  )
+  return <ContextMenuPrimitive.RadioGroup data-slot="context-menu-radio-group" {...props} />;
 }
 
 function ContextMenuSubTrigger({
@@ -59,7 +40,7 @@ function ContextMenuSubTrigger({
   children,
   ...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.SubTrigger> & {
-  inset?: boolean
+  inset?: boolean;
 }) {
   return (
     <ContextMenuPrimitive.SubTrigger
@@ -67,14 +48,14 @@ function ContextMenuSubTrigger({
       data-inset={inset}
       className={cn(
         "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        className,
       )}
       {...props}
     >
       {children}
       <ChevronRightIcon className="ml-auto" />
     </ContextMenuPrimitive.SubTrigger>
-  )
+  );
 }
 
 function ContextMenuSubContent({
@@ -85,12 +66,12 @@ function ContextMenuSubContent({
     <ContextMenuPrimitive.SubContent
       data-slot="context-menu-sub-content"
       className={cn(
-        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
-        className
+        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function ContextMenuContent({
@@ -102,23 +83,23 @@ function ContextMenuContent({
       <ContextMenuPrimitive.Content
         data-slot="context-menu-content"
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
-          className
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
+          className,
         )}
         {...props}
       />
     </ContextMenuPrimitive.Portal>
-  )
+  );
 }
 
 function ContextMenuItem({
   className,
   inset,
-  variant = "default",
+  variant = 'default',
   ...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.Item> & {
-  inset?: boolean
-  variant?: "default" | "destructive"
+  inset?: boolean;
+  variant?: 'default' | 'destructive';
 }) {
   return (
     <ContextMenuPrimitive.Item
@@ -127,11 +108,11 @@ function ContextMenuItem({
       data-variant={variant}
       className={cn(
         "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function ContextMenuCheckboxItem({
@@ -145,7 +126,7 @@ function ContextMenuCheckboxItem({
       data-slot="context-menu-checkbox-item"
       className={cn(
         "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        className,
       )}
       checked={checked}
       {...props}
@@ -157,7 +138,7 @@ function ContextMenuCheckboxItem({
       </span>
       {children}
     </ContextMenuPrimitive.CheckboxItem>
-  )
+  );
 }
 
 function ContextMenuRadioItem({
@@ -170,7 +151,7 @@ function ContextMenuRadioItem({
       data-slot="context-menu-radio-item"
       className={cn(
         "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        className,
       )}
       {...props}
     >
@@ -181,7 +162,7 @@ function ContextMenuRadioItem({
       </span>
       {children}
     </ContextMenuPrimitive.RadioItem>
-  )
+  );
 }
 
 function ContextMenuLabel({
@@ -189,19 +170,16 @@ function ContextMenuLabel({
   inset,
   ...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.Label> & {
-  inset?: boolean
+  inset?: boolean;
 }) {
   return (
     <ContextMenuPrimitive.Label
       data-slot="context-menu-label"
       data-inset={inset}
-      className={cn(
-        "text-foreground px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
-        className
-      )}
+      className={cn('text-foreground px-2 py-1.5 text-sm font-medium data-[inset]:pl-8', className)}
       {...props}
     />
-  )
+  );
 }
 
 function ContextMenuSeparator({
@@ -211,26 +189,20 @@ function ContextMenuSeparator({
   return (
     <ContextMenuPrimitive.Separator
       data-slot="context-menu-separator"
-      className={cn("bg-border -mx-1 my-1 h-px", className)}
+      className={cn('bg-border -mx-1 my-1 h-px', className)}
       {...props}
     />
-  )
+  );
 }
 
-function ContextMenuShortcut({
-  className,
-  ...props
-}: React.ComponentProps<"span">) {
+function ContextMenuShortcut({ className, ...props }: React.ComponentProps<'span'>) {
   return (
     <span
       data-slot="context-menu-shortcut"
-      className={cn(
-        "text-muted-foreground ml-auto text-xs tracking-widest",
-        className
-      )}
+      className={cn('text-muted-foreground ml-auto text-xs tracking-widest', className)}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -249,4 +221,4 @@ export {
   ContextMenuSubContent,
   ContextMenuSubTrigger,
   ContextMenuRadioGroup,
-}
+};

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,31 +1,23 @@
-import * as React from "react"
-import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { XIcon } from "lucide-react"
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { XIcon } from 'lucide-react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-function Dialog({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Root>) {
-  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
 }
 
-function DialogTrigger({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
-  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+function DialogTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
 }
 
-function DialogPortal({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
-  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
 }
 
-function DialogClose({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Close>) {
-  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
 }
 
 function DialogOverlay({
@@ -36,12 +28,12 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
-        className
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DialogContent({
@@ -50,7 +42,7 @@ function DialogContent({
   showCloseButton = true,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
-  showCloseButton?: boolean
+  showCloseButton?: boolean;
 }) {
   return (
     <DialogPortal data-slot="dialog-portal">
@@ -58,8 +50,8 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
-          className
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          className,
         )}
         {...props}
       >
@@ -75,43 +67,37 @@ function DialogContent({
         )}
       </DialogPrimitive.Content>
     </DialogPortal>
-  )
+  );
 }
 
-function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="dialog-header"
-      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
       {...props}
     />
-  )
+  );
 }
 
-function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+function DialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="dialog-footer"
-      className={cn(
-        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
-        className
-      )}
+      className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
       {...props}
     />
-  )
+  );
 }
 
-function DialogTitle({
-  className,
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+function DialogTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn("text-lg leading-none font-semibold", className)}
+      className={cn('text-lg leading-none font-semibold', className)}
       {...props}
     />
-  )
+  );
 }
 
 function DialogDescription({
@@ -121,10 +107,10 @@ function DialogDescription({
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn('text-muted-foreground text-sm', className)}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -138,4 +124,4 @@ export {
   DialogPortal,
   DialogTitle,
   DialogTrigger,
-}
+};

--- a/frontend/src/components/ui/drawer.tsx
+++ b/frontend/src/components/ui/drawer.tsx
@@ -1,32 +1,24 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import { Drawer as DrawerPrimitive } from "vaul"
+import * as React from 'react';
+import { Drawer as DrawerPrimitive } from 'vaul';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-function Drawer({
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Root>) {
-  return <DrawerPrimitive.Root data-slot="drawer" {...props} />
+function Drawer({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+  return <DrawerPrimitive.Root data-slot="drawer" {...props} />;
 }
 
-function DrawerTrigger({
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
-  return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />
+function DrawerTrigger({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
+  return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />;
 }
 
-function DrawerPortal({
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
-  return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />
+function DrawerPortal({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
+  return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />;
 }
 
-function DrawerClose({
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Close>) {
-  return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />
+function DrawerClose({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Close>) {
+  return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />;
 }
 
 function DrawerOverlay({
@@ -37,12 +29,12 @@ function DrawerOverlay({
     <DrawerPrimitive.Overlay
       data-slot="drawer-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
-        className
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DrawerContent({
@@ -56,12 +48,12 @@ function DrawerContent({
       <DrawerPrimitive.Content
         data-slot="drawer-content"
         className={cn(
-          "group/drawer-content bg-background fixed z-50 flex h-auto flex-col",
-          "data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b",
-          "data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t",
-          "data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",
-          "data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:sm:max-w-sm",
-          className
+          'group/drawer-content bg-background fixed z-50 flex h-auto flex-col',
+          'data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b',
+          'data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t',
+          'data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm',
+          'data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:sm:max-w-sm',
+          className,
         )}
         {...props}
       >
@@ -69,43 +61,40 @@ function DrawerContent({
         {children}
       </DrawerPrimitive.Content>
     </DrawerPortal>
-  )
+  );
 }
 
-function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
+function DrawerHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="drawer-header"
       className={cn(
-        "flex flex-col gap-0.5 p-4 group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center group-data-[vaul-drawer-direction=top]/drawer-content:text-center md:gap-1.5 md:text-left",
-        className
+        'flex flex-col gap-0.5 p-4 group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center group-data-[vaul-drawer-direction=top]/drawer-content:text-center md:gap-1.5 md:text-left',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
+function DrawerFooter({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="drawer-footer"
-      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      className={cn('mt-auto flex flex-col gap-2 p-4', className)}
       {...props}
     />
-  )
+  );
 }
 
-function DrawerTitle({
-  className,
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+function DrawerTitle({ className, ...props }: React.ComponentProps<typeof DrawerPrimitive.Title>) {
   return (
     <DrawerPrimitive.Title
       data-slot="drawer-title"
-      className={cn("text-foreground font-semibold", className)}
+      className={cn('text-foreground font-semibold', className)}
       {...props}
     />
-  )
+  );
 }
 
 function DrawerDescription({
@@ -115,10 +104,10 @@ function DrawerDescription({
   return (
     <DrawerPrimitive.Description
       data-slot="drawer-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn('text-muted-foreground text-sm', className)}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -132,4 +121,4 @@ export {
   DrawerFooter,
   DrawerTitle,
   DrawerDescription,
-}
+};

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -1,32 +1,23 @@
-import * as React from "react"
-import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
-import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
+import * as React from 'react';
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
+import { CheckIcon, ChevronRightIcon, CircleIcon } from 'lucide-react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-function DropdownMenu({
-  ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
-  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+function DropdownMenu({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
 }
 
 function DropdownMenuPortal({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
-  return (
-    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
-  )
+  return <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />;
 }
 
 function DropdownMenuTrigger({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
-  return (
-    <DropdownMenuPrimitive.Trigger
-      data-slot="dropdown-menu-trigger"
-      {...props}
-    />
-  )
+  return <DropdownMenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />;
 }
 
 function DropdownMenuContent({
@@ -40,31 +31,27 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
-          className
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
+          className,
         )}
         {...props}
       />
     </DropdownMenuPrimitive.Portal>
-  )
+  );
 }
 
-function DropdownMenuGroup({
-  ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
-  return (
-    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
-  )
+function DropdownMenuGroup({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />;
 }
 
 function DropdownMenuItem({
   className,
   inset,
-  variant = "default",
+  variant = 'default',
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
-  inset?: boolean
-  variant?: "default" | "destructive"
+  inset?: boolean;
+  variant?: 'default' | 'destructive';
 }) {
   return (
     <DropdownMenuPrimitive.Item
@@ -73,11 +60,11 @@ function DropdownMenuItem({
       data-variant={variant}
       className={cn(
         "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DropdownMenuCheckboxItem({
@@ -91,7 +78,7 @@ function DropdownMenuCheckboxItem({
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
         "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        className,
       )}
       checked={checked}
       {...props}
@@ -103,18 +90,13 @@ function DropdownMenuCheckboxItem({
       </span>
       {children}
     </DropdownMenuPrimitive.CheckboxItem>
-  )
+  );
 }
 
 function DropdownMenuRadioGroup({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
-  return (
-    <DropdownMenuPrimitive.RadioGroup
-      data-slot="dropdown-menu-radio-group"
-      {...props}
-    />
-  )
+  return <DropdownMenuPrimitive.RadioGroup data-slot="dropdown-menu-radio-group" {...props} />;
 }
 
 function DropdownMenuRadioItem({
@@ -127,7 +109,7 @@ function DropdownMenuRadioItem({
       data-slot="dropdown-menu-radio-item"
       className={cn(
         "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        className,
       )}
       {...props}
     >
@@ -138,7 +120,7 @@ function DropdownMenuRadioItem({
       </span>
       {children}
     </DropdownMenuPrimitive.RadioItem>
-  )
+  );
 }
 
 function DropdownMenuLabel({
@@ -146,19 +128,16 @@ function DropdownMenuLabel({
   inset,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
-  inset?: boolean
+  inset?: boolean;
 }) {
   return (
     <DropdownMenuPrimitive.Label
       data-slot="dropdown-menu-label"
       data-inset={inset}
-      className={cn(
-        "px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
-        className
-      )}
+      className={cn('px-2 py-1.5 text-sm font-medium data-[inset]:pl-8', className)}
       {...props}
     />
-  )
+  );
 }
 
 function DropdownMenuSeparator({
@@ -168,32 +147,24 @@ function DropdownMenuSeparator({
   return (
     <DropdownMenuPrimitive.Separator
       data-slot="dropdown-menu-separator"
-      className={cn("bg-border -mx-1 my-1 h-px", className)}
+      className={cn('bg-border -mx-1 my-1 h-px', className)}
       {...props}
     />
-  )
+  );
 }
 
-function DropdownMenuShortcut({
-  className,
-  ...props
-}: React.ComponentProps<"span">) {
+function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<'span'>) {
   return (
     <span
       data-slot="dropdown-menu-shortcut"
-      className={cn(
-        "text-muted-foreground ml-auto text-xs tracking-widest",
-        className
-      )}
+      className={cn('text-muted-foreground ml-auto text-xs tracking-widest', className)}
       {...props}
     />
-  )
+  );
 }
 
-function DropdownMenuSub({
-  ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
-  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
+function DropdownMenuSub({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />;
 }
 
 function DropdownMenuSubTrigger({
@@ -202,22 +173,22 @@ function DropdownMenuSubTrigger({
   children,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
-  inset?: boolean
+  inset?: boolean;
 }) {
   return (
     <DropdownMenuPrimitive.SubTrigger
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8",
-        className
+        'focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8',
+        className,
       )}
       {...props}
     >
       {children}
       <ChevronRightIcon className="ml-auto size-4" />
     </DropdownMenuPrimitive.SubTrigger>
-  )
+  );
 }
 
 function DropdownMenuSubContent({
@@ -228,12 +199,12 @@ function DropdownMenuSubContent({
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
       className={cn(
-        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
-        className
+        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -252,4 +223,4 @@ export {
   DropdownMenuSub,
   DropdownMenuSubTrigger,
   DropdownMenuSubContent,
-}
+};

--- a/frontend/src/components/ui/form.tsx
+++ b/frontend/src/components/ui/form.tsx
@@ -1,8 +1,8 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import * as LabelPrimitive from "@radix-ui/react-label"
-import { Slot } from "@radix-ui/react-slot"
+import * as React from 'react';
+import * as LabelPrimitive from '@radix-ui/react-label';
+import { Slot } from '@radix-ui/react-slot';
 import {
   Controller,
   FormProvider,
@@ -11,23 +11,21 @@ import {
   type ControllerProps,
   type FieldPath,
   type FieldValues,
-} from "react-hook-form"
+} from 'react-hook-form';
 
-import { cn } from "@/lib/utils"
-import { Label } from "@/components/ui/label"
+import { cn } from '@/lib/utils';
+import { Label } from '@/components/ui/label';
 
-const Form = FormProvider
+const Form = FormProvider;
 
 type FormFieldContextValue<
   TFieldValues extends FieldValues = FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
 > = {
-  name: TName
-}
+  name: TName;
+};
 
-const FormFieldContext = React.createContext<FormFieldContextValue>(
-  {} as FormFieldContextValue
-)
+const FormFieldContext = React.createContext<FormFieldContextValue>({} as FormFieldContextValue);
 
 const FormField = <
   TFieldValues extends FieldValues = FieldValues,
@@ -39,21 +37,21 @@ const FormField = <
     <FormFieldContext.Provider value={{ name: props.name }}>
       <Controller {...props} />
     </FormFieldContext.Provider>
-  )
-}
+  );
+};
 
 const useFormField = () => {
-  const fieldContext = React.useContext(FormFieldContext)
-  const itemContext = React.useContext(FormItemContext)
-  const { getFieldState } = useFormContext()
-  const formState = useFormState({ name: fieldContext.name })
-  const fieldState = getFieldState(fieldContext.name, formState)
+  const fieldContext = React.useContext(FormFieldContext);
+  const itemContext = React.useContext(FormItemContext);
+  const { getFieldState } = useFormContext();
+  const formState = useFormState({ name: fieldContext.name });
+  const fieldState = getFieldState(fieldContext.name, formState);
 
   if (!fieldContext) {
-    throw new Error("useFormField should be used within <FormField>")
+    throw new Error('useFormField should be used within <FormField>');
   }
 
-  const { id } = itemContext
+  const { id } = itemContext;
 
   return {
     id,
@@ -62,97 +60,84 @@ const useFormField = () => {
     formDescriptionId: `${id}-form-item-description`,
     formMessageId: `${id}-form-item-message`,
     ...fieldState,
-  }
-}
+  };
+};
 
 type FormItemContextValue = {
-  id: string
-}
+  id: string;
+};
 
-const FormItemContext = React.createContext<FormItemContextValue>(
-  {} as FormItemContextValue
-)
+const FormItemContext = React.createContext<FormItemContextValue>({} as FormItemContextValue);
 
-function FormItem({ className, ...props }: React.ComponentProps<"div">) {
-  const id = React.useId()
+function FormItem({ className, ...props }: React.ComponentProps<'div'>) {
+  const id = React.useId();
 
   return (
     <FormItemContext.Provider value={{ id }}>
-      <div
-        data-slot="form-item"
-        className={cn("grid gap-2", className)}
-        {...props}
-      />
+      <div data-slot="form-item" className={cn('grid gap-2', className)} {...props} />
     </FormItemContext.Provider>
-  )
+  );
 }
 
-function FormLabel({
-  className,
-  ...props
-}: React.ComponentProps<typeof LabelPrimitive.Root>) {
-  const { error, formItemId } = useFormField()
+function FormLabel({ className, ...props }: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  const { error, formItemId } = useFormField();
 
   return (
     <Label
       data-slot="form-label"
       data-error={!!error}
-      className={cn("data-[error=true]:text-destructive", className)}
+      className={cn('data-[error=true]:text-destructive', className)}
       htmlFor={formItemId}
       {...props}
     />
-  )
+  );
 }
 
 function FormControl({ ...props }: React.ComponentProps<typeof Slot>) {
-  const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
+  const { error, formItemId, formDescriptionId, formMessageId } = useFormField();
 
   return (
     <Slot
       data-slot="form-control"
       id={formItemId}
-      aria-describedby={
-        !error
-          ? `${formDescriptionId}`
-          : `${formDescriptionId} ${formMessageId}`
-      }
+      aria-describedby={!error ? `${formDescriptionId}` : `${formDescriptionId} ${formMessageId}`}
       aria-invalid={!!error}
       {...props}
     />
-  )
+  );
 }
 
-function FormDescription({ className, ...props }: React.ComponentProps<"p">) {
-  const { formDescriptionId } = useFormField()
+function FormDescription({ className, ...props }: React.ComponentProps<'p'>) {
+  const { formDescriptionId } = useFormField();
 
   return (
     <p
       data-slot="form-description"
       id={formDescriptionId}
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn('text-muted-foreground text-sm', className)}
       {...props}
     />
-  )
+  );
 }
 
-function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
-  const { error, formMessageId } = useFormField()
-  const body = error ? String(error?.message ?? "") : props.children
+function FormMessage({ className, ...props }: React.ComponentProps<'p'>) {
+  const { error, formMessageId } = useFormField();
+  const body = error ? String(error?.message ?? '') : props.children;
 
   if (!body) {
-    return null
+    return null;
   }
 
   return (
     <p
       data-slot="form-message"
       id={formMessageId}
-      className={cn("text-destructive text-sm", className)}
+      className={cn('text-destructive text-sm', className)}
       {...props}
     >
       {body}
     </p>
-  )
+  );
 }
 
 export {
@@ -164,4 +149,4 @@ export {
   FormDescription,
   FormMessage,
   FormField,
-}
+};

--- a/frontend/src/components/ui/hover-card.tsx
+++ b/frontend/src/components/ui/hover-card.tsx
@@ -1,27 +1,21 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import * as HoverCardPrimitive from "@radix-ui/react-hover-card"
+import * as React from 'react';
+import * as HoverCardPrimitive from '@radix-ui/react-hover-card';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-function HoverCard({
-  ...props
-}: React.ComponentProps<typeof HoverCardPrimitive.Root>) {
-  return <HoverCardPrimitive.Root data-slot="hover-card" {...props} />
+function HoverCard({ ...props }: React.ComponentProps<typeof HoverCardPrimitive.Root>) {
+  return <HoverCardPrimitive.Root data-slot="hover-card" {...props} />;
 }
 
-function HoverCardTrigger({
-  ...props
-}: React.ComponentProps<typeof HoverCardPrimitive.Trigger>) {
-  return (
-    <HoverCardPrimitive.Trigger data-slot="hover-card-trigger" {...props} />
-  )
+function HoverCardTrigger({ ...props }: React.ComponentProps<typeof HoverCardPrimitive.Trigger>) {
+  return <HoverCardPrimitive.Trigger data-slot="hover-card-trigger" {...props} />;
 }
 
 function HoverCardContent({
   className,
-  align = "center",
+  align = 'center',
   sideOffset = 4,
   ...props
 }: React.ComponentProps<typeof HoverCardPrimitive.Content>) {
@@ -32,13 +26,13 @@ function HoverCardContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
-          className
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden',
+          className,
         )}
         {...props}
       />
     </HoverCardPrimitive.Portal>
-  )
+  );
 }
 
-export { HoverCard, HoverCardTrigger, HoverCardContent }
+export { HoverCard, HoverCardTrigger, HoverCardContent };

--- a/frontend/src/components/ui/input-otp.tsx
+++ b/frontend/src/components/ui/input-otp.tsx
@@ -1,56 +1,49 @@
-import * as React from "react"
-import { OTPInput, OTPInputContext } from "input-otp"
-import { MinusIcon } from "lucide-react"
+import * as React from 'react';
+import { OTPInput, OTPInputContext } from 'input-otp';
+import { MinusIcon } from 'lucide-react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 function InputOTP({
   className,
   containerClassName,
   ...props
 }: React.ComponentProps<typeof OTPInput> & {
-  containerClassName?: string
+  containerClassName?: string;
 }) {
   return (
     <OTPInput
       data-slot="input-otp"
-      containerClassName={cn(
-        "flex items-center gap-2 has-disabled:opacity-50",
-        containerClassName
-      )}
-      className={cn("disabled:cursor-not-allowed", className)}
+      containerClassName={cn('flex items-center gap-2 has-disabled:opacity-50', containerClassName)}
+      className={cn('disabled:cursor-not-allowed', className)}
       {...props}
     />
-  )
+  );
 }
 
-function InputOTPGroup({ className, ...props }: React.ComponentProps<"div">) {
+function InputOTPGroup({ className, ...props }: React.ComponentProps<'div'>) {
   return (
-    <div
-      data-slot="input-otp-group"
-      className={cn("flex items-center", className)}
-      {...props}
-    />
-  )
+    <div data-slot="input-otp-group" className={cn('flex items-center', className)} {...props} />
+  );
 }
 
 function InputOTPSlot({
   index,
   className,
   ...props
-}: React.ComponentProps<"div"> & {
-  index: number
+}: React.ComponentProps<'div'> & {
+  index: number;
 }) {
-  const inputOTPContext = React.useContext(OTPInputContext)
-  const { char, hasFakeCaret, isActive } = inputOTPContext?.slots[index] ?? {}
+  const inputOTPContext = React.useContext(OTPInputContext);
+  const { char, hasFakeCaret, isActive } = inputOTPContext?.slots[index] ?? {};
 
   return (
     <div
       data-slot="input-otp-slot"
       data-active={isActive}
       className={cn(
-        "data-[active=true]:border-ring data-[active=true]:ring-ring/50 data-[active=true]:aria-invalid:ring-destructive/20 dark:data-[active=true]:aria-invalid:ring-destructive/40 aria-invalid:border-destructive data-[active=true]:aria-invalid:border-destructive dark:bg-input/30 border-input relative flex h-9 w-9 items-center justify-center border-y border-r text-sm shadow-xs transition-all outline-none first:rounded-l-md first:border-l last:rounded-r-md data-[active=true]:z-10 data-[active=true]:ring-[3px]",
-        className
+        'data-[active=true]:border-ring data-[active=true]:ring-ring/50 data-[active=true]:aria-invalid:ring-destructive/20 dark:data-[active=true]:aria-invalid:ring-destructive/40 aria-invalid:border-destructive data-[active=true]:aria-invalid:border-destructive dark:bg-input/30 border-input relative flex h-9 w-9 items-center justify-center border-y border-r text-sm shadow-xs transition-all outline-none first:rounded-l-md first:border-l last:rounded-r-md data-[active=true]:z-10 data-[active=true]:ring-[3px]',
+        className,
       )}
       {...props}
     >
@@ -61,15 +54,15 @@ function InputOTPSlot({
         </div>
       )}
     </div>
-  )
+  );
 }
 
-function InputOTPSeparator({ ...props }: React.ComponentProps<"div">) {
+function InputOTPSeparator({ ...props }: React.ComponentProps<'div'>) {
   return (
     <div data-slot="input-otp-separator" role="separator" {...props}>
       <MinusIcon />
     </div>
-  )
+  );
 }
 
-export { InputOTP, InputOTPGroup, InputOTPSlot, InputOTPSeparator }
+export { InputOTP, InputOTPGroup, InputOTPSlot, InputOTPSeparator };

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -1,21 +1,21 @@
-import * as React from "react"
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
   return (
     <input
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
-        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
-        className
+        'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+        'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Input }
+export { Input };

--- a/frontend/src/components/ui/label.tsx
+++ b/frontend/src/components/ui/label.tsx
@@ -1,24 +1,21 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import * as LabelPrimitive from "@radix-ui/react-label"
+import * as React from 'react';
+import * as LabelPrimitive from '@radix-ui/react-label';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-function Label({
-  className,
-  ...props
-}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+function Label({ className, ...props }: React.ComponentProps<typeof LabelPrimitive.Root>) {
   return (
     <LabelPrimitive.Root
       data-slot="label"
       className={cn(
-        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
-        className
+        'flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Label }
+export { Label };

--- a/frontend/src/components/ui/menubar.tsx
+++ b/frontend/src/components/ui/menubar.tsx
@@ -1,49 +1,36 @@
-import * as React from "react"
-import * as MenubarPrimitive from "@radix-ui/react-menubar"
-import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
+import * as React from 'react';
+import * as MenubarPrimitive from '@radix-ui/react-menubar';
+import { CheckIcon, ChevronRightIcon, CircleIcon } from 'lucide-react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-function Menubar({
-  className,
-  ...props
-}: React.ComponentProps<typeof MenubarPrimitive.Root>) {
+function Menubar({ className, ...props }: React.ComponentProps<typeof MenubarPrimitive.Root>) {
   return (
     <MenubarPrimitive.Root
       data-slot="menubar"
       className={cn(
-        "bg-background flex h-9 items-center gap-1 rounded-md border p-1 shadow-xs",
-        className
+        'bg-background flex h-9 items-center gap-1 rounded-md border p-1 shadow-xs',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-function MenubarMenu({
-  ...props
-}: React.ComponentProps<typeof MenubarPrimitive.Menu>) {
-  return <MenubarPrimitive.Menu data-slot="menubar-menu" {...props} />
+function MenubarMenu({ ...props }: React.ComponentProps<typeof MenubarPrimitive.Menu>) {
+  return <MenubarPrimitive.Menu data-slot="menubar-menu" {...props} />;
 }
 
-function MenubarGroup({
-  ...props
-}: React.ComponentProps<typeof MenubarPrimitive.Group>) {
-  return <MenubarPrimitive.Group data-slot="menubar-group" {...props} />
+function MenubarGroup({ ...props }: React.ComponentProps<typeof MenubarPrimitive.Group>) {
+  return <MenubarPrimitive.Group data-slot="menubar-group" {...props} />;
 }
 
-function MenubarPortal({
-  ...props
-}: React.ComponentProps<typeof MenubarPrimitive.Portal>) {
-  return <MenubarPrimitive.Portal data-slot="menubar-portal" {...props} />
+function MenubarPortal({ ...props }: React.ComponentProps<typeof MenubarPrimitive.Portal>) {
+  return <MenubarPrimitive.Portal data-slot="menubar-portal" {...props} />;
 }
 
-function MenubarRadioGroup({
-  ...props
-}: React.ComponentProps<typeof MenubarPrimitive.RadioGroup>) {
-  return (
-    <MenubarPrimitive.RadioGroup data-slot="menubar-radio-group" {...props} />
-  )
+function MenubarRadioGroup({ ...props }: React.ComponentProps<typeof MenubarPrimitive.RadioGroup>) {
+  return <MenubarPrimitive.RadioGroup data-slot="menubar-radio-group" {...props} />;
 }
 
 function MenubarTrigger({
@@ -54,17 +41,17 @@ function MenubarTrigger({
     <MenubarPrimitive.Trigger
       data-slot="menubar-trigger"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex items-center rounded-sm px-2 py-1 text-sm font-medium outline-hidden select-none",
-        className
+        'focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex items-center rounded-sm px-2 py-1 text-sm font-medium outline-hidden select-none',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function MenubarContent({
   className,
-  align = "start",
+  align = 'start',
   alignOffset = -4,
   sideOffset = 8,
   ...props
@@ -77,23 +64,23 @@ function MenubarContent({
         alignOffset={alignOffset}
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[12rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-md",
-          className
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[12rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-md',
+          className,
         )}
         {...props}
       />
     </MenubarPortal>
-  )
+  );
 }
 
 function MenubarItem({
   className,
   inset,
-  variant = "default",
+  variant = 'default',
   ...props
 }: React.ComponentProps<typeof MenubarPrimitive.Item> & {
-  inset?: boolean
-  variant?: "default" | "destructive"
+  inset?: boolean;
+  variant?: 'default' | 'destructive';
 }) {
   return (
     <MenubarPrimitive.Item
@@ -102,11 +89,11 @@ function MenubarItem({
       data-variant={variant}
       className={cn(
         "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function MenubarCheckboxItem({
@@ -120,7 +107,7 @@ function MenubarCheckboxItem({
       data-slot="menubar-checkbox-item"
       className={cn(
         "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-xs py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        className,
       )}
       checked={checked}
       {...props}
@@ -132,7 +119,7 @@ function MenubarCheckboxItem({
       </span>
       {children}
     </MenubarPrimitive.CheckboxItem>
-  )
+  );
 }
 
 function MenubarRadioItem({
@@ -145,7 +132,7 @@ function MenubarRadioItem({
       data-slot="menubar-radio-item"
       className={cn(
         "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-xs py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        className,
       )}
       {...props}
     >
@@ -156,7 +143,7 @@ function MenubarRadioItem({
       </span>
       {children}
     </MenubarPrimitive.RadioItem>
-  )
+  );
 }
 
 function MenubarLabel({
@@ -164,19 +151,16 @@ function MenubarLabel({
   inset,
   ...props
 }: React.ComponentProps<typeof MenubarPrimitive.Label> & {
-  inset?: boolean
+  inset?: boolean;
 }) {
   return (
     <MenubarPrimitive.Label
       data-slot="menubar-label"
       data-inset={inset}
-      className={cn(
-        "px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
-        className
-      )}
+      className={cn('px-2 py-1.5 text-sm font-medium data-[inset]:pl-8', className)}
       {...props}
     />
-  )
+  );
 }
 
 function MenubarSeparator({
@@ -186,32 +170,24 @@ function MenubarSeparator({
   return (
     <MenubarPrimitive.Separator
       data-slot="menubar-separator"
-      className={cn("bg-border -mx-1 my-1 h-px", className)}
+      className={cn('bg-border -mx-1 my-1 h-px', className)}
       {...props}
     />
-  )
+  );
 }
 
-function MenubarShortcut({
-  className,
-  ...props
-}: React.ComponentProps<"span">) {
+function MenubarShortcut({ className, ...props }: React.ComponentProps<'span'>) {
   return (
     <span
       data-slot="menubar-shortcut"
-      className={cn(
-        "text-muted-foreground ml-auto text-xs tracking-widest",
-        className
-      )}
+      className={cn('text-muted-foreground ml-auto text-xs tracking-widest', className)}
       {...props}
     />
-  )
+  );
 }
 
-function MenubarSub({
-  ...props
-}: React.ComponentProps<typeof MenubarPrimitive.Sub>) {
-  return <MenubarPrimitive.Sub data-slot="menubar-sub" {...props} />
+function MenubarSub({ ...props }: React.ComponentProps<typeof MenubarPrimitive.Sub>) {
+  return <MenubarPrimitive.Sub data-slot="menubar-sub" {...props} />;
 }
 
 function MenubarSubTrigger({
@@ -220,22 +196,22 @@ function MenubarSubTrigger({
   children,
   ...props
 }: React.ComponentProps<typeof MenubarPrimitive.SubTrigger> & {
-  inset?: boolean
+  inset?: boolean;
 }) {
   return (
     <MenubarPrimitive.SubTrigger
       data-slot="menubar-sub-trigger"
       data-inset={inset}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-none select-none data-[inset]:pl-8",
-        className
+        'focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-none select-none data-[inset]:pl-8',
+        className,
       )}
       {...props}
     >
       {children}
       <ChevronRightIcon className="ml-auto h-4 w-4" />
     </MenubarPrimitive.SubTrigger>
-  )
+  );
 }
 
 function MenubarSubContent({
@@ -246,12 +222,12 @@ function MenubarSubContent({
     <MenubarPrimitive.SubContent
       data-slot="menubar-sub-content"
       className={cn(
-        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
-        className
+        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -271,4 +247,4 @@ export {
   MenubarSub,
   MenubarSubTrigger,
   MenubarSubContent,
-}
+};

--- a/frontend/src/components/ui/navigation-menu.tsx
+++ b/frontend/src/components/ui/navigation-menu.tsx
@@ -1,9 +1,9 @@
-import * as React from "react"
-import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu"
-import { cva } from "class-variance-authority"
-import { ChevronDownIcon } from "lucide-react"
+import * as React from 'react';
+import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu';
+import { cva } from 'class-variance-authority';
+import { ChevronDownIcon } from 'lucide-react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 function NavigationMenu({
   className,
@@ -11,22 +11,22 @@ function NavigationMenu({
   viewport = true,
   ...props
 }: React.ComponentProps<typeof NavigationMenuPrimitive.Root> & {
-  viewport?: boolean
+  viewport?: boolean;
 }) {
   return (
     <NavigationMenuPrimitive.Root
       data-slot="navigation-menu"
       data-viewport={viewport}
       className={cn(
-        "group/navigation-menu relative flex max-w-max flex-1 items-center justify-center",
-        className
+        'group/navigation-menu relative flex max-w-max flex-1 items-center justify-center',
+        className,
       )}
       {...props}
     >
       {children}
       {viewport && <NavigationMenuViewport />}
     </NavigationMenuPrimitive.Root>
-  )
+  );
 }
 
 function NavigationMenuList({
@@ -36,13 +36,10 @@ function NavigationMenuList({
   return (
     <NavigationMenuPrimitive.List
       data-slot="navigation-menu-list"
-      className={cn(
-        "group flex flex-1 list-none items-center justify-center gap-1",
-        className
-      )}
+      className={cn('group flex flex-1 list-none items-center justify-center gap-1', className)}
       {...props}
     />
-  )
+  );
 }
 
 function NavigationMenuItem({
@@ -52,15 +49,15 @@ function NavigationMenuItem({
   return (
     <NavigationMenuPrimitive.Item
       data-slot="navigation-menu-item"
-      className={cn("relative", className)}
+      className={cn('relative', className)}
       {...props}
     />
-  )
+  );
 }
 
 const navigationMenuTriggerStyle = cva(
-  "group inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=open]:hover:bg-accent data-[state=open]:text-accent-foreground data-[state=open]:focus:bg-accent data-[state=open]:bg-accent/50 focus-visible:ring-ring/50 outline-none transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1"
-)
+  'group inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=open]:hover:bg-accent data-[state=open]:text-accent-foreground data-[state=open]:focus:bg-accent data-[state=open]:bg-accent/50 focus-visible:ring-ring/50 outline-none transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1',
+);
 
 function NavigationMenuTrigger({
   className,
@@ -70,16 +67,16 @@ function NavigationMenuTrigger({
   return (
     <NavigationMenuPrimitive.Trigger
       data-slot="navigation-menu-trigger"
-      className={cn(navigationMenuTriggerStyle(), "group", className)}
+      className={cn(navigationMenuTriggerStyle(), 'group', className)}
       {...props}
     >
-      {children}{" "}
+      {children}{' '}
       <ChevronDownIcon
         className="relative top-[1px] ml-1 size-3 transition duration-300 group-data-[state=open]:rotate-180"
         aria-hidden="true"
       />
     </NavigationMenuPrimitive.Trigger>
-  )
+  );
 }
 
 function NavigationMenuContent({
@@ -90,13 +87,13 @@ function NavigationMenuContent({
     <NavigationMenuPrimitive.Content
       data-slot="navigation-menu-content"
       className={cn(
-        "data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 top-0 left-0 w-full p-2 pr-2.5 md:absolute md:w-auto",
-        "group-data-[viewport=false]/navigation-menu:bg-popover group-data-[viewport=false]/navigation-menu:text-popover-foreground group-data-[viewport=false]/navigation-menu:data-[state=open]:animate-in group-data-[viewport=false]/navigation-menu:data-[state=closed]:animate-out group-data-[viewport=false]/navigation-menu:data-[state=closed]:zoom-out-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:zoom-in-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:fade-in-0 group-data-[viewport=false]/navigation-menu:data-[state=closed]:fade-out-0 group-data-[viewport=false]/navigation-menu:top-full group-data-[viewport=false]/navigation-menu:mt-1.5 group-data-[viewport=false]/navigation-menu:overflow-hidden group-data-[viewport=false]/navigation-menu:rounded-md group-data-[viewport=false]/navigation-menu:border group-data-[viewport=false]/navigation-menu:shadow group-data-[viewport=false]/navigation-menu:duration-200 **:data-[slot=navigation-menu-link]:focus:ring-0 **:data-[slot=navigation-menu-link]:focus:outline-none",
-        className
+        'data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 top-0 left-0 w-full p-2 pr-2.5 md:absolute md:w-auto',
+        'group-data-[viewport=false]/navigation-menu:bg-popover group-data-[viewport=false]/navigation-menu:text-popover-foreground group-data-[viewport=false]/navigation-menu:data-[state=open]:animate-in group-data-[viewport=false]/navigation-menu:data-[state=closed]:animate-out group-data-[viewport=false]/navigation-menu:data-[state=closed]:zoom-out-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:zoom-in-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:fade-in-0 group-data-[viewport=false]/navigation-menu:data-[state=closed]:fade-out-0 group-data-[viewport=false]/navigation-menu:top-full group-data-[viewport=false]/navigation-menu:mt-1.5 group-data-[viewport=false]/navigation-menu:overflow-hidden group-data-[viewport=false]/navigation-menu:rounded-md group-data-[viewport=false]/navigation-menu:border group-data-[viewport=false]/navigation-menu:shadow group-data-[viewport=false]/navigation-menu:duration-200 **:data-[slot=navigation-menu-link]:focus:ring-0 **:data-[slot=navigation-menu-link]:focus:outline-none',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function NavigationMenuViewport({
@@ -104,21 +101,17 @@ function NavigationMenuViewport({
   ...props
 }: React.ComponentProps<typeof NavigationMenuPrimitive.Viewport>) {
   return (
-    <div
-      className={cn(
-        "absolute top-full left-0 isolate z-50 flex justify-center"
-      )}
-    >
+    <div className={cn('absolute top-full left-0 isolate z-50 flex justify-center')}>
       <NavigationMenuPrimitive.Viewport
         data-slot="navigation-menu-viewport"
         className={cn(
-          "origin-top-center bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border shadow md:w-[var(--radix-navigation-menu-viewport-width)]",
-          className
+          'origin-top-center bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border shadow md:w-[var(--radix-navigation-menu-viewport-width)]',
+          className,
         )}
         {...props}
       />
     </div>
-  )
+  );
 }
 
 function NavigationMenuLink({
@@ -130,11 +123,11 @@ function NavigationMenuLink({
       data-slot="navigation-menu-link"
       className={cn(
         "data-[active=true]:focus:bg-accent data-[active=true]:hover:bg-accent data-[active=true]:bg-accent/50 data-[active=true]:text-accent-foreground hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus-visible:ring-ring/50 [&_svg:not([class*='text-'])]:text-muted-foreground flex flex-col gap-1 rounded-sm p-2 text-sm transition-all outline-none focus-visible:ring-[3px] focus-visible:outline-1 [&_svg:not([class*='size-'])]:size-4",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function NavigationMenuIndicator({
@@ -145,14 +138,14 @@ function NavigationMenuIndicator({
     <NavigationMenuPrimitive.Indicator
       data-slot="navigation-menu-indicator"
       className={cn(
-        "data-[state=visible]:animate-in data-[state=hidden]:animate-out data-[state=hidden]:fade-out data-[state=visible]:fade-in top-full z-[1] flex h-1.5 items-end justify-center overflow-hidden",
-        className
+        'data-[state=visible]:animate-in data-[state=hidden]:animate-out data-[state=hidden]:fade-out data-[state=visible]:fade-in top-full z-[1] flex h-1.5 items-end justify-center overflow-hidden',
+        className,
       )}
       {...props}
     >
       <div className="bg-border relative top-[60%] h-2 w-2 rotate-45 rounded-tl-sm shadow-md" />
     </NavigationMenuPrimitive.Indicator>
-  )
+  );
 }
 
 export {
@@ -165,4 +158,4 @@ export {
   NavigationMenuIndicator,
   NavigationMenuViewport,
   navigationMenuTriggerStyle,
-}
+};

--- a/frontend/src/components/ui/pagination.tsx
+++ b/frontend/src/components/ui/pagination.tsx
@@ -1,119 +1,98 @@
-import * as React from "react"
-import {
-  ChevronLeftIcon,
-  ChevronRightIcon,
-  MoreHorizontalIcon,
-} from "lucide-react"
+import * as React from 'react';
+import { ChevronLeftIcon, ChevronRightIcon, MoreHorizontalIcon } from 'lucide-react';
 
-import { cn } from "@/lib/utils"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { cn } from '@/lib/utils';
+import { Button, buttonVariants } from '@/components/ui/button';
 
-function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
+function Pagination({ className, ...props }: React.ComponentProps<'nav'>) {
   return (
     <nav
       role="navigation"
       aria-label="pagination"
       data-slot="pagination"
-      className={cn("mx-auto flex w-full justify-center", className)}
+      className={cn('mx-auto flex w-full justify-center', className)}
       {...props}
     />
-  )
+  );
 }
 
-function PaginationContent({
-  className,
-  ...props
-}: React.ComponentProps<"ul">) {
+function PaginationContent({ className, ...props }: React.ComponentProps<'ul'>) {
   return (
     <ul
       data-slot="pagination-content"
-      className={cn("flex flex-row items-center gap-1", className)}
+      className={cn('flex flex-row items-center gap-1', className)}
       {...props}
     />
-  )
+  );
 }
 
-function PaginationItem({ ...props }: React.ComponentProps<"li">) {
-  return <li data-slot="pagination-item" {...props} />
+function PaginationItem({ ...props }: React.ComponentProps<'li'>) {
+  return <li data-slot="pagination-item" {...props} />;
 }
 
 type PaginationLinkProps = {
-  isActive?: boolean
-} & Pick<React.ComponentProps<typeof Button>, "size"> &
-  React.ComponentProps<"a">
+  isActive?: boolean;
+} & Pick<React.ComponentProps<typeof Button>, 'size'> &
+  React.ComponentProps<'a'>;
 
-function PaginationLink({
-  className,
-  isActive,
-  size = "icon",
-  ...props
-}: PaginationLinkProps) {
+function PaginationLink({ className, isActive, size = 'icon', ...props }: PaginationLinkProps) {
   return (
     <a
-      aria-current={isActive ? "page" : undefined}
+      aria-current={isActive ? 'page' : undefined}
       data-slot="pagination-link"
       data-active={isActive}
       className={cn(
         buttonVariants({
-          variant: isActive ? "outline" : "ghost",
+          variant: isActive ? 'outline' : 'ghost',
           size,
         }),
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-function PaginationPrevious({
-  className,
-  ...props
-}: React.ComponentProps<typeof PaginationLink>) {
+function PaginationPrevious({ className, ...props }: React.ComponentProps<typeof PaginationLink>) {
   return (
     <PaginationLink
       aria-label="Go to previous page"
       size="default"
-      className={cn("gap-1 px-2.5 sm:pl-2.5", className)}
+      className={cn('gap-1 px-2.5 sm:pl-2.5', className)}
       {...props}
     >
       <ChevronLeftIcon />
       <span className="hidden sm:block">Previous</span>
     </PaginationLink>
-  )
+  );
 }
 
-function PaginationNext({
-  className,
-  ...props
-}: React.ComponentProps<typeof PaginationLink>) {
+function PaginationNext({ className, ...props }: React.ComponentProps<typeof PaginationLink>) {
   return (
     <PaginationLink
       aria-label="Go to next page"
       size="default"
-      className={cn("gap-1 px-2.5 sm:pr-2.5", className)}
+      className={cn('gap-1 px-2.5 sm:pr-2.5', className)}
       {...props}
     >
       <span className="hidden sm:block">Next</span>
       <ChevronRightIcon />
     </PaginationLink>
-  )
+  );
 }
 
-function PaginationEllipsis({
-  className,
-  ...props
-}: React.ComponentProps<"span">) {
+function PaginationEllipsis({ className, ...props }: React.ComponentProps<'span'>) {
   return (
     <span
       aria-hidden
       data-slot="pagination-ellipsis"
-      className={cn("flex size-9 items-center justify-center", className)}
+      className={cn('flex size-9 items-center justify-center', className)}
       {...props}
     >
       <MoreHorizontalIcon className="size-4" />
       <span className="sr-only">More pages</span>
     </span>
-  )
+  );
 }
 
 export {
@@ -124,4 +103,4 @@ export {
   PaginationPrevious,
   PaginationNext,
   PaginationEllipsis,
-}
+};

--- a/frontend/src/components/ui/popover.tsx
+++ b/frontend/src/components/ui/popover.tsx
@@ -1,25 +1,21 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import * as PopoverPrimitive from "@radix-ui/react-popover"
+import * as React from 'react';
+import * as PopoverPrimitive from '@radix-ui/react-popover';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-function Popover({
-  ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
-  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+function Popover({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />;
 }
 
-function PopoverTrigger({
-  ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
-  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+function PopoverTrigger({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
 }
 
 function PopoverContent({
   className,
-  align = "center",
+  align = 'center',
   sideOffset = 4,
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Content>) {
@@ -30,19 +26,17 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
-          className
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden',
+          className,
         )}
         {...props}
       />
     </PopoverPrimitive.Portal>
-  )
+  );
 }
 
-function PopoverAnchor({
-  ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
-  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+function PopoverAnchor({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
 }
 
-export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor }
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor };

--- a/frontend/src/components/ui/progress.tsx
+++ b/frontend/src/components/ui/progress.tsx
@@ -1,7 +1,7 @@
-import * as React from "react"
-import * as ProgressPrimitive from "@radix-ui/react-progress"
+import * as React from 'react';
+import * as ProgressPrimitive from '@radix-ui/react-progress';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 function Progress({
   className,
@@ -11,10 +11,7 @@ function Progress({
   return (
     <ProgressPrimitive.Root
       data-slot="progress"
-      className={cn(
-        "bg-primary/20 relative h-2 w-full overflow-hidden rounded-full",
-        className
-      )}
+      className={cn('bg-primary/20 relative h-2 w-full overflow-hidden rounded-full', className)}
       {...props}
     >
       <ProgressPrimitive.Indicator
@@ -23,7 +20,7 @@ function Progress({
         style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
       />
     </ProgressPrimitive.Root>
-  )
+  );
 }
 
-export { Progress }
+export { Progress };

--- a/frontend/src/components/ui/radio-group.tsx
+++ b/frontend/src/components/ui/radio-group.tsx
@@ -1,10 +1,10 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import * as RadioGroupPrimitive from "@radix-ui/react-radio-group"
-import { CircleIcon } from "lucide-react"
+import * as React from 'react';
+import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
+import { CircleIcon } from 'lucide-react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 function RadioGroup({
   className,
@@ -13,10 +13,10 @@ function RadioGroup({
   return (
     <RadioGroupPrimitive.Root
       data-slot="radio-group"
-      className={cn("grid gap-3", className)}
+      className={cn('grid gap-3', className)}
       {...props}
     />
-  )
+  );
 }
 
 function RadioGroupItem({
@@ -27,8 +27,8 @@ function RadioGroupItem({
     <RadioGroupPrimitive.Item
       data-slot="radio-group-item"
       className={cn(
-        "border-input text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
-        className
+        'border-input text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+        className,
       )}
       {...props}
     >
@@ -39,7 +39,7 @@ function RadioGroupItem({
         <CircleIcon className="fill-primary absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2" />
       </RadioGroupPrimitive.Indicator>
     </RadioGroupPrimitive.Item>
-  )
+  );
 }
 
-export { RadioGroup, RadioGroupItem }
+export { RadioGroup, RadioGroupItem };

--- a/frontend/src/components/ui/resizable.tsx
+++ b/frontend/src/components/ui/resizable.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
-import { GripVerticalIcon } from "lucide-react"
-import * as ResizablePrimitive from "react-resizable-panels"
+import * as React from 'react';
+import { GripVerticalIcon } from 'lucide-react';
+import * as ResizablePrimitive from 'react-resizable-panels';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 function ResizablePanelGroup({
   className,
@@ -11,19 +11,14 @@ function ResizablePanelGroup({
   return (
     <ResizablePrimitive.PanelGroup
       data-slot="resizable-panel-group"
-      className={cn(
-        "flex h-full w-full data-[panel-group-direction=vertical]:flex-col",
-        className
-      )}
+      className={cn('flex h-full w-full data-[panel-group-direction=vertical]:flex-col', className)}
       {...props}
     />
-  )
+  );
 }
 
-function ResizablePanel({
-  ...props
-}: React.ComponentProps<typeof ResizablePrimitive.Panel>) {
-  return <ResizablePrimitive.Panel data-slot="resizable-panel" {...props} />
+function ResizablePanel({ ...props }: React.ComponentProps<typeof ResizablePrimitive.Panel>) {
+  return <ResizablePrimitive.Panel data-slot="resizable-panel" {...props} />;
 }
 
 function ResizableHandle({
@@ -31,14 +26,14 @@ function ResizableHandle({
   className,
   ...props
 }: React.ComponentProps<typeof ResizablePrimitive.PanelResizeHandle> & {
-  withHandle?: boolean
+  withHandle?: boolean;
 }) {
   return (
     <ResizablePrimitive.PanelResizeHandle
       data-slot="resizable-handle"
       className={cn(
-        "bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:translate-x-0 data-[panel-group-direction=vertical]:after:-translate-y-1/2 [&[data-panel-group-direction=vertical]>div]:rotate-90",
-        className
+        'bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:translate-x-0 data-[panel-group-direction=vertical]:after:-translate-y-1/2 [&[data-panel-group-direction=vertical]>div]:rotate-90',
+        className,
       )}
       {...props}
     >
@@ -48,7 +43,7 @@ function ResizableHandle({
         </div>
       )}
     </ResizablePrimitive.PanelResizeHandle>
-  )
+  );
 }
 
-export { ResizablePanelGroup, ResizablePanel, ResizableHandle }
+export { ResizablePanelGroup, ResizablePanel, ResizableHandle };

--- a/frontend/src/components/ui/scroll-area.tsx
+++ b/frontend/src/components/ui/scroll-area.tsx
@@ -1,9 +1,9 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
+import * as React from 'react';
+import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 function ScrollArea({
   className,
@@ -13,7 +13,7 @@ function ScrollArea({
   return (
     <ScrollAreaPrimitive.Root
       data-slot="scroll-area"
-      className={cn("relative", className)}
+      className={cn('relative', className)}
       {...props}
     >
       <ScrollAreaPrimitive.Viewport
@@ -25,12 +25,12 @@ function ScrollArea({
       <ScrollBar />
       <ScrollAreaPrimitive.Corner />
     </ScrollAreaPrimitive.Root>
-  )
+  );
 }
 
 function ScrollBar({
   className,
-  orientation = "vertical",
+  orientation = 'vertical',
   ...props
 }: React.ComponentProps<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>) {
   return (
@@ -38,12 +38,10 @@ function ScrollBar({
       data-slot="scroll-area-scrollbar"
       orientation={orientation}
       className={cn(
-        "flex touch-none p-px transition-colors select-none",
-        orientation === "vertical" &&
-          "h-full w-2.5 border-l border-l-transparent",
-        orientation === "horizontal" &&
-          "h-2.5 flex-col border-t border-t-transparent",
-        className
+        'flex touch-none p-px transition-colors select-none',
+        orientation === 'vertical' && 'h-full w-2.5 border-l border-l-transparent',
+        orientation === 'horizontal' && 'h-2.5 flex-col border-t border-t-transparent',
+        className,
       )}
       {...props}
     >
@@ -52,7 +50,7 @@ function ScrollBar({
         className="bg-border relative flex-1 rounded-full"
       />
     </ScrollAreaPrimitive.ScrollAreaScrollbar>
-  )
+  );
 }
 
-export { ScrollArea, ScrollBar }
+export { ScrollArea, ScrollBar };

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -1,34 +1,28 @@
-import * as React from "react"
-import * as SelectPrimitive from "@radix-ui/react-select"
-import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+import * as React from 'react';
+import * as SelectPrimitive from '@radix-ui/react-select';
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from 'lucide-react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-function Select({
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.Root>) {
-  return <SelectPrimitive.Root data-slot="select" {...props} />
+function Select({ ...props }: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />;
 }
 
-function SelectGroup({
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.Group>) {
-  return <SelectPrimitive.Group data-slot="select-group" {...props} />
+function SelectGroup({ ...props }: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />;
 }
 
-function SelectValue({
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.Value>) {
-  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+function SelectValue({ ...props }: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />;
 }
 
 function SelectTrigger({
   className,
-  size = "default",
+  size = 'default',
   children,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
-  size?: "sm" | "default"
+  size?: 'sm' | 'default';
 }) {
   return (
     <SelectPrimitive.Trigger
@@ -36,7 +30,7 @@ function SelectTrigger({
       data-size={size}
       className={cn(
         "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        className,
       )}
       {...props}
     >
@@ -45,13 +39,13 @@ function SelectTrigger({
         <ChevronDownIcon className="size-4 opacity-50" />
       </SelectPrimitive.Icon>
     </SelectPrimitive.Trigger>
-  )
+  );
 }
 
 function SelectContent({
   className,
   children,
-  position = "popper",
+  position = 'popper',
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Content>) {
   return (
@@ -59,10 +53,10 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
-          position === "popper" &&
-            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
-          className
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md',
+          position === 'popper' &&
+            'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+          className,
         )}
         position={position}
         {...props}
@@ -70,9 +64,9 @@ function SelectContent({
         <SelectScrollUpButton />
         <SelectPrimitive.Viewport
           className={cn(
-            "p-1",
-            position === "popper" &&
-              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
+            'p-1',
+            position === 'popper' &&
+              'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1',
           )}
         >
           {children}
@@ -80,20 +74,17 @@ function SelectContent({
         <SelectScrollDownButton />
       </SelectPrimitive.Content>
     </SelectPrimitive.Portal>
-  )
+  );
 }
 
-function SelectLabel({
-  className,
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+function SelectLabel({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.Label>) {
   return (
     <SelectPrimitive.Label
       data-slot="select-label"
-      className={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
+      className={cn('text-muted-foreground px-2 py-1.5 text-xs', className)}
       {...props}
     />
-  )
+  );
 }
 
 function SelectItem({
@@ -106,7 +97,7 @@ function SelectItem({
       data-slot="select-item"
       className={cn(
         "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
-        className
+        className,
       )}
       {...props}
     >
@@ -117,7 +108,7 @@ function SelectItem({
       </span>
       <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
     </SelectPrimitive.Item>
-  )
+  );
 }
 
 function SelectSeparator({
@@ -127,10 +118,10 @@ function SelectSeparator({
   return (
     <SelectPrimitive.Separator
       data-slot="select-separator"
-      className={cn("bg-border pointer-events-none -mx-1 my-1 h-px", className)}
+      className={cn('bg-border pointer-events-none -mx-1 my-1 h-px', className)}
       {...props}
     />
-  )
+  );
 }
 
 function SelectScrollUpButton({
@@ -140,15 +131,12 @@ function SelectScrollUpButton({
   return (
     <SelectPrimitive.ScrollUpButton
       data-slot="select-scroll-up-button"
-      className={cn(
-        "flex cursor-default items-center justify-center py-1",
-        className
-      )}
+      className={cn('flex cursor-default items-center justify-center py-1', className)}
       {...props}
     >
       <ChevronUpIcon className="size-4" />
     </SelectPrimitive.ScrollUpButton>
-  )
+  );
 }
 
 function SelectScrollDownButton({
@@ -158,15 +146,12 @@ function SelectScrollDownButton({
   return (
     <SelectPrimitive.ScrollDownButton
       data-slot="select-scroll-down-button"
-      className={cn(
-        "flex cursor-default items-center justify-center py-1",
-        className
-      )}
+      className={cn('flex cursor-default items-center justify-center py-1', className)}
       {...props}
     >
       <ChevronDownIcon className="size-4" />
     </SelectPrimitive.ScrollDownButton>
-  )
+  );
 }
 
 export {
@@ -180,4 +165,4 @@ export {
   SelectSeparator,
   SelectTrigger,
   SelectValue,
-}
+};

--- a/frontend/src/components/ui/separator.tsx
+++ b/frontend/src/components/ui/separator.tsx
@@ -1,13 +1,13 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import * as SeparatorPrimitive from "@radix-ui/react-separator"
+import * as React from 'react';
+import * as SeparatorPrimitive from '@radix-ui/react-separator';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 function Separator({
   className,
-  orientation = "horizontal",
+  orientation = 'horizontal',
   decorative = true,
   ...props
 }: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
@@ -17,12 +17,12 @@ function Separator({
       decorative={decorative}
       orientation={orientation}
       className={cn(
-        "bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
-        className
+        'bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Separator }
+export { Separator };

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -1,29 +1,23 @@
-import * as React from "react"
-import * as SheetPrimitive from "@radix-ui/react-dialog"
-import { XIcon } from "lucide-react"
+import * as React from 'react';
+import * as SheetPrimitive from '@radix-ui/react-dialog';
+import { XIcon } from 'lucide-react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
-  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />;
 }
 
-function SheetTrigger({
-  ...props
-}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
-  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+function SheetTrigger({ ...props }: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />;
 }
 
-function SheetClose({
-  ...props
-}: React.ComponentProps<typeof SheetPrimitive.Close>) {
-  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+function SheetClose({ ...props }: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />;
 }
 
-function SheetPortal({
-  ...props
-}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
-  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+function SheetPortal({ ...props }: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />;
 }
 
 function SheetOverlay({
@@ -34,21 +28,21 @@ function SheetOverlay({
     <SheetPrimitive.Overlay
       data-slot="sheet-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
-        className
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function SheetContent({
   className,
   children,
-  side = "right",
+  side = 'right',
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Content> & {
-  side?: "top" | "right" | "bottom" | "left"
+  side?: 'top' | 'right' | 'bottom' | 'left';
 }) {
   return (
     <SheetPortal>
@@ -56,16 +50,16 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
-          side === "right" &&
-            "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
-          side === "left" &&
-            "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
-          side === "top" &&
-            "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
-          side === "bottom" &&
-            "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
-          className
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
+          side === 'right' &&
+            'data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm',
+          side === 'left' &&
+            'data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm',
+          side === 'top' &&
+            'data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b',
+          side === 'bottom' &&
+            'data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t',
+          className,
         )}
         {...props}
       >
@@ -76,40 +70,37 @@ function SheetContent({
         </SheetPrimitive.Close>
       </SheetPrimitive.Content>
     </SheetPortal>
-  )
+  );
 }
 
-function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+function SheetHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="sheet-header"
-      className={cn("flex flex-col gap-1.5 p-4", className)}
+      className={cn('flex flex-col gap-1.5 p-4', className)}
       {...props}
     />
-  )
+  );
 }
 
-function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+function SheetFooter({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="sheet-footer"
-      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      className={cn('mt-auto flex flex-col gap-2 p-4', className)}
       {...props}
     />
-  )
+  );
 }
 
-function SheetTitle({
-  className,
-  ...props
-}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+function SheetTitle({ className, ...props }: React.ComponentProps<typeof SheetPrimitive.Title>) {
   return (
     <SheetPrimitive.Title
       data-slot="sheet-title"
-      className={cn("text-foreground font-semibold", className)}
+      className={cn('text-foreground font-semibold', className)}
       {...props}
     />
-  )
+  );
 }
 
 function SheetDescription({
@@ -119,10 +110,10 @@ function SheetDescription({
   return (
     <SheetPrimitive.Description
       data-slot="sheet-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn('text-muted-foreground text-sm', className)}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -134,4 +125,4 @@ export {
   SheetFooter,
   SheetTitle,
   SheetDescription,
-}
+};

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -1,39 +1,34 @@
-"use client";
+'use client';
 
-import { Slot } from "@radix-ui/react-slot";
-import { cva, type VariantProps } from "class-variance-authority";
-import { PanelLeftIcon } from "lucide-react";
-import * as React from "react";
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { PanelLeftIcon } from 'lucide-react';
+import * as React from 'react';
 
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Separator } from "@/components/ui/separator";
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Separator } from '@/components/ui/separator';
 import {
   Sheet,
   SheetContent,
   SheetDescription,
   SheetHeader,
   SheetTitle,
-} from "@/components/ui/sheet";
-import { Skeleton } from "@/components/ui/skeleton";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import { useIsMobile } from "@/hooks/use-mobile";
-import { cn } from "@/lib/utils";
+} from '@/components/ui/sheet';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { useIsMobile } from '@/hooks/use-mobile';
+import { cn } from '@/lib/utils';
 
-const SIDEBAR_COOKIE_NAME = "sidebar_state";
+const SIDEBAR_COOKIE_NAME = 'sidebar_state';
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
-const SIDEBAR_WIDTH = "16rem";
-const SIDEBAR_WIDTH_MOBILE = "18rem";
-const SIDEBAR_WIDTH_ICON = "3rem";
-const SIDEBAR_KEYBOARD_SHORTCUT = "b";
+const SIDEBAR_WIDTH = '16rem';
+const SIDEBAR_WIDTH_MOBILE = '18rem';
+const SIDEBAR_WIDTH_ICON = '3rem';
+const SIDEBAR_KEYBOARD_SHORTCUT = 'b';
 
 type SidebarContextProps = {
-  state: "expanded" | "collapsed";
+  state: 'expanded' | 'collapsed';
   open: boolean;
   setOpen: (open: boolean) => void;
   openMobile: boolean;
@@ -47,7 +42,7 @@ const SidebarContext = React.createContext<SidebarContextProps | null>(null);
 function useSidebar() {
   const context = React.useContext(SidebarContext);
   if (!context) {
-    throw new Error("useSidebar must be used within a SidebarProvider.");
+    throw new Error('useSidebar must be used within a SidebarProvider.');
   }
 
   return context;
@@ -61,7 +56,7 @@ function SidebarProvider({
   style,
   children,
   ...props
-}: React.ComponentProps<"div"> & {
+}: React.ComponentProps<'div'> & {
   defaultOpen?: boolean;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
@@ -75,7 +70,7 @@ function SidebarProvider({
   const open = openProp ?? _open;
   const setOpen = React.useCallback(
     (value: boolean | ((value: boolean) => boolean)) => {
-      const openState = typeof value === "function" ? value(open) : value;
+      const openState = typeof value === 'function' ? value(open) : value;
       if (setOpenProp) {
         setOpenProp(openState);
       } else {
@@ -96,22 +91,19 @@ function SidebarProvider({
   // Adds a keyboard shortcut to toggle the sidebar.
   React.useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (
-        event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
-      ) {
+      if (event.key === SIDEBAR_KEYBOARD_SHORTCUT && (event.metaKey || event.ctrlKey)) {
         event.preventDefault();
         toggleSidebar();
       }
     };
 
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
   }, [toggleSidebar]);
 
   // We add a state so that we can do data-state="expanded" or "collapsed".
   // This makes it easier to style the sidebar with Tailwind classes.
-  const state = open ? "expanded" : "collapsed";
+  const state = open ? 'expanded' : 'collapsed';
 
   const contextValue = React.useMemo<SidebarContextProps>(
     () => ({
@@ -133,13 +125,13 @@ function SidebarProvider({
           data-slot="sidebar-wrapper"
           style={
             {
-              "--sidebar-width": SIDEBAR_WIDTH,
-              "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
+              '--sidebar-width': SIDEBAR_WIDTH,
+              '--sidebar-width-icon': SIDEBAR_WIDTH_ICON,
               ...style,
             } as React.CSSProperties
           }
           className={cn(
-            "group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full",
+            'group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full',
             className,
           )}
           {...props}
@@ -152,25 +144,25 @@ function SidebarProvider({
 }
 
 function Sidebar({
-  side = "left",
-  variant = "sidebar",
-  collapsible = "offcanvas",
+  side = 'left',
+  variant = 'sidebar',
+  collapsible = 'offcanvas',
   className,
   children,
   ...props
-}: React.ComponentProps<"div"> & {
-  side?: "left" | "right";
-  variant?: "sidebar" | "floating" | "inset";
-  collapsible?: "offcanvas" | "icon" | "none";
+}: React.ComponentProps<'div'> & {
+  side?: 'left' | 'right';
+  variant?: 'sidebar' | 'floating' | 'inset';
+  collapsible?: 'offcanvas' | 'icon' | 'none';
 }) {
   const { isMobile, state, openMobile, setOpenMobile } = useSidebar();
 
-  if (collapsible === "none") {
+  if (collapsible === 'none') {
     return (
       <div
         data-slot="sidebar"
         className={cn(
-          "bg-sidebar text-sidebar-foreground flex h-full w-(--sidebar-width) flex-col",
+          'bg-sidebar text-sidebar-foreground flex h-full w-(--sidebar-width) flex-col',
           className,
         )}
         {...props}
@@ -190,7 +182,7 @@ function Sidebar({
           className="bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden"
           style={
             {
-              "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
+              '--sidebar-width': SIDEBAR_WIDTH_MOBILE,
             } as React.CSSProperties
           }
           side={side}
@@ -209,7 +201,7 @@ function Sidebar({
     <div
       className="group peer text-sidebar-foreground hidden md:block"
       data-state={state}
-      data-collapsible={state === "collapsed" ? collapsible : ""}
+      data-collapsible={state === 'collapsed' ? collapsible : ''}
       data-variant={variant}
       data-side={side}
       data-slot="sidebar"
@@ -218,25 +210,25 @@ function Sidebar({
       <div
         data-slot="sidebar-gap"
         className={cn(
-          "relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
-          "group-data-[collapsible=offcanvas]:w-0",
-          "group-data-[side=right]:rotate-180",
-          variant === "floating" || variant === "inset"
-            ? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]"
-            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon)",
+          'relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear',
+          'group-data-[collapsible=offcanvas]:w-0',
+          'group-data-[side=right]:rotate-180',
+          variant === 'floating' || variant === 'inset'
+            ? 'group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]'
+            : 'group-data-[collapsible=icon]:w-(--sidebar-width-icon)',
         )}
       />
       <div
         data-slot="sidebar-container"
         className={cn(
-          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
-          side === "left"
-            ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
-            : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
+          'fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex',
+          side === 'left'
+            ? 'left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]'
+            : 'right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]',
           // Adjust the padding for floating and inset variants.
-          variant === "floating" || variant === "inset"
-            ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
-            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l",
+          variant === 'floating' || variant === 'inset'
+            ? 'p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]'
+            : 'group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l',
           className,
         )}
         {...props}
@@ -253,11 +245,7 @@ function Sidebar({
   );
 }
 
-function SidebarTrigger({
-  className,
-  onClick,
-  ...props
-}: React.ComponentProps<typeof Button>) {
+function SidebarTrigger({ className, onClick, ...props }: React.ComponentProps<typeof Button>) {
   const { toggleSidebar } = useSidebar();
 
   return (
@@ -266,7 +254,7 @@ function SidebarTrigger({
       data-slot="sidebar-trigger"
       variant="ghost"
       size="icon"
-      className={cn("size-7", className)}
+      className={cn('size-7', className)}
       onClick={(event) => {
         onClick?.(event);
         toggleSidebar();
@@ -279,7 +267,7 @@ function SidebarTrigger({
   );
 }
 
-function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
+function SidebarRail({ className, ...props }: React.ComponentProps<'button'>) {
   const { toggleSidebar } = useSidebar();
 
   return (
@@ -291,12 +279,12 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
       onClick={toggleSidebar}
       title="Toggle Sidebar"
       className={cn(
-        "hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex",
-        "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
-        "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
-        "hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full",
-        "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
-        "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
+        'hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex',
+        'in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize',
+        '[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize',
+        'hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full',
+        '[[data-side=left][data-collapsible=offcanvas]_&]:-right-2',
+        '[[data-side=right][data-collapsible=offcanvas]_&]:-left-2',
         className,
       )}
       {...props}
@@ -304,13 +292,13 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
   );
 }
 
-function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
+function SidebarInset({ className, ...props }: React.ComponentProps<'main'>) {
   return (
     <main
       data-slot="sidebar-inset"
       className={cn(
-        "bg-background relative flex w-full flex-1 flex-col",
-        "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
+        'bg-background relative flex w-full flex-1 flex-col',
+        'md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2',
         className,
       )}
       {...props}
@@ -318,63 +306,57 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
   );
 }
 
-function SidebarInput({
-  className,
-  ...props
-}: React.ComponentProps<typeof Input>) {
+function SidebarInput({ className, ...props }: React.ComponentProps<typeof Input>) {
   return (
     <Input
       data-slot="sidebar-input"
       data-sidebar="input"
-      className={cn("bg-background h-8 w-full shadow-none", className)}
+      className={cn('bg-background h-8 w-full shadow-none', className)}
       {...props}
     />
   );
 }
 
-function SidebarHeader({ className, ...props }: React.ComponentProps<"div">) {
+function SidebarHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="sidebar-header"
       data-sidebar="header"
-      className={cn("flex flex-col gap-2 p-2", className)}
+      className={cn('flex flex-col gap-2 p-2', className)}
       {...props}
     />
   );
 }
 
-function SidebarFooter({ className, ...props }: React.ComponentProps<"div">) {
+function SidebarFooter({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="sidebar-footer"
       data-sidebar="footer"
-      className={cn("flex flex-col gap-2 p-2", className)}
+      className={cn('flex flex-col gap-2 p-2', className)}
       {...props}
     />
   );
 }
 
-function SidebarSeparator({
-  className,
-  ...props
-}: React.ComponentProps<typeof Separator>) {
+function SidebarSeparator({ className, ...props }: React.ComponentProps<typeof Separator>) {
   return (
     <Separator
       data-slot="sidebar-separator"
       data-sidebar="separator"
-      className={cn("bg-sidebar-border mx-2 w-auto", className)}
+      className={cn('bg-sidebar-border mx-2 w-auto', className)}
       {...props}
     />
   );
 }
 
-function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
+function SidebarContent({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="sidebar-content"
       data-sidebar="content"
       className={cn(
-        "flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        'flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden',
         className,
       )}
       {...props}
@@ -382,12 +364,12 @@ function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
   );
 }
 
-function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {
+function SidebarGroup({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="sidebar-group"
       data-sidebar="group"
-      className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
+      className={cn('relative flex w-full min-w-0 flex-col p-2', className)}
       {...props}
     />
   );
@@ -397,16 +379,16 @@ function SidebarGroupLabel({
   className,
   asChild = false,
   ...props
-}: React.ComponentProps<"div"> & { asChild?: boolean }) {
-  const Comp = asChild ? Slot : "div";
+}: React.ComponentProps<'div'> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : 'div';
 
   return (
     <Comp
       data-slot="sidebar-group-label"
       data-sidebar="group-label"
       className={cn(
-        "text-sidebar-foreground/70 ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
-        "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
+        'text-sidebar-foreground/70 ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
+        'group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0',
         className,
       )}
       {...props}
@@ -418,18 +400,18 @@ function SidebarGroupAction({
   className,
   asChild = false,
   ...props
-}: React.ComponentProps<"button"> & { asChild?: boolean }) {
-  const Comp = asChild ? Slot : "button";
+}: React.ComponentProps<'button'> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : 'button';
 
   return (
     <Comp
       data-slot="sidebar-group-action"
       data-sidebar="group-action"
       className={cn(
-        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
         // Increases the hit area of the button on mobile.
-        "after:absolute after:-inset-2 md:after:hidden",
-        "group-data-[collapsible=icon]:hidden",
+        'after:absolute after:-inset-2 md:after:hidden',
+        'group-data-[collapsible=icon]:hidden',
         className,
       )}
       {...props}
@@ -437,60 +419,57 @@ function SidebarGroupAction({
   );
 }
 
-function SidebarGroupContent({
-  className,
-  ...props
-}: React.ComponentProps<"div">) {
+function SidebarGroupContent({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="sidebar-group-content"
       data-sidebar="group-content"
-      className={cn("w-full text-sm", className)}
+      className={cn('w-full text-sm', className)}
       {...props}
     />
   );
 }
 
-function SidebarMenu({ className, ...props }: React.ComponentProps<"ul">) {
+function SidebarMenu({ className, ...props }: React.ComponentProps<'ul'>) {
   return (
     <ul
       data-slot="sidebar-menu"
       data-sidebar="menu"
-      className={cn("flex w-full min-w-0 flex-col gap-1", className)}
+      className={cn('flex w-full min-w-0 flex-col gap-1', className)}
       {...props}
     />
   );
 }
 
-function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
+function SidebarMenuItem({ className, ...props }: React.ComponentProps<'li'>) {
   return (
     <li
       data-slot="sidebar-menu-item"
       data-sidebar="menu-item"
-      className={cn("group/menu-item relative", className)}
+      className={cn('group/menu-item relative', className)}
       {...props}
     />
   );
 }
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
   {
     variants: {
       variant: {
-        default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+        default: 'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
         outline:
-          "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
+          'bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]',
       },
       size: {
-        default: "h-8 text-sm",
-        sm: "h-7 text-xs",
-        lg: "h-12 text-sm group-data-[collapsible=icon]:p-0!",
+        default: 'h-8 text-sm',
+        sm: 'h-7 text-xs',
+        lg: 'h-12 text-sm group-data-[collapsible=icon]:p-0!',
       },
     },
     defaultVariants: {
-      variant: "default",
-      size: "default",
+      variant: 'default',
+      size: 'default',
     },
   },
 );
@@ -498,17 +477,17 @@ const sidebarMenuButtonVariants = cva(
 function SidebarMenuButton({
   asChild = false,
   isActive = false,
-  variant = "default",
-  size = "default",
+  variant = 'default',
+  size = 'default',
   tooltip,
   className,
   ...props
-}: React.ComponentProps<"button"> & {
+}: React.ComponentProps<'button'> & {
   asChild?: boolean;
   isActive?: boolean;
   tooltip?: string | React.ComponentProps<typeof TooltipContent>;
 } & VariantProps<typeof sidebarMenuButtonVariants>) {
-  const Comp = asChild ? Slot : "button";
+  const Comp = asChild ? Slot : 'button';
   const { isMobile, state } = useSidebar();
 
   const button = (
@@ -526,7 +505,7 @@ function SidebarMenuButton({
     return button;
   }
 
-  if (typeof tooltip === "string") {
+  if (typeof tooltip === 'string') {
     tooltip = {
       children: tooltip,
     };
@@ -538,7 +517,7 @@ function SidebarMenuButton({
       <TooltipContent
         side="right"
         align="center"
-        hidden={state !== "collapsed" || isMobile}
+        hidden={state !== 'collapsed' || isMobile}
         {...tooltip}
       />
     </Tooltip>
@@ -550,26 +529,26 @@ function SidebarMenuAction({
   asChild = false,
   showOnHover = false,
   ...props
-}: React.ComponentProps<"button"> & {
+}: React.ComponentProps<'button'> & {
   asChild?: boolean;
   showOnHover?: boolean;
 }) {
-  const Comp = asChild ? Slot : "button";
+  const Comp = asChild ? Slot : 'button';
 
   return (
     <Comp
       data-slot="sidebar-menu-action"
       data-sidebar="menu-action"
       className={cn(
-        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
         // Increases the hit area of the button on mobile.
-        "after:absolute after:-inset-2 md:after:hidden",
-        "peer-data-[size=sm]/menu-button:top-1",
-        "peer-data-[size=default]/menu-button:top-1.5",
-        "peer-data-[size=lg]/menu-button:top-2.5",
-        "group-data-[collapsible=icon]:hidden",
+        'after:absolute after:-inset-2 md:after:hidden',
+        'peer-data-[size=sm]/menu-button:top-1',
+        'peer-data-[size=default]/menu-button:top-1.5',
+        'peer-data-[size=lg]/menu-button:top-2.5',
+        'group-data-[collapsible=icon]:hidden',
         showOnHover &&
-          "peer-data-[active=true]/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 md:opacity-0",
+          'peer-data-[active=true]/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 md:opacity-0',
         className,
       )}
       {...props}
@@ -577,21 +556,18 @@ function SidebarMenuAction({
   );
 }
 
-function SidebarMenuBadge({
-  className,
-  ...props
-}: React.ComponentProps<"div">) {
+function SidebarMenuBadge({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="sidebar-menu-badge"
       data-sidebar="menu-badge"
       className={cn(
-        "text-sidebar-foreground pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums select-none",
-        "peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground",
-        "peer-data-[size=sm]/menu-button:top-1",
-        "peer-data-[size=default]/menu-button:top-1.5",
-        "peer-data-[size=lg]/menu-button:top-2.5",
-        "group-data-[collapsible=icon]:hidden",
+        'text-sidebar-foreground pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums select-none',
+        'peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground',
+        'peer-data-[size=sm]/menu-button:top-1',
+        'peer-data-[size=default]/menu-button:top-1.5',
+        'peer-data-[size=lg]/menu-button:top-2.5',
+        'group-data-[collapsible=icon]:hidden',
         className,
       )}
       {...props}
@@ -603,7 +579,7 @@ function SidebarMenuSkeleton({
   className,
   showIcon = false,
   ...props
-}: React.ComponentProps<"div"> & {
+}: React.ComponentProps<'div'> & {
   showIcon?: boolean;
 }) {
   // Random width between 50 to 90%.
@@ -615,21 +591,16 @@ function SidebarMenuSkeleton({
     <div
       data-slot="sidebar-menu-skeleton"
       data-sidebar="menu-skeleton"
-      className={cn("flex h-8 items-center gap-2 rounded-md px-2", className)}
+      className={cn('flex h-8 items-center gap-2 rounded-md px-2', className)}
       {...props}
     >
-      {showIcon && (
-        <Skeleton
-          className="size-4 rounded-md"
-          data-sidebar="menu-skeleton-icon"
-        />
-      )}
+      {showIcon && <Skeleton className="size-4 rounded-md" data-sidebar="menu-skeleton-icon" />}
       <Skeleton
         className="h-4 max-w-(--skeleton-width) flex-1"
         data-sidebar="menu-skeleton-text"
         style={
           {
-            "--skeleton-width": width,
+            '--skeleton-width': width,
           } as React.CSSProperties
         }
       />
@@ -637,14 +608,14 @@ function SidebarMenuSkeleton({
   );
 }
 
-function SidebarMenuSub({ className, ...props }: React.ComponentProps<"ul">) {
+function SidebarMenuSub({ className, ...props }: React.ComponentProps<'ul'>) {
   return (
     <ul
       data-slot="sidebar-menu-sub"
       data-sidebar="menu-sub"
       className={cn(
-        "border-sidebar-border mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l px-2.5 py-0.5",
-        "group-data-[collapsible=icon]:hidden",
+        'border-sidebar-border mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l px-2.5 py-0.5',
+        'group-data-[collapsible=icon]:hidden',
         className,
       )}
       {...props}
@@ -652,15 +623,12 @@ function SidebarMenuSub({ className, ...props }: React.ComponentProps<"ul">) {
   );
 }
 
-function SidebarMenuSubItem({
-  className,
-  ...props
-}: React.ComponentProps<"li">) {
+function SidebarMenuSubItem({ className, ...props }: React.ComponentProps<'li'>) {
   return (
     <li
       data-slot="sidebar-menu-sub-item"
       data-sidebar="menu-sub-item"
-      className={cn("group/menu-sub-item relative", className)}
+      className={cn('group/menu-sub-item relative', className)}
       {...props}
     />
   );
@@ -668,16 +636,16 @@ function SidebarMenuSubItem({
 
 function SidebarMenuSubButton({
   asChild = false,
-  size = "md",
+  size = 'md',
   isActive = false,
   className,
   ...props
-}: React.ComponentProps<"a"> & {
+}: React.ComponentProps<'a'> & {
   asChild?: boolean;
-  size?: "sm" | "md";
+  size?: 'sm' | 'md';
   isActive?: boolean;
 }) {
-  const Comp = asChild ? Slot : "a";
+  const Comp = asChild ? Slot : 'a';
 
   return (
     <Comp
@@ -686,11 +654,11 @@ function SidebarMenuSubButton({
       data-size={size}
       data-active={isActive}
       className={cn(
-        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-hidden focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
-        "data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground",
-        size === "sm" && "text-xs",
-        size === "md" && "text-sm",
-        "group-data-[collapsible=icon]:hidden",
+        'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-hidden focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
+        'data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground',
+        size === 'sm' && 'text-xs',
+        size === 'md' && 'text-sm',
+        'group-data-[collapsible=icon]:hidden',
         className,
       )}
       {...props}

--- a/frontend/src/components/ui/skeleton.tsx
+++ b/frontend/src/components/ui/skeleton.tsx
@@ -1,13 +1,13 @@
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="skeleton"
-      className={cn("bg-accent animate-pulse rounded-md", className)}
+      className={cn('bg-accent animate-pulse rounded-md', className)}
       {...props}
     />
-  )
+  );
 }
 
-export { Skeleton }
+export { Skeleton };

--- a/frontend/src/components/ui/slider.tsx
+++ b/frontend/src/components/ui/slider.tsx
@@ -1,9 +1,9 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import * as SliderPrimitive from "@radix-ui/react-slider"
+import * as React from 'react';
+import * as SliderPrimitive from '@radix-ui/react-slider';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 function Slider({
   className,
@@ -14,14 +14,9 @@ function Slider({
   ...props
 }: React.ComponentProps<typeof SliderPrimitive.Root>) {
   const _values = React.useMemo(
-    () =>
-      Array.isArray(value)
-        ? value
-        : Array.isArray(defaultValue)
-          ? defaultValue
-          : [min, max],
-    [value, defaultValue, min, max]
-  )
+    () => (Array.isArray(value) ? value : Array.isArray(defaultValue) ? defaultValue : [min, max]),
+    [value, defaultValue, min, max],
+  );
 
   return (
     <SliderPrimitive.Root
@@ -31,21 +26,21 @@ function Slider({
       min={min}
       max={max}
       className={cn(
-        "relative flex w-full touch-none items-center select-none data-[disabled]:opacity-50 data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col",
-        className
+        'relative flex w-full touch-none items-center select-none data-[disabled]:opacity-50 data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col',
+        className,
       )}
       {...props}
     >
       <SliderPrimitive.Track
         data-slot="slider-track"
         className={cn(
-          "bg-muted relative grow overflow-hidden rounded-full data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5"
+          'bg-muted relative grow overflow-hidden rounded-full data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5',
         )}
       >
         <SliderPrimitive.Range
           data-slot="slider-range"
           className={cn(
-            "bg-primary absolute data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full"
+            'bg-primary absolute data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full',
           )}
         />
       </SliderPrimitive.Track>
@@ -57,7 +52,7 @@ function Slider({
         />
       ))}
     </SliderPrimitive.Root>
-  )
+  );
 }
 
-export { Slider }
+export { Slider };

--- a/frontend/src/components/ui/sonner.tsx
+++ b/frontend/src/components/ui/sonner.tsx
@@ -1,18 +1,18 @@
-import { useTheme } from "next-themes";
-import { Toaster as Sonner, type ToasterProps } from "sonner";
+import { useTheme } from 'next-themes';
+import { Toaster as Sonner, type ToasterProps } from 'sonner';
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme();
+  const { theme = 'system' } = useTheme();
 
   return (
     <Sonner
-      theme={theme as ToasterProps["theme"]}
+      theme={theme as ToasterProps['theme']}
       className="toaster group"
       style={
         {
-          "--normal-bg": "var(--popover)",
-          "--normal-text": "var(--popover-foreground)",
-          "--normal-border": "var(--border)",
+          '--normal-bg': 'var(--popover)',
+          '--normal-text': 'var(--popover-foreground)',
+          '--normal-border': 'var(--border)',
         } as React.CSSProperties
       }
       {...props}

--- a/frontend/src/components/ui/switch.tsx
+++ b/frontend/src/components/ui/switch.tsx
@@ -1,31 +1,28 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import * as SwitchPrimitive from "@radix-ui/react-switch"
+import * as React from 'react';
+import * as SwitchPrimitive from '@radix-ui/react-switch';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-function Switch({
-  className,
-  ...props
-}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+function Switch({ className, ...props }: React.ComponentProps<typeof SwitchPrimitive.Root>) {
   return (
     <SwitchPrimitive.Root
       data-slot="switch"
       className={cn(
-        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
-        className
+        'peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+        className,
       )}
       {...props}
     >
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
         className={cn(
-          "bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0"
+          'bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0',
         )}
       />
     </SwitchPrimitive.Root>
-  )
+  );
 }
 
-export { Switch }
+export { Switch };

--- a/frontend/src/components/ui/table.tsx
+++ b/frontend/src/components/ui/table.tsx
@@ -1,114 +1,90 @@
-import * as React from "react"
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-function Table({ className, ...props }: React.ComponentProps<"table">) {
+function Table({ className, ...props }: React.ComponentProps<'table'>) {
   return (
-    <div
-      data-slot="table-container"
-      className="relative w-full overflow-x-auto"
-    >
+    <div data-slot="table-container" className="relative w-full overflow-x-auto">
       <table
         data-slot="table"
-        className={cn("w-full caption-bottom text-sm", className)}
+        className={cn('w-full caption-bottom text-sm', className)}
         {...props}
       />
     </div>
-  )
+  );
 }
 
-function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
-  return (
-    <thead
-      data-slot="table-header"
-      className={cn("[&_tr]:border-b", className)}
-      {...props}
-    />
-  )
+function TableHeader({ className, ...props }: React.ComponentProps<'thead'>) {
+  return <thead data-slot="table-header" className={cn('[&_tr]:border-b', className)} {...props} />;
 }
 
-function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+function TableBody({ className, ...props }: React.ComponentProps<'tbody'>) {
   return (
     <tbody
       data-slot="table-body"
-      className={cn("[&_tr:last-child]:border-0", className)}
+      className={cn('[&_tr:last-child]:border-0', className)}
       {...props}
     />
-  )
+  );
 }
 
-function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+function TableFooter({ className, ...props }: React.ComponentProps<'tfoot'>) {
   return (
     <tfoot
       data-slot="table-footer"
-      className={cn(
-        "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
-        className
-      )}
+      className={cn('bg-muted/50 border-t font-medium [&>tr]:last:border-b-0', className)}
       {...props}
     />
-  )
+  );
 }
 
-function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+function TableRow({ className, ...props }: React.ComponentProps<'tr'>) {
   return (
     <tr
       data-slot="table-row"
       className={cn(
-        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
-        className
+        'hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+function TableHead({ className, ...props }: React.ComponentProps<'th'>) {
   return (
     <th
       data-slot="table-head"
       className={cn(
-        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
-        className
+        'text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+function TableCell({ className, ...props }: React.ComponentProps<'td'>) {
   return (
     <td
       data-slot="table-cell"
       className={cn(
-        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
-        className
+        'p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-function TableCaption({
-  className,
-  ...props
-}: React.ComponentProps<"caption">) {
+function TableCaption({ className, ...props }: React.ComponentProps<'caption'>) {
   return (
     <caption
       data-slot="table-caption"
-      className={cn("text-muted-foreground mt-4 text-sm", className)}
+      className={cn('text-muted-foreground mt-4 text-sm', className)}
       {...props}
     />
-  )
+  );
 }
 
-export {
-  Table,
-  TableHeader,
-  TableBody,
-  TableFooter,
-  TableHead,
-  TableRow,
-  TableCell,
-  TableCaption,
-}
+export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -1,66 +1,54 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import * as TabsPrimitive from "@radix-ui/react-tabs"
+import * as React from 'react';
+import * as TabsPrimitive from '@radix-ui/react-tabs';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-function Tabs({
-  className,
-  ...props
-}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+function Tabs({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Root>) {
   return (
     <TabsPrimitive.Root
       data-slot="tabs"
-      className={cn("flex flex-col gap-2", className)}
+      className={cn('flex flex-col gap-2', className)}
       {...props}
     />
-  )
+  );
 }
 
-function TabsList({
-  className,
-  ...props
-}: React.ComponentProps<typeof TabsPrimitive.List>) {
+function TabsList({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.List>) {
   return (
     <TabsPrimitive.List
       data-slot="tabs-list"
       className={cn(
-        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]",
-        className
+        'bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-function TabsTrigger({
-  className,
-  ...props
-}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
   return (
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
         "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-function TabsContent({
-  className,
-  ...props
-}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+function TabsContent({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Content>) {
   return (
     <TabsPrimitive.Content
       data-slot="tabs-content"
-      className={cn("flex-1 outline-none", className)}
+      className={cn('flex-1 outline-none', className)}
       {...props}
     />
-  )
+  );
 }
 
-export { Tabs, TabsList, TabsTrigger, TabsContent }
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -1,18 +1,18 @@
-import * as React from "react"
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
   return (
     <textarea
       data-slot="textarea"
       className={cn(
-        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        className
+        'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Textarea }
+export { Textarea };

--- a/frontend/src/components/ui/toggle-group.tsx
+++ b/frontend/src/components/ui/toggle-group.tsx
@@ -1,16 +1,14 @@
-import * as React from "react"
-import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group"
-import { type VariantProps } from "class-variance-authority"
+import * as React from 'react';
+import * as ToggleGroupPrimitive from '@radix-ui/react-toggle-group';
+import { type VariantProps } from 'class-variance-authority';
 
-import { cn } from "@/lib/utils"
-import { toggleVariants } from "@/components/ui/toggle"
+import { cn } from '@/lib/utils';
+import { toggleVariants } from '@/components/ui/toggle';
 
-const ToggleGroupContext = React.createContext<
-  VariantProps<typeof toggleVariants>
->({
-  size: "default",
-  variant: "default",
-})
+const ToggleGroupContext = React.createContext<VariantProps<typeof toggleVariants>>({
+  size: 'default',
+  variant: 'default',
+});
 
 function ToggleGroup({
   className,
@@ -18,16 +16,15 @@ function ToggleGroup({
   size,
   children,
   ...props
-}: React.ComponentProps<typeof ToggleGroupPrimitive.Root> &
-  VariantProps<typeof toggleVariants>) {
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Root> & VariantProps<typeof toggleVariants>) {
   return (
     <ToggleGroupPrimitive.Root
       data-slot="toggle-group"
       data-variant={variant}
       data-size={size}
       className={cn(
-        "group/toggle-group flex w-fit items-center rounded-md data-[variant=outline]:shadow-xs",
-        className
+        'group/toggle-group flex w-fit items-center rounded-md data-[variant=outline]:shadow-xs',
+        className,
       )}
       {...props}
     >
@@ -35,7 +32,7 @@ function ToggleGroup({
         {children}
       </ToggleGroupContext.Provider>
     </ToggleGroupPrimitive.Root>
-  )
+  );
 }
 
 function ToggleGroupItem({
@@ -44,9 +41,8 @@ function ToggleGroupItem({
   variant,
   size,
   ...props
-}: React.ComponentProps<typeof ToggleGroupPrimitive.Item> &
-  VariantProps<typeof toggleVariants>) {
-  const context = React.useContext(ToggleGroupContext)
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Item> & VariantProps<typeof toggleVariants>) {
+  const context = React.useContext(ToggleGroupContext);
 
   return (
     <ToggleGroupPrimitive.Item
@@ -58,14 +54,14 @@ function ToggleGroupItem({
           variant: context.variant || variant,
           size: context.size || size,
         }),
-        "min-w-0 flex-1 shrink-0 rounded-none shadow-none first:rounded-l-md last:rounded-r-md focus:z-10 focus-visible:z-10 data-[variant=outline]:border-l-0 data-[variant=outline]:first:border-l",
-        className
+        'min-w-0 flex-1 shrink-0 rounded-none shadow-none first:rounded-l-md last:rounded-r-md focus:z-10 focus-visible:z-10 data-[variant=outline]:border-l-0 data-[variant=outline]:first:border-l',
+        className,
       )}
       {...props}
     >
       {children}
     </ToggleGroupPrimitive.Item>
-  )
+  );
 }
 
-export { ToggleGroup, ToggleGroupItem }
+export { ToggleGroup, ToggleGroupItem };

--- a/frontend/src/components/ui/toggle.tsx
+++ b/frontend/src/components/ui/toggle.tsx
@@ -1,45 +1,44 @@
-import * as React from "react"
-import * as TogglePrimitive from "@radix-ui/react-toggle"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from 'react';
+import * as TogglePrimitive from '@radix-ui/react-toggle';
+import { cva, type VariantProps } from 'class-variance-authority';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 const toggleVariants = cva(
   "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap",
   {
     variants: {
       variant: {
-        default: "bg-transparent",
+        default: 'bg-transparent',
         outline:
-          "border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground",
+          'border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground',
       },
       size: {
-        default: "h-9 px-2 min-w-9",
-        sm: "h-8 px-1.5 min-w-8",
-        lg: "h-10 px-2.5 min-w-10",
+        default: 'h-9 px-2 min-w-9',
+        sm: 'h-8 px-1.5 min-w-8',
+        lg: 'h-10 px-2.5 min-w-10',
       },
     },
     defaultVariants: {
-      variant: "default",
-      size: "default",
+      variant: 'default',
+      size: 'default',
     },
-  }
-)
+  },
+);
 
 function Toggle({
   className,
   variant,
   size,
   ...props
-}: React.ComponentProps<typeof TogglePrimitive.Root> &
-  VariantProps<typeof toggleVariants>) {
+}: React.ComponentProps<typeof TogglePrimitive.Root> & VariantProps<typeof toggleVariants>) {
   return (
     <TogglePrimitive.Root
       data-slot="toggle"
       className={cn(toggleVariants({ variant, size, className }))}
       {...props}
     />
-  )
+  );
 }
 
-export { Toggle, toggleVariants }
+export { Toggle, toggleVariants };

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -1,9 +1,9 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+import * as React from 'react';
+import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 function TooltipProvider({
   delayDuration = 0,
@@ -15,23 +15,19 @@ function TooltipProvider({
       delayDuration={delayDuration}
       {...props}
     />
-  )
+  );
 }
 
-function Tooltip({
-  ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+function Tooltip({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
   return (
     <TooltipProvider>
       <TooltipPrimitive.Root data-slot="tooltip" {...props} />
     </TooltipProvider>
-  )
+  );
 }
 
-function TooltipTrigger({
-  ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
-  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+function TooltipTrigger({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
 }
 
 function TooltipContent({
@@ -46,8 +42,8 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
-          className
+          'bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance',
+          className,
         )}
         {...props}
       >
@@ -55,7 +51,7 @@ function TooltipContent({
         <TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
-  )
+  );
 }
 
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/frontend/src/hooks/use-mobile.ts
+++ b/frontend/src/hooks/use-mobile.ts
@@ -1,19 +1,19 @@
-import * as React from "react"
+import * as React from 'react';
 
-const MOBILE_BREAKPOINT = 768
+const MOBILE_BREAKPOINT = 768;
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined);
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
     const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    }
-    mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener("change", onChange)
-  }, [])
+      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    };
+    mql.addEventListener('change', onChange);
+    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    return () => mql.removeEventListener('change', onChange);
+  }, []);
 
-  return !!isMobile
+  return !!isMobile;
 }

--- a/frontend/src/hooks/useConversions.ts
+++ b/frontend/src/hooks/useConversions.ts
@@ -1,15 +1,9 @@
-import { useState, useEffect, useCallback } from "react";
-import { conversionsApi, ApiError } from "../services/api";
-import type {
-  ConversionJob,
-  ConversionStats,
-  PaginatedResponse,
-} from "../types/api";
+import { useState, useEffect, useCallback } from 'react';
+import { conversionsApi, ApiError } from '../services/api';
+import type { ConversionJob, ConversionStats, PaginatedResponse } from '../types/api';
 
 export function useConversions(page = 1, limit = 20, status?: string) {
-  const [data, setData] = useState<PaginatedResponse<ConversionJob> | null>(
-    null,
-  );
+  const [data, setData] = useState<PaginatedResponse<ConversionJob> | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -20,12 +14,9 @@ export function useConversions(page = 1, limit = 20, status?: string) {
       const response = await conversionsApi.getAll(page, limit, status);
       setData(response);
     } catch (err) {
-      const errorMessage =
-        err instanceof ApiError
-          ? err.message
-          : "Failed to load conversions";
+      const errorMessage = err instanceof ApiError ? err.message : 'Failed to load conversions';
       setError(errorMessage);
-      console.error("Error fetching conversions:", err);
+      console.error('Error fetching conversions:', err);
     } finally {
       setLoading(false);
     }
@@ -38,10 +29,7 @@ export function useConversions(page = 1, limit = 20, status?: string) {
         await fetchConversions();
         return cancelledJob;
       } catch (err) {
-        const errorMessage =
-          err instanceof ApiError
-            ? err.message
-            : "Failed to cancel job";
+        const errorMessage = err instanceof ApiError ? err.message : 'Failed to cancel job';
         throw new Error(errorMessage);
       }
     },
@@ -55,10 +43,7 @@ export function useConversions(page = 1, limit = 20, status?: string) {
         await fetchConversions();
         return retriedJob;
       } catch (err) {
-        const errorMessage =
-          err instanceof ApiError
-            ? err.message
-            : "Failed to retry job";
+        const errorMessage = err instanceof ApiError ? err.message : 'Failed to retry job';
         throw new Error(errorMessage);
       }
     },
@@ -92,12 +77,9 @@ export function useConversionStats() {
       const data = await conversionsApi.getStats();
       setStats(data);
     } catch (err) {
-      const errorMessage =
-        err instanceof ApiError
-          ? err.message
-          : "Failed to load statistics";
+      const errorMessage = err instanceof ApiError ? err.message : 'Failed to load statistics';
       setError(errorMessage);
-      console.error("Error fetching conversion stats:", err);
+      console.error('Error fetching conversion stats:', err);
     } finally {
       setLoading(false);
     }
@@ -139,12 +121,9 @@ export function useJobProgress(jobId: string | null, pollingInterval = 2000) {
       const data = await conversionsApi.getProgress(jobId);
       setProgress(data);
     } catch (err) {
-      const errorMessage =
-        err instanceof ApiError
-          ? err.message
-          : "Failed to load progress";
+      const errorMessage = err instanceof ApiError ? err.message : 'Failed to load progress';
       setError(errorMessage);
-      console.error("Error fetching job progress:", err);
+      console.error('Error fetching job progress:', err);
     } finally {
       setLoading(false);
     }
@@ -159,7 +138,7 @@ export function useJobProgress(jobId: string | null, pollingInterval = 2000) {
     fetchProgress();
 
     const interval = setInterval(() => {
-      if (progress?.status === "processing" || progress?.status === "pending") {
+      if (progress?.status === 'processing' || progress?.status === 'pending') {
         fetchProgress();
       }
     }, pollingInterval);

--- a/frontend/src/hooks/useGoogleAuth.ts
+++ b/frontend/src/hooks/useGoogleAuth.ts
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useState } from "react";
-import { GOOGLE_TOKEN_EXPIRED_EVENT } from "../services/api";
-import { TokenStorage } from "../services/tokenStorage";
+import { useCallback, useEffect, useState } from 'react';
+import { GOOGLE_TOKEN_EXPIRED_EVENT } from '../services/api';
+import { TokenStorage } from '../services/tokenStorage';
 
 interface GoogleUser {
   email: string;
@@ -36,7 +36,7 @@ export function useGoogleAuth(): UseGoogleAuthReturn {
           return;
         }
 
-        const authData = localStorage.getItem("google_auth_data");
+        const authData = localStorage.getItem('google_auth_data');
         if (authData) {
           const parsedData = JSON.parse(authData);
           const userCredentials = {
@@ -48,20 +48,20 @@ export function useGoogleAuth(): UseGoogleAuthReturn {
 
           setUser(userCredentials);
           TokenStorage.saveCredentials(userCredentials);
-          localStorage.removeItem("google_auth_data");
+          localStorage.removeItem('google_auth_data');
         }
 
         const urlParams = new URLSearchParams(window.location.search);
-        const authError = urlParams.get("auth_error");
+        const authError = urlParams.get('auth_error');
         if (authError) {
           setError(authError);
 
           const newUrl = new URL(window.location.href);
-          newUrl.searchParams.delete("auth_error");
-          window.history.replaceState({}, "", newUrl.toString());
+          newUrl.searchParams.delete('auth_error');
+          window.history.replaceState({}, '', newUrl.toString());
         }
       } catch (err) {
-        console.error("Error checking auth data:", err);
+        console.error('Error checking auth data:', err);
       }
     };
 
@@ -76,9 +76,9 @@ export function useGoogleAuth(): UseGoogleAuthReturn {
 
   useEffect(() => {
     const handleTokenExpired = () => {
-      console.warn("Google token expired, disconnecting...");
+      console.warn('Google token expired, disconnecting...');
       disconnect();
-      setError("Your Google session has expired, please reconnect");
+      setError('Your Google session has expired, please reconnect');
     };
 
     window.addEventListener(GOOGLE_TOKEN_EXPIRED_EVENT, handleTokenExpired);
@@ -92,21 +92,16 @@ export function useGoogleAuth(): UseGoogleAuthReturn {
     setError(null);
 
     try {
-      const authResponse = await fetch(
-        `${import.meta.env.VITE_API_URL}/auth/google`,
-      );
+      const authResponse = await fetch(`${import.meta.env.VITE_API_URL}/auth/google`);
       const authData = await authResponse.json();
 
       if (!authData.success) {
-        throw new Error(
-          authData.message ||
-            "Error generating authorization URL",
-        );
+        throw new Error(authData.message || 'Error generating authorization URL');
       }
 
       window.location.href = authData.data.authUrl;
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Unknown error");
+      setError(err instanceof Error ? err.message : 'Unknown error');
       setIsConnecting(false);
     }
   };

--- a/frontend/src/hooks/useMonitoring.ts
+++ b/frontend/src/hooks/useMonitoring.ts
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useState } from "react";
-import { ApiError, monitoringApi } from "../services/api";
-import type { MonitoringStatus, SyncLog } from "../types/api";
+import { useCallback, useEffect, useState } from 'react';
+import { ApiError, monitoringApi } from '../services/api';
+import type { MonitoringStatus, SyncLog } from '../types/api';
 
 export function useMonitoring() {
   const [status, setStatus] = useState<MonitoringStatus | null>(null);
@@ -14,12 +14,9 @@ export function useMonitoring() {
       const data = await monitoringApi.getStatus();
       setStatus(data);
     } catch (err) {
-      const errorMessage =
-        err instanceof ApiError
-          ? err.message
-          : "Failed to load status";
+      const errorMessage = err instanceof ApiError ? err.message : 'Failed to load status';
       setError(errorMessage);
-      console.error("Error fetching monitoring status:", err);
+      console.error('Error fetching monitoring status:', err);
     } finally {
       setLoading(false);
     }
@@ -30,10 +27,7 @@ export function useMonitoring() {
       await monitoringApi.start();
       await fetchStatus();
     } catch (err) {
-      const errorMessage =
-        err instanceof ApiError
-          ? err.message
-          : "Failed to start monitoring";
+      const errorMessage = err instanceof ApiError ? err.message : 'Failed to start monitoring';
       throw new Error(errorMessage);
     }
   }, [fetchStatus]);
@@ -43,10 +37,7 @@ export function useMonitoring() {
       await monitoringApi.stop();
       await fetchStatus();
     } catch (err) {
-      const errorMessage =
-        err instanceof ApiError
-          ? err.message
-          : "Failed to stop monitoring";
+      const errorMessage = err instanceof ApiError ? err.message : 'Failed to stop monitoring';
       throw new Error(errorMessage);
     }
   }, [fetchStatus]);
@@ -56,10 +47,7 @@ export function useMonitoring() {
       await monitoringApi.restart();
       await fetchStatus();
     } catch (err) {
-      const errorMessage =
-        err instanceof ApiError
-          ? err.message
-          : "Failed to restart monitoring";
+      const errorMessage = err instanceof ApiError ? err.message : 'Failed to restart monitoring';
       throw new Error(errorMessage);
     }
   }, [fetchStatus]);
@@ -91,12 +79,9 @@ export function useLogs(sourceId?: string, limit = 50) {
       const data = await monitoringApi.getLogs(sourceId, limit);
       setLogs(data);
     } catch (err) {
-      const errorMessage =
-        err instanceof ApiError
-          ? err.message
-          : "Failed to load logs";
+      const errorMessage = err instanceof ApiError ? err.message : 'Failed to load logs';
       setError(errorMessage);
-      console.error("Error fetching logs:", err);
+      console.error('Error fetching logs:', err);
     } finally {
       setLoading(false);
     }
@@ -126,12 +111,9 @@ export function useHealthCheck() {
       const data = await monitoringApi.healthCheck();
       setHealth(data);
     } catch (err) {
-      const errorMessage =
-        err instanceof ApiError
-          ? err.message
-          : "Failed to check health";
+      const errorMessage = err instanceof ApiError ? err.message : 'Failed to check health';
       setError(errorMessage);
-      console.error("Error fetching health status:", err);
+      console.error('Error fetching health status:', err);
     } finally {
       setLoading(false);
     }

--- a/frontend/src/hooks/useSources.ts
+++ b/frontend/src/hooks/useSources.ts
@@ -1,83 +1,92 @@
-import { useState, useEffect, useCallback } from 'react'
-import { sourcesApi, ApiError } from '../services/api'
-import type { Source, CreateSourceRequest, SourceStats } from '../types/api'
+import { useState, useEffect, useCallback } from 'react';
+import { sourcesApi, ApiError } from '../services/api';
+import type { Source, CreateSourceRequest, SourceStats } from '../types/api';
 
 export function useSources() {
-  const [sources, setSources] = useState<Source[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  const [sources, setSources] = useState<Source[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   const fetchSources = useCallback(async () => {
     try {
-      setLoading(true)
-      setError(null)
-      const data = await sourcesApi.getAll()
-      setSources(data)
+      setLoading(true);
+      setError(null);
+      const data = await sourcesApi.getAll();
+      setSources(data);
     } catch (err) {
-      const errorMessage = err instanceof ApiError ? err.message : 'Failed to load sources'
-      setError(errorMessage)
-      console.error('Error fetching sources:', err)
+      const errorMessage = err instanceof ApiError ? err.message : 'Failed to load sources';
+      setError(errorMessage);
+      console.error('Error fetching sources:', err);
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
-  }, [])
+  }, []);
 
   const createSource = useCallback(async (sourceData: CreateSourceRequest): Promise<Source> => {
     try {
-      const newSource = await sourcesApi.create(sourceData)
-      setSources(prev => [...prev, newSource])
-      return newSource
+      const newSource = await sourcesApi.create(sourceData);
+      setSources((prev) => [...prev, newSource]);
+      return newSource;
     } catch (err) {
-      const errorMessage = err instanceof ApiError ? err.message : 'Failed to create source'
-      throw new Error(errorMessage)
+      const errorMessage = err instanceof ApiError ? err.message : 'Failed to create source';
+      throw new Error(errorMessage);
     }
-  }, [])
+  }, []);
 
-  const updateSource = useCallback(async (id: string, sourceData: Partial<CreateSourceRequest>): Promise<Source> => {
-    try {
-      const updatedSource = await sourcesApi.update(id, sourceData)
-      setSources(prev => prev.map(source => source.id === id ? updatedSource : source))
-      return updatedSource
-    } catch (err) {
-      const errorMessage = err instanceof ApiError ? err.message : 'Failed to update source'
-      throw new Error(errorMessage)
-    }
-  }, [])
+  const updateSource = useCallback(
+    async (id: string, sourceData: Partial<CreateSourceRequest>): Promise<Source> => {
+      try {
+        const updatedSource = await sourcesApi.update(id, sourceData);
+        setSources((prev) => prev.map((source) => (source.id === id ? updatedSource : source)));
+        return updatedSource;
+      } catch (err) {
+        const errorMessage = err instanceof ApiError ? err.message : 'Failed to update source';
+        throw new Error(errorMessage);
+      }
+    },
+    [],
+  );
 
   const deleteSource = useCallback(async (id: string): Promise<void> => {
     try {
-      await sourcesApi.delete(id)
-      setSources(prev => prev.filter(source => source.id !== id))
+      await sourcesApi.delete(id);
+      setSources((prev) => prev.filter((source) => source.id !== id));
     } catch (err) {
-      const errorMessage = err instanceof ApiError ? err.message : 'Failed to delete source'
-      throw new Error(errorMessage)
+      const errorMessage = err instanceof ApiError ? err.message : 'Failed to delete source';
+      throw new Error(errorMessage);
     }
-  }, [])
+  }, []);
 
-  const testConnection = useCallback(async (id: string) => {
-    try {
-      const result = await sourcesApi.testConnection(id)
-      await fetchSources()
-      return result
-    } catch (err) {
-      const errorMessage = err instanceof ApiError ? err.message : 'Failed to test connection'
-      throw new Error(errorMessage)
-    }
-  }, [fetchSources])
+  const testConnection = useCallback(
+    async (id: string) => {
+      try {
+        const result = await sourcesApi.testConnection(id);
+        await fetchSources();
+        return result;
+      } catch (err) {
+        const errorMessage = err instanceof ApiError ? err.message : 'Failed to test connection';
+        throw new Error(errorMessage);
+      }
+    },
+    [fetchSources],
+  );
 
-  const syncSource = useCallback(async (id: string): Promise<void> => {
-    try {
-      await sourcesApi.sync(id)
-      await fetchSources()
-    } catch (err) {
-      const errorMessage = err instanceof ApiError ? err.message : 'Failed to sync'
-      throw new Error(errorMessage)
-    }
-  }, [fetchSources])
+  const syncSource = useCallback(
+    async (id: string): Promise<void> => {
+      try {
+        await sourcesApi.sync(id);
+        await fetchSources();
+      } catch (err) {
+        const errorMessage = err instanceof ApiError ? err.message : 'Failed to sync';
+        throw new Error(errorMessage);
+      }
+    },
+    [fetchSources],
+  );
 
   useEffect(() => {
-    fetchSources()
-  }, [fetchSources])
+    fetchSources();
+  }, [fetchSources]);
 
   return {
     sources,
@@ -89,74 +98,74 @@ export function useSources() {
     deleteSource,
     testConnection,
     syncSource,
-  }
+  };
 }
 
 export function useSourceStats() {
-  const [stats, setStats] = useState<SourceStats | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  const [stats, setStats] = useState<SourceStats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   const fetchStats = useCallback(async () => {
     try {
-      setLoading(true)
-      setError(null)
-      const data = await sourcesApi.getStats()
-      setStats(data)
+      setLoading(true);
+      setError(null);
+      const data = await sourcesApi.getStats();
+      setStats(data);
     } catch (err) {
-      const errorMessage = err instanceof ApiError ? err.message : 'Failed to load statistics'
-      setError(errorMessage)
-      console.error('Error fetching source stats:', err)
+      const errorMessage = err instanceof ApiError ? err.message : 'Failed to load statistics';
+      setError(errorMessage);
+      console.error('Error fetching source stats:', err);
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
-  }, [])
+  }, []);
 
   useEffect(() => {
-    fetchStats()
-  }, [fetchStats])
+    fetchStats();
+  }, [fetchStats]);
 
   return {
     stats,
     loading,
     error,
     refetch: fetchStats,
-  }
+  };
 }
 
 export function useSource(id: string | null) {
-  const [source, setSource] = useState<Source | null>(null)
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const [source, setSource] = useState<Source | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const fetchSource = useCallback(async () => {
     if (!id) {
-      setSource(null)
-      return
+      setSource(null);
+      return;
     }
 
     try {
-      setLoading(true)
-      setError(null)
-      const data = await sourcesApi.getById(id)
-      setSource(data)
+      setLoading(true);
+      setError(null);
+      const data = await sourcesApi.getById(id);
+      setSource(data);
     } catch (err) {
-      const errorMessage = err instanceof ApiError ? err.message : 'Failed to load source'
-      setError(errorMessage)
-      console.error('Error fetching source:', err)
+      const errorMessage = err instanceof ApiError ? err.message : 'Failed to load source';
+      setError(errorMessage);
+      console.error('Error fetching source:', err);
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
-  }, [id])
+  }, [id]);
 
   useEffect(() => {
-    fetchSource()
-  }, [fetchSource])
+    fetchSource();
+  }, [fetchSource]);
 
   return {
     source,
     loading,
     error,
     refetch: fetchSource,
-  }
+  };
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,5 +1,5 @@
-@import "tailwindcss";
-@import "tw-animate-css";
+@import 'tailwindcss';
+@import 'tw-animate-css';
 
 @custom-variant dark (&:is(.dark *));
 

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,6 +1,6 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,10 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './index.css';
+import App from './App.tsx';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
   </StrictMode>,
-)
+);

--- a/frontend/src/pages/AuthCallback.tsx
+++ b/frontend/src/pages/AuthCallback.tsx
@@ -1,33 +1,27 @@
-import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { ArrowLeft, CheckCircle, Loader2, XCircle } from "lucide-react";
-import React, { useEffect } from "react";
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { ArrowLeft, CheckCircle, Loader2, XCircle } from 'lucide-react';
+import React, { useEffect } from 'react';
 
 const AuthCallback: React.FC = () => {
   useEffect(() => {
     const handleCallback = () => {
       try {
         const urlParams = new URLSearchParams(window.location.search);
-        const success = urlParams.get("success");
-        const encodedData = urlParams.get("data");
-        const error = urlParams.get("error");
+        const success = urlParams.get('success');
+        const encodedData = urlParams.get('data');
+        const error = urlParams.get('error');
 
-        if (success === "true" && encodedData) {
+        if (success === 'true' && encodedData) {
           const jsonData = atob(encodedData);
           const authData = JSON.parse(jsonData);
 
-          localStorage.setItem("google_auth_data", JSON.stringify(authData));
+          localStorage.setItem('google_auth_data', JSON.stringify(authData));
 
           if (window.opener) {
             window.opener.postMessage(
               {
-                type: "GOOGLE_AUTH_SUCCESS",
+                type: 'GOOGLE_AUTH_SUCCESS',
                 data: authData,
               },
               window.location.origin,
@@ -35,16 +29,16 @@ const AuthCallback: React.FC = () => {
             window.close();
           } else {
             setTimeout(() => {
-              window.location.href = "/";
+              window.location.href = '/';
             }, 2000);
           }
         } else if (error) {
-          console.error("Auth error:", error);
+          console.error('Auth error:', error);
 
           if (window.opener) {
             window.opener.postMessage(
               {
-                type: "GOOGLE_AUTH_ERROR",
+                type: 'GOOGLE_AUTH_ERROR',
                 error: error,
               },
               window.location.origin,
@@ -52,19 +46,18 @@ const AuthCallback: React.FC = () => {
             window.close();
           } else {
             setTimeout(() => {
-              window.location.href =
-                "/?auth_error=" + encodeURIComponent(error);
+              window.location.href = '/?auth_error=' + encodeURIComponent(error);
             }, 2000);
           }
         }
       } catch (err) {
-        console.error("Error processing auth callback:", err);
+        console.error('Error processing auth callback:', err);
 
         if (window.opener) {
           window.opener.postMessage(
             {
-              type: "GOOGLE_AUTH_ERROR",
-              error: "Error processing authentication",
+              type: 'GOOGLE_AUTH_ERROR',
+              error: 'Error processing authentication',
             },
             window.location.origin,
           );
@@ -77,14 +70,14 @@ const AuthCallback: React.FC = () => {
   }, []);
 
   const urlParams = new URLSearchParams(window.location.search);
-  const success = urlParams.get("success");
-  const error = urlParams.get("error");
+  const success = urlParams.get('success');
+  const error = urlParams.get('error');
 
   return (
     <div className="flex items-center justify-center flex-1">
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
-          {success === "true" ? (
+          {success === 'true' ? (
             <>
               <div className="mx-auto mb-2">
                 <CheckCircle className="h-12 w-12 text-green-500" />
@@ -99,9 +92,7 @@ const AuthCallback: React.FC = () => {
               <div className="mx-auto mb-2">
                 <XCircle className="h-12 w-12 text-destructive" />
               </div>
-              <CardTitle className="text-destructive">
-                Authentication Error
-              </CardTitle>
+              <CardTitle className="text-destructive">Authentication Error</CardTitle>
               <CardDescription>{error}</CardDescription>
             </>
           ) : (
@@ -110,25 +101,23 @@ const AuthCallback: React.FC = () => {
                 <Loader2 className="h-12 w-12 animate-spin text-primary" />
               </div>
               <CardTitle>Processing...</CardTitle>
-              <CardDescription>
-                Please wait while we process your authentication.
-              </CardDescription>
+              <CardDescription>Please wait while we process your authentication.</CardDescription>
             </>
           )}
         </CardHeader>
 
         <CardContent className="space-y-4">
-          {success === "true" && (
+          {success === 'true' && (
             <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
               <Loader2 className="h-4 w-4 animate-spin" />
               <span>Redirecting...</span>
             </div>
           )}
 
-          {(success === "true" || error) && (
+          {(success === 'true' || error) && (
             <Button
               variant="outline"
-              onClick={() => (window.location.href = "/")}
+              onClick={() => (window.location.href = '/')}
               className="w-full"
             >
               <ArrowLeft className="h-4 w-4" />

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,27 +1,15 @@
-import { Alert, AlertDescription } from "@/components/ui/alert";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Skeleton } from "@/components/ui/skeleton";
-import {
-  Activity,
-  AlertCircle,
-  Cloud,
-  Download,
-  Plus,
-} from "lucide-react";
-import { useEffect, useState } from "react";
-import { SourceCard } from "../components/dashboard/SourceCard";
-import { AddSourceDialog } from "../components/forms/AddSourceDialog";
-import { useConversionStats } from "../hooks/useConversions";
-import { useMonitoring } from "../hooks/useMonitoring";
-import { useSources, useSourceStats } from "../hooks/useSources";
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Activity, AlertCircle, Cloud, Download, Plus } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { SourceCard } from '../components/dashboard/SourceCard';
+import { AddSourceDialog } from '../components/forms/AddSourceDialog';
+import { useConversionStats } from '../hooks/useConversions';
+import { useMonitoring } from '../hooks/useMonitoring';
+import { useSources, useSourceStats } from '../hooks/useSources';
 
 export default function Dashboard() {
   const [refreshKey, setRefreshKey] = useState(0);
@@ -59,9 +47,7 @@ export default function Dashboard() {
       {sourcesError && (
         <Alert className="mb-6">
           <AlertCircle className="h-4 w-4" />
-          <AlertDescription>
-            Error loading data: {sourcesError}
-          </AlertDescription>
+          <AlertDescription>Error loading data: {sourcesError}</AlertDescription>
         </Alert>
       )}
 
@@ -82,9 +68,7 @@ export default function Dashboard() {
                 {sourceStats?.totalSources || sources.length}
               </div>
             )}
-            <p className="text-sm text-muted-foreground">
-              Configured document sources
-            </p>
+            <p className="text-sm text-muted-foreground">Configured document sources</p>
             {sourceStats && sourceStats.activeSources > 0 && (
               <Badge variant="outline" className="mt-2">
                 {sourceStats.activeSources} active
@@ -101,12 +85,8 @@ export default function Dashboard() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-3xl font-bold">
-              {conversionStats?.recent ?? 0}
-            </div>
-            <p className="text-sm text-muted-foreground">
-              Last 24 hours
-            </p>
+            <div className="text-3xl font-bold">{conversionStats?.recent ?? 0}</div>
+            <p className="text-sm text-muted-foreground">Last 24 hours</p>
           </CardContent>
         </Card>
 
@@ -120,17 +100,13 @@ export default function Dashboard() {
           <CardContent>
             {monitoringStatus ? (
               <>
-                <Badge
-                  variant={
-                    monitoringStatus.isRunning ? "default" : "secondary"
-                  }
-                >
-                  {monitoringStatus.isRunning ? "Active" : "Inactive"}
+                <Badge variant={monitoringStatus.isRunning ? 'default' : 'secondary'}>
+                  {monitoringStatus.isRunning ? 'Active' : 'Inactive'}
                 </Badge>
                 <p className="text-sm text-muted-foreground mt-2">
                   {monitoringStatus.isRunning
                     ? `${monitoringStatus.totalActiveSources} sources monitored`
-                    : "Monitoring stopped"}
+                    : 'Monitoring stopped'}
                 </p>
               </>
             ) : (
@@ -188,13 +164,10 @@ export default function Dashboard() {
           <Card className="p-12 text-center">
             <CardContent>
               <Cloud className="h-16 w-16 text-muted-foreground mx-auto mb-4" />
-              <CardTitle className="mb-2">
-                No document sources
-              </CardTitle>
+              <CardTitle className="mb-2">No document sources</CardTitle>
               <CardDescription className="mb-6 max-w-md mx-auto">
-                Start by connecting your first document source.
-                Support for Microsoft SharePoint, Google Drive, and other
-                cloud storage platforms.
+                Start by connecting your first document source. Support for Microsoft SharePoint,
+                Google Drive, and other cloud storage platforms.
               </CardDescription>
               <AddSourceDialog onSourceAdded={handleSourceAdded}>
                 <Button size="lg">

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -9,13 +9,13 @@ import type {
   Source,
   SourceStats,
   SyncLog,
-} from "../types/api";
+} from '../types/api';
 
 const API_BASE_URL = import.meta.env.VITE_API_URL;
-console.log("API_BASE_URL: ", API_BASE_URL);
+console.log('API_BASE_URL: ', API_BASE_URL);
 
 /** Custom event dispatched when Google OAuth token is expired/revoked */
-export const GOOGLE_TOKEN_EXPIRED_EVENT = "google-auth-expired";
+export const GOOGLE_TOKEN_EXPIRED_EVENT = 'google-auth-expired';
 
 class ApiError extends Error {
   public status?: number;
@@ -23,50 +23,39 @@ class ApiError extends Error {
 
   constructor(message: string, status?: number, data?: any) {
     super(message);
-    this.name = "ApiError";
+    this.name = 'ApiError';
     this.status = status;
     this.data = data;
   }
 }
 
-async function fetchApi<T>(
-  endpoint: string,
-  options: RequestInit = {},
-): Promise<T> {
+async function fetchApi<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
   const url = `${API_BASE_URL}${endpoint}`;
 
   const defaultOptions: RequestInit = {
     headers: {
-      "Content-Type": "application/json",
+      'Content-Type': 'application/json',
       ...options.headers,
     },
   };
 
-  console.log("fetchApi: Making request to:", url, "with options:", {
+  console.log('fetchApi: Making request to:', url, 'with options:', {
     ...defaultOptions,
     ...options,
   });
 
   try {
     const response = await fetch(url, { ...defaultOptions, ...options });
-    console.log(
-      "fetchApi: Response status:",
-      response.status,
-      response.statusText,
-    );
+    console.log('fetchApi: Response status:', response.status, response.statusText);
     const data = await response.json();
-    console.log("fetchApi: Response data:", data);
+    console.log('fetchApi: Response data:', data);
 
     if (!response.ok) {
-      if (response.status === 401 && data.code === "TOKEN_EXPIRED") {
+      if (response.status === 401 && data.code === 'TOKEN_EXPIRED') {
         window.dispatchEvent(new CustomEvent(GOOGLE_TOKEN_EXPIRED_EVENT));
       }
 
-      throw new ApiError(
-        data.message || "An error occurred",
-        response.status,
-        data,
-      );
+      throw new ApiError(data.message || 'An error occurred', response.status, data);
     }
 
     return data;
@@ -75,10 +64,7 @@ async function fetchApi<T>(
       throw error;
     }
 
-    throw new ApiError(
-      error instanceof Error ? error.message : "Connection error",
-      0,
-    );
+    throw new ApiError(error instanceof Error ? error.message : 'Connection error', 0);
   }
 }
 
@@ -86,7 +72,7 @@ async function fetchApi<T>(
 
 export const sourcesApi = {
   getAll: async (): Promise<Source[]> => {
-    const response = await fetchApi<ApiResponse<Source[]>>("/sources");
+    const response = await fetchApi<ApiResponse<Source[]>>('/sources');
     return response.data;
   },
 
@@ -96,22 +82,19 @@ export const sourcesApi = {
   },
 
   create: async (sourceData: CreateSourceRequest): Promise<Source> => {
-    console.log("API: Creating source with data:", sourceData);
-    console.log("API: Making POST request to:", `${API_BASE_URL}/sources`);
-    const response = await fetchApi<ApiResponse<Source>>("/sources", {
-      method: "POST",
+    console.log('API: Creating source with data:', sourceData);
+    console.log('API: Making POST request to:', `${API_BASE_URL}/sources`);
+    const response = await fetchApi<ApiResponse<Source>>('/sources', {
+      method: 'POST',
       body: JSON.stringify(sourceData),
     });
-    console.log("API: Create source response:", response);
+    console.log('API: Create source response:', response);
     return response.data;
   },
 
-  update: async (
-    id: string,
-    sourceData: Partial<CreateSourceRequest>,
-  ): Promise<Source> => {
+  update: async (id: string, sourceData: Partial<CreateSourceRequest>): Promise<Source> => {
     const response = await fetchApi<ApiResponse<Source>>(`/sources/${id}`, {
-      method: "PUT",
+      method: 'PUT',
       body: JSON.stringify(sourceData),
     });
     return response.data;
@@ -119,17 +102,14 @@ export const sourcesApi = {
 
   delete: async (id: string): Promise<void> => {
     await fetchApi<ApiResponse<null>>(`/sources/${id}`, {
-      method: "DELETE",
+      method: 'DELETE',
     });
   },
 
   testConnection: async (id: string): Promise<ConnectionTestResult> => {
-    const response = await fetchApi<ApiResponse<ConnectionTestResult>>(
-      `/sources/${id}/test`,
-      {
-        method: "POST",
-      },
-    );
+    const response = await fetchApi<ApiResponse<ConnectionTestResult>>(`/sources/${id}/test`, {
+      method: 'POST',
+    });
     return response.data;
   },
 
@@ -142,7 +122,7 @@ export const sourcesApi = {
     const response = await fetchApi<ApiResponse<ConnectionTestResult>>(
       `/sources/test-credentials`,
       {
-        method: "POST",
+        method: 'POST',
         body: JSON.stringify(credentialsData),
       },
     );
@@ -150,16 +130,13 @@ export const sourcesApi = {
   },
 
   sync: async (id: string): Promise<void> => {
-    await fetchApi<ApiResponse<{ success: boolean; message: string }>>(
-      `/sources/${id}/sync`,
-      {
-        method: "POST",
-      },
-    );
+    await fetchApi<ApiResponse<{ success: boolean; message: string }>>(`/sources/${id}/sync`, {
+      method: 'POST',
+    });
   },
 
   getStats: async (): Promise<SourceStats> => {
-    const response = await fetchApi<ApiResponse<SourceStats>>("/sources/stats");
+    const response = await fetchApi<ApiResponse<SourceStats>>('/sources/stats');
     return response.data;
   },
 
@@ -170,7 +147,7 @@ export const sourcesApi = {
     const response = await fetchApi<ApiResponse<any[]>>(
       `/sources/google-drive/folders?parent_id=${encodeURIComponent(parentId)}`,
       {
-        method: "POST",
+        method: 'POST',
         body: JSON.stringify({ credentials }),
       },
     );
@@ -184,8 +161,8 @@ export const sourcesApi = {
   ): Promise<{ totalFiles: number; convertibleFiles: number; files: any[] }> => {
     const response = await fetchApi<
       ApiResponse<{ totalFiles: number; convertibleFiles: number; files: any[] }>
-    >("/sources/google-drive/preview-files", {
-      method: "POST",
+    >('/sources/google-drive/preview-files', {
+      method: 'POST',
       body: JSON.stringify({ folder_id: folderId, credentials, extensions }),
     });
     return response.data;
@@ -206,15 +183,11 @@ export const conversionsApi = {
       ...(status && { status }),
     });
 
-    return await fetchApi<PaginatedResponse<ConversionJob>>(
-      `/conversions?${params}`,
-    );
+    return await fetchApi<PaginatedResponse<ConversionJob>>(`/conversions?${params}`);
   },
 
   getById: async (id: string): Promise<ConversionJob> => {
-    const response = await fetchApi<ApiResponse<ConversionJob>>(
-      `/conversions/${id}`,
-    );
+    const response = await fetchApi<ApiResponse<ConversionJob>>(`/conversions/${id}`);
     return response.data;
   },
 
@@ -224,33 +197,24 @@ export const conversionsApi = {
     filePath: string;
     fileSize?: number;
   }): Promise<ConversionJob> => {
-    const response = await fetchApi<ApiResponse<ConversionJob>>(
-      "/conversions",
-      {
-        method: "POST",
-        body: JSON.stringify(jobData),
-      },
-    );
+    const response = await fetchApi<ApiResponse<ConversionJob>>('/conversions', {
+      method: 'POST',
+      body: JSON.stringify(jobData),
+    });
     return response.data;
   },
 
   cancel: async (id: string): Promise<ConversionJob> => {
-    const response = await fetchApi<ApiResponse<ConversionJob>>(
-      `/conversions/${id}`,
-      {
-        method: "DELETE",
-      },
-    );
+    const response = await fetchApi<ApiResponse<ConversionJob>>(`/conversions/${id}`, {
+      method: 'DELETE',
+    });
     return response.data;
   },
 
   retry: async (id: string): Promise<ConversionJob> => {
-    const response = await fetchApi<ApiResponse<ConversionJob>>(
-      `/conversions/${id}/retry`,
-      {
-        method: "POST",
-      },
-    );
+    const response = await fetchApi<ApiResponse<ConversionJob>>(`/conversions/${id}/retry`, {
+      method: 'POST',
+    });
     return response.data;
   },
 
@@ -264,26 +228,20 @@ export const conversionsApi = {
     startedAt?: string;
     completedAt?: string;
   }> => {
-    const response = await fetchApi<ApiResponse<any>>(
-      `/conversions/${id}/progress`,
-    );
+    const response = await fetchApi<ApiResponse<any>>(`/conversions/${id}/progress`);
     return response.data;
   },
 
   getStats: async (): Promise<ConversionStats> => {
-    const response =
-      await fetchApi<ApiResponse<ConversionStats>>("/conversions/stats");
+    const response = await fetchApi<ApiResponse<ConversionStats>>('/conversions/stats');
     return response.data;
   },
 
   cleanup: async (olderThanDays = 30): Promise<{ deletedCount: number }> => {
-    const response = await fetchApi<ApiResponse<{ deletedCount: number }>>(
-      "/conversions/cleanup",
-      {
-        method: "POST",
-        body: JSON.stringify({ olderThanDays }),
-      },
-    );
+    const response = await fetchApi<ApiResponse<{ deletedCount: number }>>('/conversions/cleanup', {
+      method: 'POST',
+      body: JSON.stringify({ olderThanDays }),
+    });
     return response.data;
   },
 };
@@ -292,26 +250,25 @@ export const conversionsApi = {
 
 export const monitoringApi = {
   getStatus: async (): Promise<MonitoringStatus> => {
-    const response =
-      await fetchApi<ApiResponse<MonitoringStatus>>("/monitoring/status");
+    const response = await fetchApi<ApiResponse<MonitoringStatus>>('/monitoring/status');
     return response.data;
   },
 
   start: async (): Promise<void> => {
-    await fetchApi<ApiResponse<null>>("/monitoring/start", {
-      method: "POST",
+    await fetchApi<ApiResponse<null>>('/monitoring/start', {
+      method: 'POST',
     });
   },
 
   stop: async (): Promise<void> => {
-    await fetchApi<ApiResponse<null>>("/monitoring/stop", {
-      method: "POST",
+    await fetchApi<ApiResponse<null>>('/monitoring/stop', {
+      method: 'POST',
     });
   },
 
   restart: async (): Promise<void> => {
-    await fetchApi<ApiResponse<null>>("/monitoring/restart", {
-      method: "POST",
+    await fetchApi<ApiResponse<null>>('/monitoring/restart', {
+      method: 'POST',
     });
   },
 
@@ -321,15 +278,13 @@ export const monitoringApi = {
       ...(sourceId && { sourceId }),
     });
 
-    const response = await fetchApi<ApiResponse<SyncLog[]>>(
-      `/monitoring/logs?${params}`,
-    );
+    const response = await fetchApi<ApiResponse<SyncLog[]>>(`/monitoring/logs?${params}`);
     return response.data;
   },
 
   syncSource: async (sourceId: string): Promise<void> => {
     await fetchApi<ApiResponse<null>>(`/monitoring/sync/${sourceId}`, {
-      method: "POST",
+      method: 'POST',
     });
   },
 
@@ -341,7 +296,7 @@ export const monitoringApi = {
     lastSync?: string;
     timestamp: string;
   }> => {
-    const response = await fetchApi<ApiResponse<any>>("/monitoring/health");
+    const response = await fetchApi<ApiResponse<any>>('/monitoring/health');
     return response.data;
   },
 };
@@ -357,7 +312,7 @@ export const healthApi = {
     environment: string;
     endpoints: Record<string, string>;
   }> => {
-    const response = await fetchApi<any>("/health");
+    const response = await fetchApi<any>('/health');
     return response;
   },
 };

--- a/frontend/src/services/tokenStorage.ts
+++ b/frontend/src/services/tokenStorage.ts
@@ -6,7 +6,7 @@ interface GoogleCredentials {
   expiresAt?: number;
 }
 
-const STORAGE_KEY = "doc2ai_google_credentials";
+const STORAGE_KEY = 'doc2ai_google_credentials';
 const TOKEN_EXPIRY_HOURS = 24;
 
 export class TokenStorage {
@@ -14,12 +14,12 @@ export class TokenStorage {
     try {
       const dataToStore = {
         ...credentials,
-        expiresAt: Date.now() + (TOKEN_EXPIRY_HOURS * 60 * 60 * 1000)
+        expiresAt: Date.now() + TOKEN_EXPIRY_HOURS * 60 * 60 * 1000,
       };
 
       localStorage.setItem(STORAGE_KEY, JSON.stringify(dataToStore));
     } catch (error) {
-      console.error("Failed to save credentials:", error);
+      console.error('Failed to save credentials:', error);
     }
   }
 
@@ -38,7 +38,7 @@ export class TokenStorage {
 
       return credentials;
     } catch (error) {
-      console.error("Failed to get credentials:", error);
+      console.error('Failed to get credentials:', error);
       this.clearCredentials();
       return null;
     }
@@ -48,7 +48,7 @@ export class TokenStorage {
     try {
       localStorage.removeItem(STORAGE_KEY);
     } catch (error) {
-      console.error("Failed to clear credentials:", error);
+      console.error('Failed to clear credentials:', error);
     }
   }
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,9 +1,9 @@
 export interface Source {
   id: string;
   name: string;
-  platform: "sharepoint" | "googledrive" | "onedrive";
+  platform: 'sharepoint' | 'googledrive' | 'onedrive';
   config: SourceConfig;
-  status: "active" | "inactive" | "error";
+  status: 'active' | 'inactive' | 'error';
   lastSync?: string;
   createdAt: string;
   updatedAt: string;
@@ -24,7 +24,7 @@ export interface SourceConfig {
 
 export interface CreateSourceRequest {
   name: string;
-  platform: "sharepoint" | "googledrive" | "onedrive";
+  platform: 'sharepoint' | 'googledrive' | 'onedrive';
   config: {
     credentials: SharePointCredentials | GoogleDriveCredentials;
     sourcePath: string;
@@ -56,7 +56,7 @@ export interface ConversionJob {
   filePath: string;
   outputPath?: string;
   fileSize?: number;
-  status: "pending" | "processing" | "completed" | "failed";
+  status: 'pending' | 'processing' | 'completed' | 'failed';
   progress: number;
   error?: string;
   startedAt?: string;
@@ -73,7 +73,7 @@ export interface SyncLog {
   id: string;
   sourceId: string;
   action: string;
-  status: "success" | "error" | "warning";
+  status: 'success' | 'error' | 'warning';
   message: string;
   details?: Record<string, any>;
   createdAt: string;

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -9,9 +9,7 @@
 
     "baseUrl": ".",
     "paths": {
-      "@/*": [
-        "./src/*"
-      ]
+      "@/*": ["./src/*"]
     },
 
     /* Bundler mode */
@@ -30,7 +28,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,9 +1,6 @@
 {
   "files": [],
-  "references": [
-    { "path": "./tsconfig.app.json"},
-    { "path": "./tsconfig.node.json"}
-  ],
+  "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }],
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -21,7 +21,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": [
-    "vite.config.ts"
-  ]
+  "include": ["vite.config.ts"]
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,7 +1,7 @@
-import path from "path"
-import tailwindcss from "@tailwindcss/vite"
-import react from "@vitejs/plugin-react"
-import { defineConfig } from "vite"
+import path from 'path';
+import tailwindcss from '@tailwindcss/vite';
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -11,16 +11,13 @@ export default defineConfig({
     {
       name: 'conductor-workspace-title',
       transformIndexHtml(html) {
-        return html.replace(
-          /%TITLE%/g,
-          process.env.CONDUCTOR_WORKSPACE_NAME || 'Doc2AI'
-        )
+        return html.replace(/%TITLE%/g, process.env.CONDUCTOR_WORKSPACE_NAME || 'Doc2AI');
       },
     },
   ],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      '@': path.resolve(__dirname, './src'),
     },
   },
-})
+});


### PR DESCRIPTION
## Summary
- Add a new CI workflow (`ci.yml`) that runs on PRs and pushes to main: lint, build (frontend), Prettier format check, and Prisma schema validation (backend)
- Disable the SonarQube workflow (`build.yml`) by switching it to manual trigger (`workflow_dispatch`) until configured
- Add Prettier as a dev dependency to both frontend and backend with a shared config at the project root
- Format all existing source files (100 files) to match the new Prettier config

## Test plan
- [x] `npm run lint` passes on both frontend and backend
- [x] `npm run build` passes on frontend (TypeScript + Vite)
- [x] `npm run format:check` passes on both frontend and backend
- [x] `npx prisma validate` passes on backend