### PR TITLE
Replace Winston with Pino for structured JSON logging

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -25,8 +25,9 @@
         "multer": "^1.4.5-lts.1",
         "node-cron": "^3.0.3",
         "pdf-parse": "^2.4.5",
-        "prisma": "^7.2.0",
-        "winston": "^3.11.0"
+        "pino": "^10.3.1",
+        "pino-http": "^11.0.0",
+        "prisma": "^7.2.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
@@ -68,26 +69,6 @@
       "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.5.0.tgz",
       "integrity": "sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ==",
       "license": "Apache-2.0"
-    },
-    "node_modules/@colors/colors": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
-      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
-    "node_modules/@dabh/diagnostics": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
-      "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
-      "license": "MIT",
-      "dependencies": {
-        "colorspace": "1.1.x",
-        "enabled": "2.0.x",
-        "kuler": "^2.0.0"
-      }
     },
     "node_modules/@electric-sql/pglite": {
       "version": "0.3.2",
@@ -606,6 +587,12 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
     "node_modules/@prisma/adapter-better-sqlite3": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@prisma/adapter-better-sqlite3/-/adapter-better-sqlite3-7.2.0.tgz",
@@ -808,12 +795,6 @@
         "csstype": "^3.2.2"
       }
     },
-    "node_modules/@types/triple-beam": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
-      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
-      "license": "MIT"
-    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.11",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
@@ -926,17 +907,20 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
-    "node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "license": "MIT"
-    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/aws-ssl-profiles": {
       "version": "1.1.2",
@@ -1412,16 +1396,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/color": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.3",
-        "color-string": "^1.6.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1439,42 +1413,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
-    },
-    "node_modules/color/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/color/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "license": "MIT"
-    },
-    "node_modules/colorspace": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
-      "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
-      "license": "MIT",
-      "dependencies": {
-        "color": "^3.1.3",
-        "text-hex": "1.0.x"
-      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -1801,12 +1741,6 @@
       "engines": {
         "node": ">=14"
       }
-    },
-    "node_modules/enabled": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
-      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
-      "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -2214,12 +2148,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fecha": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
-      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
-      "license": "MIT"
-    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -2322,12 +2250,6 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/fn.name": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
-      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
-      "license": "MIT"
     },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
@@ -2462,6 +2384,15 @@
       "license": "MIT",
       "dependencies": {
         "is-property": "^1.0.2"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -2861,18 +2792,6 @@
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
       "license": "MIT"
     },
-    "node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -3005,12 +2924,6 @@
         "json-buffer": "3.0.1"
       }
     },
-    "node_modules/kuler": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
-      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
-      "license": "MIT"
-    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -3125,23 +3038,6 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
-    },
-    "node_modules/logform": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
-      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@colors/colors": "1.6.0",
-        "@types/triple-beam": "^1.3.2",
-        "fecha": "^4.2.0",
-        "ms": "^2.1.1",
-        "safe-stable-stringify": "^2.3.1",
-        "triple-beam": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
     },
     "node_modules/long": {
       "version": "5.3.2",
@@ -3617,6 +3513,15 @@
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "license": "MIT"
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -3636,15 +3541,6 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
-      }
-    },
-    "node_modules/one-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
-      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
-      "license": "MIT",
-      "dependencies": {
-        "fn.name": "1.x.x"
       }
     },
     "node_modules/option": {
@@ -3822,6 +3718,55 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-http": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-11.0.0.tgz",
+      "integrity": "sha512-wqg5XIAGRRIWtTk8qPGxkbrfiwEWz1lgedVLvhLALudKXvg1/L2lTFgTGPJ4Z2e3qcRmxoFxDuSdMdMGNM6I1g==",
+      "license": "MIT",
+      "dependencies": {
+        "get-caller-file": "^2.0.5",
+        "pino": "^10.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
     "node_modules/pkg-types": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
@@ -3938,6 +3883,22 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/proper-lockfile": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
@@ -4025,6 +3986,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -4168,6 +4135,15 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/redis-errors": {
@@ -4514,21 +4490,6 @@
         "simple-concat": "^1.0.0"
       }
     },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
-    },
-    "node_modules/simple-swizzle/node_modules/is-arrayish": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-      "license": "MIT"
-    },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -4540,6 +4501,24 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -4555,15 +4534,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/stack-trace": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/standard-as-callback": {
@@ -4678,11 +4648,17 @@
         "node": ">= 6"
       }
     },
-    "node_modules/text-hex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
-      "license": "MIT"
+    "node_modules/thread-stream": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
+      "integrity": "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/tinyexec": {
       "version": "1.0.2",
@@ -4723,15 +4699,6 @@
       "license": "ISC",
       "bin": {
         "nodetouch": "bin/nodetouch.js"
-      }
-    },
-    "node_modules/triple-beam": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
-      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.0.0"
       }
     },
     "node_modules/tunnel-agent": {
@@ -4879,70 +4846,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/winston": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.17.0.tgz",
-      "integrity": "sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==",
-      "license": "MIT",
-      "dependencies": {
-        "@colors/colors": "^1.6.0",
-        "@dabh/diagnostics": "^2.0.2",
-        "async": "^3.2.3",
-        "is-stream": "^2.0.0",
-        "logform": "^2.7.0",
-        "one-time": "^1.0.0",
-        "readable-stream": "^3.4.0",
-        "safe-stable-stringify": "^2.3.1",
-        "stack-trace": "0.0.x",
-        "triple-beam": "^1.3.0",
-        "winston-transport": "^4.9.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/winston-transport": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
-      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
-      "license": "MIT",
-      "dependencies": {
-        "logform": "^2.7.0",
-        "readable-stream": "^3.6.2",
-        "triple-beam": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/winston-transport/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/winston/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/word-wrap": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -35,8 +35,9 @@
     "multer": "^1.4.5-lts.1",
     "node-cron": "^3.0.3",
     "pdf-parse": "^2.4.5",
-    "prisma": "^7.2.0",
-    "winston": "^3.11.0"
+    "pino": "^10.3.1",
+    "pino-http": "^11.0.0",
+    "prisma": "^7.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -2,8 +2,10 @@ import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
 import rateLimit from 'express-rate-limit';
+import pinoHttp from 'pino-http';
 import { initializeDatabase, closeDatabase } from './config/database.js';
 import config from './config/env.js';
+import logger from './config/logger.js';
 import apiRoutes from './routes/index.js';
 import { errorHandler, notFoundHandler, logError } from './middleware/errorHandler.js';
 import { extractUserInfo } from './middleware/auth.js';
@@ -17,11 +19,11 @@ const app = express();
 app.set('trust proxy', 1);
 
 async function setupApp() {
-  console.log('Starting Doc2AI Backend...');
+  logger.info('Starting Doc2AI Backend...');
 
   await fs.ensureDir(config.storagePath);
   await fs.ensureDir(config.tempPath);
-  console.log('Storage directories created');
+  logger.info('Storage directories created');
 
   app.use(
     helmet({
@@ -65,10 +67,7 @@ async function setupApp() {
   app.use(sanitizeInput);
   app.use(extractUserInfo);
 
-  app.use((req, res, next) => {
-    console.log(`${req.method} ${req.originalUrl} - ${req.ip}`);
-    next();
-  });
+  app.use(pinoHttp({ logger }));
 
   app.use('/api', apiRoutes);
 
@@ -101,46 +100,48 @@ async function startServer() {
 
     const externalPort = process.env.EXTERNAL_PORT || config.port;
     const server = app.listen(config.port, () => {
-      console.log(`Doc2AI Backend running on port ${externalPort}`);
-      console.log(`Environment: ${config.nodeEnv}`);
-      console.log(`API available at: http://localhost:${externalPort}/api`);
+      logger.info(
+        { port: externalPort, env: config.nodeEnv },
+        `Doc2AI Backend running on port ${externalPort}`,
+      );
+      logger.info(`API available at: http://localhost:${externalPort}/api`);
     });
 
-    console.log('Starting queue processor...');
+    logger.info('Starting queue processor...');
     try {
       await queueService.startProcessing(3);
-      console.log('Queue processor started successfully');
+      logger.info('Queue processor started successfully');
     } catch (error) {
-      console.error('❌ Queue processor failed to start:', error.message);
+      logger.error({ err: error }, 'Queue processor failed to start');
     }
 
-    console.log('Starting monitoring service...');
+    logger.info('Starting monitoring service...');
     try {
       await monitoringService.start();
-      console.log('Monitoring service started successfully');
+      logger.info('Monitoring service started successfully');
     } catch (error) {
-      console.warn('⚠️ Monitoring service failed to start:', error.message);
+      logger.warn({ err: error }, 'Monitoring service failed to start');
     }
 
     const gracefulShutdown = async (signal) => {
-      console.log(`\nReceived ${signal}. Graceful shutdown...`);
+      logger.info({ signal }, 'Graceful shutdown...');
 
       if (monitoringService.isRunning) {
         await monitoringService.stop();
       }
 
-      console.log('Closing queue...');
+      logger.info('Closing queue...');
       await queueService.close();
 
       await closeDatabase();
 
       server.close(() => {
-        console.log('Doc2AI Backend stopped gracefully');
+        logger.info('Doc2AI Backend stopped gracefully');
         process.exit(0);
       });
 
       setTimeout(() => {
-        console.error('❌ Could not close connections in time, forcefully shutting down');
+        logger.error('Could not close connections in time, forcefully shutting down');
         process.exit(1);
       }, 10000);
     };
@@ -149,17 +150,17 @@ async function startServer() {
     process.on('SIGINT', () => gracefulShutdown('SIGINT'));
 
     process.on('unhandledRejection', (reason, promise) => {
-      console.error('❌ Unhandled Rejection at:', promise, 'reason:', reason);
+      logger.error({ reason, promise }, 'Unhandled Rejection');
     });
 
     process.on('uncaughtException', (error) => {
-      console.error('❌ Uncaught Exception:', error);
+      logger.error({ err: error }, 'Uncaught Exception');
       process.exit(1);
     });
 
     return server;
   } catch (error) {
-    console.error('❌ Failed to start server:', error);
+    logger.error({ err: error }, 'Failed to start server');
     process.exit(1);
   }
 }

--- a/backend/src/config/database.js
+++ b/backend/src/config/database.js
@@ -1,5 +1,6 @@
 import { PrismaClient } from '@prisma/client';
 import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3';
+import logger from './logger.js';
 
 let prisma;
 
@@ -16,16 +17,16 @@ function getPrismaClient() {
 
 export async function initializeDatabase() {
   try {
-    console.log('Initializing database...');
+    logger.info('Initializing database...');
 
     const client = getPrismaClient();
 
     await client.$connect();
-    console.log('Database connected successfully');
+    logger.info('Database connected successfully');
 
     return client;
   } catch (error) {
-    console.error('❌ Database initialization failed:', error);
+    logger.error({ err: error }, 'Database initialization failed');
     throw error;
   }
 }
@@ -33,7 +34,7 @@ export async function initializeDatabase() {
 export async function closeDatabase() {
   if (prisma) {
     await prisma.$disconnect();
-    console.log('Database disconnected');
+    logger.info('Database disconnected');
   }
 }
 

--- a/backend/src/config/logger.js
+++ b/backend/src/config/logger.js
@@ -1,0 +1,15 @@
+import pino from 'pino';
+import config from './env.js';
+
+const logger = pino({
+  level: config.logLevel,
+  transport:
+    config.nodeEnv === 'development'
+      ? {
+          target: 'pino/file',
+          options: { destination: 1 },
+        }
+      : undefined,
+});
+
+export default logger;

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import config from '../config/env.js';
+import logger from '../config/logger.js';
 
 class AuthController {
   // GET /api/auth/google/callback
@@ -84,7 +85,7 @@ class AuthController {
 
         return res.redirect(`${frontendUrl}/auth/callback?data=${encodedData}&success=true`);
       } catch (userInfoError) {
-        console.warn('Could not fetch user info:', userInfoError.message);
+        logger.warn({ err: userInfoError }, 'Could not fetch user info');
 
         const fallbackData = {
           refresh_token,
@@ -106,7 +107,7 @@ class AuthController {
         );
       }
     } catch (error) {
-      console.error('Error in Google OAuth callback:', error);
+      logger.error({ err: error }, 'Error in Google OAuth callback');
 
       let errorMessage = 'OAuth callback failed';
       let errorDetails = error.message;
@@ -154,7 +155,7 @@ class AuthController {
         },
       });
     } catch (error) {
-      console.error('Error generating Google auth URL:', error);
+      logger.error({ err: error }, 'Error generating Google auth URL');
       res.status(500).json({
         success: false,
         message: 'Failed to generate authorization URL',

--- a/backend/src/controllers/conversionController.js
+++ b/backend/src/controllers/conversionController.js
@@ -1,4 +1,5 @@
 import ConversionService from '../services/conversionService.js';
+import logger from '../config/logger.js';
 
 const conversionService = new ConversionService();
 
@@ -18,7 +19,7 @@ class ConversionController {
         pagination: result.pagination,
       });
     } catch (error) {
-      console.error('Error in getAllJobs:', error);
+      logger.error({ err: error }, 'Error in getAllJobs');
       res.status(500).json({
         success: false,
         message: 'Failed to fetch conversion jobs',
@@ -38,7 +39,7 @@ class ConversionController {
         data: job,
       });
     } catch (error) {
-      console.error('Error in getJobById:', error);
+      logger.error({ err: error }, 'Error in getJobById');
 
       if (error.message === 'Conversion job not found') {
         return res.status(404).json({
@@ -73,10 +74,10 @@ class ConversionController {
       conversionService
         .processJob(job.id)
         .then(() => {
-          console.log(`Job ${job.id} completed`);
+          logger.info({ jobId: job.id }, 'Job completed');
         })
         .catch((error) => {
-          console.error(`❌ Job ${job.id} failed:`, error);
+          logger.error({ err: error, jobId: job.id }, 'Job failed');
         });
 
       res.status(201).json({
@@ -85,7 +86,7 @@ class ConversionController {
         message: 'Conversion job created and started',
       });
     } catch (error) {
-      console.error('Error in createJob:', error);
+      logger.error({ err: error }, 'Error in createJob');
       res.status(500).json({
         success: false,
         message: 'Failed to create conversion job',
@@ -106,7 +107,7 @@ class ConversionController {
         message: 'Job cancelled successfully',
       });
     } catch (error) {
-      console.error('Error in cancelJob:', error);
+      logger.error({ err: error }, 'Error in cancelJob');
       res.status(500).json({
         success: false,
         message: 'Failed to cancel job',
@@ -125,7 +126,7 @@ class ConversionController {
         data: stats,
       });
     } catch (error) {
-      console.error('Error in getStats:', error);
+      logger.error({ err: error }, 'Error in getStats');
       res.status(500).json({
         success: false,
         message: 'Failed to fetch conversion statistics',
@@ -146,7 +147,7 @@ class ConversionController {
         message: `Cleaned up ${deletedCount} old conversion jobs`,
       });
     } catch (error) {
-      console.error('Error in cleanupJobs:', error);
+      logger.error({ err: error }, 'Error in cleanupJobs');
       res.status(500).json({
         success: false,
         message: 'Failed to cleanup jobs',
@@ -173,7 +174,7 @@ class ConversionController {
         },
       });
     } catch (error) {
-      console.error('Error in getJobProgress:', error);
+      logger.error({ err: error }, 'Error in getJobProgress');
       res.status(500).json({
         success: false,
         message: 'Failed to get job progress',
@@ -205,10 +206,10 @@ class ConversionController {
       conversionService
         .processJob(updatedJob.id)
         .then(() => {
-          console.log(`Retry job ${updatedJob.id} completed`);
+          logger.info({ jobId: updatedJob.id }, 'Retry job completed');
         })
         .catch((error) => {
-          console.error(`❌ Retry job ${updatedJob.id} failed:`, error);
+          logger.error({ err: error, jobId: updatedJob.id }, 'Retry job failed');
         });
 
       res.json({
@@ -217,7 +218,7 @@ class ConversionController {
         message: 'Job retry started',
       });
     } catch (error) {
-      console.error('Error in retryJob:', error);
+      logger.error({ err: error }, 'Error in retryJob');
       res.status(500).json({
         success: false,
         message: 'Failed to retry job',

--- a/backend/src/controllers/monitoringController.js
+++ b/backend/src/controllers/monitoringController.js
@@ -1,4 +1,5 @@
 import monitoringService from '../services/monitoringService.js';
+import logger from '../config/logger.js';
 
 class MonitoringController {
   // GET /api/monitoring/status
@@ -11,7 +12,7 @@ class MonitoringController {
         data: status,
       });
     } catch (error) {
-      console.error('Error in getStatus:', error);
+      logger.error({ err: error }, 'Error in getStatus');
       res.status(500).json({
         success: false,
         message: 'Failed to get monitoring status',
@@ -37,7 +38,7 @@ class MonitoringController {
         message: 'Monitoring service started successfully',
       });
     } catch (error) {
-      console.error('Error in startMonitoring:', error);
+      logger.error({ err: error }, 'Error in startMonitoring');
       res.status(500).json({
         success: false,
         message: 'Failed to start monitoring service',
@@ -63,7 +64,7 @@ class MonitoringController {
         message: 'Monitoring service stopped successfully',
       });
     } catch (error) {
-      console.error('Error in stopMonitoring:', error);
+      logger.error({ err: error }, 'Error in stopMonitoring');
       res.status(500).json({
         success: false,
         message: 'Failed to stop monitoring service',
@@ -85,7 +86,7 @@ class MonitoringController {
         data: logs,
       });
     } catch (error) {
-      console.error('Error in getLogs:', error);
+      logger.error({ err: error }, 'Error in getLogs');
       res.status(500).json({
         success: false,
         message: 'Failed to fetch monitoring logs',
@@ -113,7 +114,7 @@ class MonitoringController {
         message: 'Source sync completed successfully',
       });
     } catch (error) {
-      console.error('Error in syncSource:', error);
+      logger.error({ err: error }, 'Error in syncSource');
       res.status(500).json({
         success: false,
         message: 'Failed to sync source',
@@ -140,7 +141,7 @@ class MonitoringController {
         },
       });
     } catch (error) {
-      console.error('Error in healthCheck:', error);
+      logger.error({ err: error }, 'Error in healthCheck');
       res.status(503).json({
         success: false,
         data: {
@@ -155,7 +156,7 @@ class MonitoringController {
   // POST /api/monitoring/restart
   async restartMonitoring(req, res) {
     try {
-      console.log('Restarting monitoring service...');
+      logger.info('Restarting monitoring service...');
 
       if (monitoringService.isRunning) {
         await monitoringService.stop();
@@ -169,7 +170,7 @@ class MonitoringController {
         message: 'Monitoring service restarted successfully',
       });
     } catch (error) {
-      console.error('Error in restartMonitoring:', error);
+      logger.error({ err: error }, 'Error in restartMonitoring');
       res.status(500).json({
         success: false,
         message: 'Failed to restart monitoring service',
@@ -191,7 +192,7 @@ class MonitoringController {
         data: logs,
       });
     } catch (error) {
-      console.error('Error in getSourceLogs:', error);
+      logger.error({ err: error }, 'Error in getSourceLogs');
       res.status(500).json({
         success: false,
         message: 'Failed to fetch source logs',

--- a/backend/src/controllers/sourceController.js
+++ b/backend/src/controllers/sourceController.js
@@ -1,5 +1,6 @@
 import { TokenExpiredError } from '../integrations/base/driveConnector.js';
 import SourceService from '../services/sourceService.js';
+import logger from '../config/logger.js';
 
 const sourceService = new SourceService();
 
@@ -13,7 +14,7 @@ class SourceController {
         data: sources,
       });
     } catch (error) {
-      console.error('Error in getAllSources:', error);
+      logger.error({ err: error }, 'Error in getAllSources');
       res.status(500).json({
         success: false,
         message: 'Failed to fetch sources',
@@ -33,7 +34,7 @@ class SourceController {
         data: source,
       });
     } catch (error) {
-      console.error('Error in getSourceById:', error);
+      logger.error({ err: error }, 'Error in getSourceById');
 
       if (error.message === 'Source not found') {
         return res.status(404).json({
@@ -78,7 +79,7 @@ class SourceController {
         message: 'Source created successfully',
       });
     } catch (error) {
-      console.error('Error in createSource:', error);
+      logger.error({ err: error }, 'Error in createSource');
       res.status(500).json({
         success: false,
         message: 'Failed to create source',
@@ -99,7 +100,7 @@ class SourceController {
         message: 'Source updated successfully',
       });
     } catch (error) {
-      console.error('Error in updateSource:', error);
+      logger.error({ err: error }, 'Error in updateSource');
 
       if (error.message === 'Source not found') {
         return res.status(404).json({
@@ -127,7 +128,7 @@ class SourceController {
         message: 'Source deleted successfully',
       });
     } catch (error) {
-      console.error('Error in deleteSource:', error);
+      logger.error({ err: error }, 'Error in deleteSource');
       res.status(500).json({
         success: false,
         message: 'Failed to delete source',
@@ -168,7 +169,7 @@ class SourceController {
         data: result,
       });
     } catch (error) {
-      console.error('Error in testCredentials:', error);
+      logger.error({ err: error }, 'Error in testCredentials');
       if (error instanceof TokenExpiredError) {
         return res.status(401).json({
           success: false,
@@ -195,7 +196,7 @@ class SourceController {
         data: result,
       });
     } catch (error) {
-      console.error('Error in testConnection:', error);
+      logger.error({ err: error }, 'Error in testConnection');
       if (error instanceof TokenExpiredError) {
         return res.status(401).json({
           success: false,
@@ -222,7 +223,7 @@ class SourceController {
         data: result,
       });
     } catch (error) {
-      console.error('Error in syncSource:', error);
+      logger.error({ err: error }, 'Error in syncSource');
       res.status(500).json({
         success: false,
         message: 'Sync failed',
@@ -241,7 +242,7 @@ class SourceController {
         data: stats,
       });
     } catch (error) {
-      console.error('Error in getStats:', error);
+      logger.error({ err: error }, 'Error in getStats');
       res.status(500).json({
         success: false,
         message: 'Failed to fetch statistics',
@@ -270,7 +271,7 @@ class SourceController {
         data: folders,
       });
     } catch (error) {
-      console.error('Error in getGoogleDriveFolders:', error);
+      logger.error({ err: error }, 'Error in getGoogleDriveFolders');
       if (error instanceof TokenExpiredError) {
         return res.status(401).json({
           success: false,
@@ -309,7 +310,7 @@ class SourceController {
         data: files,
       });
     } catch (error) {
-      console.error('Error in previewGoogleDriveFiles:', error);
+      logger.error({ err: error }, 'Error in previewGoogleDriveFiles');
       if (error instanceof TokenExpiredError) {
         return res.status(401).json({
           success: false,

--- a/backend/src/converters/baseConverter.js
+++ b/backend/src/converters/baseConverter.js
@@ -1,6 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 import { generateFileChecksum } from '../utils/encryption.js';
+import logger from '../config/logger.js';
 
 class BaseConverter {
   constructor() {
@@ -30,7 +31,7 @@ class BaseConverter {
 
       return true;
     } catch (error) {
-      console.error(`File validation failed for ${filePath}:`, error);
+      logger.error({ err: error, filePath }, 'File validation failed');
       throw error;
     }
   }
@@ -43,7 +44,7 @@ class BaseConverter {
         await fs.remove(outputPath);
       }
     } catch (error) {
-      console.error(`Failed to prepare output file ${outputPath}:`, error);
+      logger.error({ err: error, outputPath }, 'Failed to prepare output file');
       throw error;
     }
   }
@@ -89,24 +90,25 @@ class BaseConverter {
 
       const checksum = await generateFileChecksum(outputPath);
 
-      console.log(
-        `✅ Markdown saved: ${outputPath} (${cleanedMarkdown.length} chars, checksum: ${checksum.substring(0, 8)}...)`,
+      logger.info(
+        { outputPath, chars: cleanedMarkdown.length, checksum: checksum.substring(0, 8) },
+        'Markdown saved',
       );
 
       return checksum;
     } catch (error) {
-      console.error(`Failed to save markdown to ${outputPath}:`, error);
+      logger.error({ err: error, outputPath }, 'Failed to save markdown');
       throw error;
     }
   }
 
   log(operation, details = {}) {
-    console.log(`[${this.name}] ${operation}:`, details);
+    logger.info({ converter: this.name, ...details }, operation);
   }
 
   handleError(error, operation, filePath) {
     const errorMessage = `${operation} failed for ${filePath}: ${error.message}`;
-    console.error(`[${this.name}] ${errorMessage}`, error);
+    logger.error({ err: error, converter: this.name, operation, filePath }, errorMessage);
 
     return {
       success: false,
@@ -139,7 +141,7 @@ class BaseConverter {
   }
 
   updateProgress(progress, message) {
-    console.log(`[${this.name}] ${progress}% - ${message}`);
+    logger.info({ converter: this.name, progress }, message);
   }
 }
 

--- a/backend/src/converters/docxToMarkdownConverter.js
+++ b/backend/src/converters/docxToMarkdownConverter.js
@@ -1,6 +1,7 @@
 import BaseConverter from './baseConverter.js';
 import { createRequire } from 'module';
 import path from 'path';
+import logger from '../config/logger.js';
 
 const require = createRequire(import.meta.url);
 const mammoth = require('mammoth');
@@ -145,7 +146,7 @@ class DocxToMarkdownConverter extends BaseConverter {
       fs.readSync(fd, buffer, 0, 8, 0);
 
       if (extension === '.docx' && !buffer.toString('ascii', 0, 2).includes('PK')) {
-        console.warn(`Warning: ${filePath} may not be a valid DOCX file`);
+        logger.warn({ filePath }, 'File may not be a valid DOCX file');
       }
     } finally {
       fs.closeSync(fd);

--- a/backend/src/integrations/base/driveConnector.js
+++ b/backend/src/integrations/base/driveConnector.js
@@ -1,3 +1,5 @@
+import logger from '../../config/logger.js';
+
 /**
  * Error thrown when OAuth credentials are expired or revoked.
  * Controllers should catch this to return 401 instead of 500.
@@ -66,7 +68,10 @@ class DriveConnector {
   }
 
   handleApiError(error, operation) {
-    console.error(`${this.constructor.name} ${operation} failed:`, error);
+    logger.error(
+      { err: error, connector: this.constructor.name, operation },
+      `${operation} failed`,
+    );
 
     // Detect expired/revoked OAuth tokens
     const responseData = error.response?.data;
@@ -85,7 +90,7 @@ class DriveConnector {
   }
 
   log(operation, details = {}) {
-    console.log(`[${this.constructor.name}] ${operation}:`, details);
+    logger.info({ connector: this.constructor.name, ...details }, operation);
   }
 }
 

--- a/backend/src/integrations/googledrive/googledriveConnector.js
+++ b/backend/src/integrations/googledrive/googledriveConnector.js
@@ -2,6 +2,7 @@ import DriveConnector from '../base/driveConnector.js';
 import axios from 'axios';
 import fs from 'fs-extra';
 import path from 'path';
+import logger from '../../config/logger.js';
 
 class GoogleDriveConnector extends DriveConnector {
   constructor(config) {
@@ -271,7 +272,7 @@ class GoogleDriveConnector extends DriveConnector {
 
         pageToken = response.data.nextPageToken || response.data.newStartPageToken;
       } catch (error) {
-        console.error('Error in watchForChanges polling:', error);
+        logger.error({ err: error }, 'Error in watchForChanges polling');
       }
     };
 

--- a/backend/src/integrations/sharepoint/sharepointConnector.js
+++ b/backend/src/integrations/sharepoint/sharepointConnector.js
@@ -2,6 +2,7 @@ import DriveConnector from '../base/driveConnector.js';
 import axios from 'axios';
 import fs from 'fs-extra';
 import path from 'path';
+import logger from '../../config/logger.js';
 
 class SharePointConnector extends DriveConnector {
   constructor(config) {
@@ -206,7 +207,7 @@ class SharePointConnector extends DriveConnector {
 
         lastCheck = new Date();
       } catch (error) {
-        console.error('Error in watchForChanges polling:', error);
+        logger.error({ err: error }, 'Error in watchForChanges polling');
       }
     }, 60000);
 

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,9 +1,10 @@
 import jwt from 'jsonwebtoken';
 import config from '../config/env.js';
+import logger from '../config/logger.js';
 
 export function authenticateToken(req, res, next) {
   if (config.nodeEnv === 'development') {
-    console.log('Authentication bypassed in development mode');
+    logger.debug('Authentication bypassed in development mode');
     return next();
   }
 
@@ -23,7 +24,7 @@ export function authenticateToken(req, res, next) {
     req.user = decoded;
     next();
   } catch (error) {
-    console.error('Token verification failed:', error);
+    logger.error({ err: error }, 'Token verification failed');
 
     if (error.name === 'TokenExpiredError') {
       return res.status(401).json({
@@ -55,7 +56,7 @@ export function optionalAuth(req, res, next) {
     req.user = decoded;
   } catch {
     req.user = null;
-    console.warn('Optional auth: invalid token provided');
+    logger.warn('Optional auth: invalid token provided');
   }
 
   next();
@@ -148,14 +149,16 @@ export function logAuthAttempts(req, res, next) {
   const userAgent = req.get('User-Agent');
   const ip = req.ip || req.connection.remoteAddress;
 
-  console.log('Auth attempt:', {
-    method: req.method,
-    url: req.originalUrl,
-    hasToken,
-    userAgent: userAgent?.substring(0, 50),
-    ip,
-    timestamp: new Date().toISOString(),
-  });
+  logger.info(
+    {
+      method: req.method,
+      url: req.originalUrl,
+      hasToken,
+      userAgent: userAgent?.substring(0, 50),
+      ip,
+    },
+    'Auth attempt',
+  );
 
   next();
 }
@@ -184,7 +187,7 @@ export function extractUserInfo(req, res, next) {
         ...decoded,
       };
     } catch (error) {
-      console.warn('Token extraction failed:', error.message);
+      logger.warn({ err: error }, 'Token extraction failed');
     }
   }
 

--- a/backend/src/middleware/errorHandler.js
+++ b/backend/src/middleware/errorHandler.js
@@ -1,7 +1,8 @@
 import config from '../config/env.js';
+import logger from '../config/logger.js';
 
 export function errorHandler(error, req, res, _next) {
-  console.error('❌ Unhandled error:', error);
+  logger.error({ err: error }, 'Unhandled error');
 
   if (error.code === 'P2002') {
     return res.status(409).json({
@@ -144,15 +145,16 @@ export function validationErrorHandler(error, req, res, next) {
 }
 
 export function logError(error, req, res, next) {
-  console.error('Error details:', {
-    message: error.message,
-    stack: error.stack,
-    url: req.originalUrl,
-    method: req.method,
-    userAgent: req.get('User-Agent'),
-    ip: req.ip,
-    timestamp: new Date().toISOString(),
-  });
+  logger.error(
+    {
+      err: error,
+      url: req.originalUrl,
+      method: req.method,
+      userAgent: req.get('User-Agent'),
+      ip: req.ip,
+    },
+    'Request error',
+  );
 
   next(error);
 }

--- a/backend/src/services/conversionService.js
+++ b/backend/src/services/conversionService.js
@@ -3,6 +3,7 @@ import { ConverterFactory } from '../converters/converterFactory.js';
 import path from 'path';
 import fs from 'fs-extra';
 import config from '../config/env.js';
+import logger from '../config/logger.js';
 import { enrichSourceWithConfig, getValidatedDestination } from '../utils/configParser.js';
 
 const prisma = getPrismaClient();
@@ -37,7 +38,7 @@ class ConversionService {
         },
       };
     } catch (error) {
-      console.error('Error fetching conversion jobs:', error);
+      logger.error({ err: error }, 'Error fetching conversion jobs');
       throw error;
     }
   }
@@ -61,7 +62,7 @@ class ConversionService {
 
       return job;
     } catch (error) {
-      console.error('Error fetching job:', error);
+      logger.error({ err: error }, 'Error fetching job');
       throw error;
     }
   }
@@ -93,10 +94,10 @@ class ConversionService {
         job.source = enrichSourceWithConfig(job.source);
       }
 
-      console.log(`Conversion job created: ${fileName}`);
+      logger.info(`Conversion job created: ${fileName}`);
       return job;
     } catch (error) {
-      console.error('Error creating job:', error);
+      logger.error({ err: error }, 'Error creating job');
       throw error;
     }
   }
@@ -127,7 +128,7 @@ class ConversionService {
 
       job.source.config = parsedConfig;
 
-      console.log(`Processing job: ${job.fileName}`);
+      logger.info(`Processing job: ${job.fileName}`);
 
       const fileExtension = path.extname(job.filePath).toLowerCase();
       const converter = ConverterFactory.getConverter(fileExtension);
@@ -165,9 +166,9 @@ class ConversionService {
 
         await fs.ensureDir(path.dirname(exportFilePath));
         await fs.copy(outputPath, exportFilePath);
-        console.log(`File exported to: ${exportFilePath}`);
+        logger.info(`File exported to: ${exportFilePath}`);
       } catch (error) {
-        console.warn(`Warning: Failed to export to configured destination:`, error.message);
+        logger.warn({ err: error }, 'Failed to export to configured destination');
       }
 
       const completedJob = await prisma.conversionJob.update({
@@ -191,10 +192,10 @@ class ConversionService {
         },
       });
 
-      console.log(`Job completed: ${job.fileName}`);
+      logger.info(`Job completed: ${job.fileName}`);
       return completedJob;
     } catch (error) {
-      console.error(`❌ Job failed: ${job?.fileName || jobId}`, error);
+      logger.error({ err: error, fileName: job?.fileName, jobId }, 'Job failed');
 
       await prisma.conversionJob
         .update({
@@ -221,10 +222,10 @@ class ConversionService {
       });
 
       if (message) {
-        console.log(`Job ${jobId}: ${progress}% - ${message}`);
+        logger.info(`Job ${jobId}: ${progress}% - ${message}`);
       }
     } catch (error) {
-      console.error('Error updating job progress:', error);
+      logger.error({ err: error }, 'Error updating job progress');
     }
   }
 
@@ -242,10 +243,10 @@ class ConversionService {
         },
       });
 
-      console.log(`Job cancelled: ${job.fileName}`);
+      logger.info(`Job cancelled: ${job.fileName}`);
       return job;
     } catch (error) {
-      console.error('Error cancelling job:', error);
+      logger.error({ err: error }, 'Error cancelling job');
       throw error;
     }
   }
@@ -275,7 +276,7 @@ class ConversionService {
         recent,
       };
     } catch (error) {
-      console.error('Error fetching job stats:', error);
+      logger.error({ err: error }, 'Error fetching job stats');
       throw error;
     }
   }
@@ -294,10 +295,10 @@ class ConversionService {
         },
       });
 
-      console.log(`Cleaned up ${result.count} old conversion jobs`);
+      logger.info(`Cleaned up ${result.count} old conversion jobs`);
       return result.count;
     } catch (error) {
-      console.error('Error cleaning up jobs:', error);
+      logger.error({ err: error }, 'Error cleaning up jobs');
       throw error;
     }
   }

--- a/backend/src/services/monitoringService.js
+++ b/backend/src/services/monitoringService.js
@@ -5,6 +5,7 @@ import queueService from './queueService.js';
 import { decryptCredentials } from '../utils/encryption.js';
 import cron from 'node-cron';
 import config from '../config/env.js';
+import logger from '../config/logger.js';
 
 const prisma = getPrismaClient();
 
@@ -35,11 +36,11 @@ class MonitoringService {
   async start() {
     try {
       if (this.isRunning) {
-        console.warn('⚠️ Monitoring service is already running');
+        logger.warn('Monitoring service is already running');
         return;
       }
 
-      console.log('Starting monitoring service...');
+      logger.info('Starting monitoring service...');
 
       const activeSources = await prisma.source.findMany({
         where: { status: 'active' },
@@ -52,16 +53,16 @@ class MonitoringService {
       this.startCronJob();
 
       this.isRunning = true;
-      console.log(`Monitoring service started for ${activeSources.length} sources`);
+      logger.info(`Monitoring service started for ${activeSources.length} sources`);
     } catch (error) {
-      console.error('❌ Failed to start monitoring service:', error);
+      logger.error({ err: error }, 'Failed to start monitoring service');
       throw error;
     }
   }
 
   async stop() {
     try {
-      console.log('Stopping monitoring service...');
+      logger.info('Stopping monitoring service...');
 
       for (const [sourceId] of this.activeMonitors) {
         await this.stopSourceMonitoring(sourceId);
@@ -73,9 +74,9 @@ class MonitoringService {
       }
 
       this.isRunning = false;
-      console.log('Monitoring service stopped');
+      logger.info('Monitoring service stopped');
     } catch (error) {
-      console.error('❌ Failed to stop monitoring service:', error);
+      logger.error({ err: error }, 'Failed to stop monitoring service');
       throw error;
     }
   }
@@ -86,7 +87,7 @@ class MonitoringService {
     this.cronJob = cron.schedule(
       cronExpression,
       async () => {
-        console.log('Running scheduled sync...');
+        logger.info('Running scheduled sync...');
         await this.syncAllActiveSources();
       },
       {
@@ -95,7 +96,7 @@ class MonitoringService {
       },
     );
 
-    console.log(`Cron job scheduled: every ${config.syncIntervalMinutes} minutes`);
+    logger.info(`Cron job scheduled: every ${config.syncIntervalMinutes} minutes`);
   }
 
   /**
@@ -104,7 +105,7 @@ class MonitoringService {
    */
   async startSourceMonitoring(source) {
     try {
-      console.log(`Starting monitoring for: ${source.name}`);
+      logger.info(`Starting monitoring for: ${source.name}`);
 
       const { decryptedConfig } = this._parseAndDecryptConfig(source);
 
@@ -130,7 +131,7 @@ class MonitoringService {
         },
       });
     } catch (error) {
-      console.error(`❌ Failed to start monitoring for ${source.name}:`, error);
+      logger.error({ err: error, source: source.name }, 'Failed to start monitoring for source');
 
       await prisma.syncLog.create({
         data: {
@@ -151,7 +152,7 @@ class MonitoringService {
         return;
       }
 
-      console.log(`Stopping monitoring for: ${monitor.source.name}`);
+      logger.info(`Stopping monitoring for: ${monitor.source.name}`);
 
       if (monitor.connector && typeof monitor.connector.cleanup === 'function') {
         await monitor.connector.cleanup();
@@ -168,7 +169,7 @@ class MonitoringService {
         },
       });
     } catch (error) {
-      console.error(`❌ Error stopping monitoring for source ${sourceId}:`, error);
+      logger.error({ err: error, sourceId }, 'Error stopping monitoring for source');
     }
   }
 
@@ -179,7 +180,7 @@ class MonitoringService {
       try {
         await this.syncSource(monitor.source.id);
       } catch (error) {
-        console.error(`❌ Sync failed for ${monitor.source.name}:`, error);
+        logger.error({ err: error, source: monitor.source.name }, 'Sync failed for source');
       }
     }
   }
@@ -191,7 +192,7 @@ class MonitoringService {
    */
   async syncSource(sourceId) {
     if (this.syncInProgress.has(sourceId)) {
-      console.warn(`⚠️ Sync already in progress for source: ${sourceId}`);
+      logger.warn({ sourceId }, 'Sync already in progress for source');
       return;
     }
 
@@ -219,7 +220,7 @@ class MonitoringService {
         connector = monitor.connector;
         monitor.source = source;
       } else {
-        console.log(`Manual sync for source: ${sourceId}`);
+        logger.info(`Manual sync for source: ${sourceId}`);
 
         const { decryptedConfig } = this._parseAndDecryptConfig(source);
 
@@ -227,7 +228,7 @@ class MonitoringService {
         await connector.authenticate();
       }
 
-      console.log(`Syncing source: ${source.name}`);
+      logger.info(`Syncing source: ${source.name}`);
 
       const { parsedConfig } = this._parseAndDecryptConfig(source);
 
@@ -275,7 +276,7 @@ class MonitoringService {
         return !isExcluded;
       });
 
-      console.log(`Found ${filteredFiles.length} files to process`);
+      logger.info(`Found ${filteredFiles.length} files to process`);
 
       for (const file of filteredFiles) {
         await this.processFileChange(sourceId, file, connector);
@@ -300,7 +301,7 @@ class MonitoringService {
         },
       });
     } catch (error) {
-      console.error(`❌ Sync failed for source ${sourceId}:`, error);
+      logger.error({ err: error, sourceId }, 'Sync failed for source');
 
       try {
         await prisma.syncLog.create({
@@ -313,7 +314,7 @@ class MonitoringService {
           },
         });
       } catch (dbError) {
-        console.error('Failed to log sync error:', dbError);
+        logger.error({ err: dbError }, 'Failed to log sync error');
       }
 
       throw error;
@@ -335,7 +336,7 @@ class MonitoringService {
         return;
       }
 
-      console.log(`Processing file: ${file.name}`);
+      logger.info(`Processing file: ${file.name}`);
 
       const tempPath = await connector.downloadFile(file.id, config.tempPath);
 
@@ -343,9 +344,9 @@ class MonitoringService {
 
       await queueService.enqueueConversion(job.id, file.name);
 
-      console.log(`Job queued for async processing: ${file.name}`);
+      logger.info(`Job queued for async processing: ${file.name}`);
     } catch (error) {
-      console.error(`❌ Failed to process file ${file.name}:`, error);
+      logger.error({ err: error, fileName: file.name }, 'Failed to process file');
 
       await prisma.syncLog.create({
         data: {
@@ -390,7 +391,7 @@ class MonitoringService {
         recentLogs,
       };
     } catch (error) {
-      console.error('Error getting monitoring status:', error);
+      logger.error({ err: error }, 'Error getting monitoring status');
       throw error;
     }
   }
@@ -412,7 +413,7 @@ class MonitoringService {
 
       return logs;
     } catch (error) {
-      console.error('Error fetching logs:', error);
+      logger.error({ err: error }, 'Error fetching logs');
       throw error;
     }
   }

--- a/backend/src/services/queueService.js
+++ b/backend/src/services/queueService.js
@@ -1,5 +1,6 @@
 import Queue from 'bull';
 import config from '../config/env.js';
+import logger from '../config/logger.js';
 import ConversionService from './conversionService.js';
 
 class QueueService {
@@ -23,23 +24,23 @@ class QueueService {
 
   setupEventHandlers() {
     this.conversionQueue.on('completed', (job, result) => {
-      console.log(`Job ${job.id} completed: ${result.fileName}`);
+      logger.info(`Job ${job.id} completed: ${result.fileName}`);
     });
 
     this.conversionQueue.on('failed', (job, error) => {
-      console.error(`❌ Job ${job.id} failed:`, error.message);
+      logger.error({ err: error, jobId: job.id }, 'Job failed');
     });
 
     this.conversionQueue.on('active', (job) => {
-      console.log(`Processing job ${job.id}: ${job.data.fileName}`);
+      logger.info(`Processing job ${job.id}: ${job.data.fileName}`);
     });
 
     this.conversionQueue.on('progress', (job, progress) => {
-      console.log(`Job ${job.id} progress: ${progress}%`);
+      logger.info(`Job ${job.id} progress: ${progress}%`);
     });
 
     this.conversionQueue.on('error', (error) => {
-      console.error('❌ Queue error:', error);
+      logger.error({ err: error }, 'Queue error');
     });
   }
 
@@ -48,7 +49,7 @@ class QueueService {
    * @param {number} concurrency - Number of jobs to process in parallel
    */
   async startProcessing(concurrency = 3) {
-    console.log(`Starting queue processor (concurrency: ${concurrency})`);
+    logger.info(`Starting queue processor (concurrency: ${concurrency})`);
 
     this.conversionQueue.process(concurrency, async (job) => {
       const { jobId, fileName } = job.data;
@@ -65,7 +66,7 @@ class QueueService {
           outputPath: result.outputPath,
         };
       } catch (error) {
-        console.error(`❌ Error processing job ${jobId}:`, error);
+        logger.error({ err: error, jobId }, 'Error processing job');
         throw error;
       }
     });
@@ -91,10 +92,10 @@ class QueueService {
         },
       );
 
-      console.log(`Job enqueued: ${fileName} (ID: ${job.id})`);
+      logger.info(`Job enqueued: ${fileName} (ID: ${job.id})`);
       return job;
     } catch (error) {
-      console.error('❌ Error enqueuing job:', error);
+      logger.error({ err: error }, 'Error enqueuing job');
       throw error;
     }
   }
@@ -118,7 +119,7 @@ class QueueService {
         total: waiting + active + completed + failed + delayed,
       };
     } catch (error) {
-      console.error('❌ Error fetching stats:', error);
+      logger.error({ err: error }, 'Error fetching stats');
       throw error;
     }
   }
@@ -133,7 +134,7 @@ class QueueService {
         timestamp: job.timestamp,
       }));
     } catch (error) {
-      console.error('❌ Error fetching active jobs:', error);
+      logger.error({ err: error }, 'Error fetching active jobs');
       throw error;
     }
   }
@@ -147,7 +148,7 @@ class QueueService {
         timestamp: job.timestamp,
       }));
     } catch (error) {
-      console.error('❌ Error fetching waiting jobs:', error);
+      logger.error({ err: error }, 'Error fetching waiting jobs');
       throw error;
     }
   }
@@ -164,7 +165,7 @@ class QueueService {
         attemptsMade: job.attemptsMade,
       }));
     } catch (error) {
-      console.error('❌ Error fetching failed jobs:', error);
+      logger.error({ err: error }, 'Error fetching failed jobs');
       throw error;
     }
   }
@@ -173,9 +174,9 @@ class QueueService {
     try {
       await this.conversionQueue.clean(grace, 'completed');
       await this.conversionQueue.clean(grace, 'failed');
-      console.log(`Cleaned jobs older than ${grace / 1000 / 60 / 60}h`);
+      logger.info(`Cleaned jobs older than ${grace / 1000 / 60 / 60}h`);
     } catch (error) {
-      console.error('❌ Error cleaning jobs:', error);
+      logger.error({ err: error }, 'Error cleaning jobs');
       throw error;
     }
   }
@@ -183,9 +184,9 @@ class QueueService {
   async emptyQueue() {
     try {
       await this.conversionQueue.empty();
-      console.log('Queue emptied');
+      logger.info('Queue emptied');
     } catch (error) {
-      console.error('❌ Error emptying queue:', error);
+      logger.error({ err: error }, 'Error emptying queue');
       throw error;
     }
   }
@@ -193,9 +194,9 @@ class QueueService {
   async pause() {
     try {
       await this.conversionQueue.pause();
-      console.log('Queue paused');
+      logger.info('Queue paused');
     } catch (error) {
-      console.error('❌ Error pausing queue:', error);
+      logger.error({ err: error }, 'Error pausing queue');
       throw error;
     }
   }
@@ -203,9 +204,9 @@ class QueueService {
   async resume() {
     try {
       await this.conversionQueue.resume();
-      console.log('Queue resumed');
+      logger.info('Queue resumed');
     } catch (error) {
-      console.error('❌ Error resuming queue:', error);
+      logger.error({ err: error }, 'Error resuming queue');
       throw error;
     }
   }
@@ -213,9 +214,9 @@ class QueueService {
   async close() {
     try {
       await this.conversionQueue.close();
-      console.log('Queue closed');
+      logger.info('Queue closed');
     } catch (error) {
-      console.error('❌ Error closing queue:', error);
+      logger.error({ err: error }, 'Error closing queue');
       throw error;
     }
   }

--- a/backend/src/services/sourceService.js
+++ b/backend/src/services/sourceService.js
@@ -3,6 +3,7 @@ import { encryptCredentials, decryptCredentials } from '../utils/encryption.js';
 import { DriveConnectorFactory } from '../integrations/base/driveConnectorFactory.js';
 import ConversionService from './conversionService.js';
 import config from '../config/env.js';
+import logger from '../config/logger.js';
 
 const prisma = getPrismaClient();
 
@@ -33,7 +34,7 @@ class SourceService {
         };
       });
     } catch (error) {
-      console.error('Error fetching sources:', error);
+      logger.error({ err: error }, 'Error fetching sources');
       throw new Error('Failed to fetch sources');
     }
   }
@@ -61,7 +62,7 @@ class SourceService {
         config: JSON.parse(source.config),
       };
     } catch (error) {
-      console.error('Error fetching source:', error);
+      logger.error({ err: error }, 'Error fetching source');
       throw error;
     }
   }
@@ -93,10 +94,10 @@ class SourceService {
         },
       });
 
-      console.log(`Source created: ${name} (${platform})`);
+      logger.info(`Source created: ${name} (${platform})`);
       return source;
     } catch (error) {
-      console.error('Error creating source:', error);
+      logger.error({ err: error }, 'Error creating source');
       throw error;
     }
   }
@@ -124,10 +125,10 @@ class SourceService {
         },
       });
 
-      console.log(`Source updated: ${source.name}`);
+      logger.info(`Source updated: ${source.name}`);
       return source;
     } catch (error) {
-      console.error('Error updating source:', error);
+      logger.error({ err: error }, 'Error updating source');
       throw error;
     }
   }
@@ -138,10 +139,10 @@ class SourceService {
         where: { id },
       });
 
-      console.log(`Source deleted: ${id}`);
+      logger.info(`Source deleted: ${id}`);
       return { success: true };
     } catch (error) {
-      console.error('Error deleting source:', error);
+      logger.error({ err: error }, 'Error deleting source');
       throw error;
     }
   }
@@ -165,11 +166,11 @@ class SourceService {
 
       const result = await connector.testConnection();
 
-      console.log(`Credentials test for ${platform}: ${result.success ? 'success' : 'failed'}`);
+      logger.info(`Credentials test for ${platform}: ${result.success ? 'success' : 'failed'}`);
 
       return result;
     } catch (error) {
-      console.error('Credentials test failed:', error);
+      logger.error({ err: error }, 'Credentials test failed');
 
       return {
         success: false,
@@ -209,7 +210,7 @@ class SourceService {
 
       return result;
     } catch (error) {
-      console.error('Connection test failed:', error);
+      logger.error({ err: error }, 'Connection test failed');
 
       await prisma.syncLog.create({
         data: {
@@ -237,7 +238,7 @@ class SourceService {
         message: 'Sync completed successfully',
       };
     } catch (error) {
-      console.error('Sync failed:', error);
+      logger.error({ err: error }, 'Sync failed');
       throw error;
     }
   }
@@ -268,7 +269,7 @@ class SourceService {
         recentJobs,
       };
     } catch (error) {
-      console.error('Error fetching stats:', error);
+      logger.error({ err: error }, 'Error fetching stats');
       throw error;
     }
   }
@@ -281,7 +282,7 @@ class SourceService {
    */
   async getGoogleDriveFolders(parentId, credentials) {
     try {
-      console.log(`Fetching Google Drive folders from parent: ${parentId}`);
+      logger.info(`Fetching Google Drive folders from parent: ${parentId}`);
 
       const config = {
         credentials: credentials,
@@ -297,10 +298,10 @@ class SourceService {
 
       await connector.cleanup();
 
-      console.log(`Found ${folders.length} folders`);
+      logger.info(`Found ${folders.length} folders`);
       return folders;
     } catch (error) {
-      console.error('Error fetching Google Drive folders:', error);
+      logger.error({ err: error }, 'Error fetching Google Drive folders');
       throw error;
     }
   }
@@ -314,7 +315,7 @@ class SourceService {
    */
   async previewGoogleDriveFiles(folderId, credentials, allowedExtensions) {
     try {
-      console.log(`Previewing files in Google Drive folder: ${folderId}`);
+      logger.info(`Previewing files in Google Drive folder: ${folderId}`);
 
       let extensionsArray;
       if (Array.isArray(allowedExtensions)) {
@@ -366,7 +367,7 @@ class SourceService {
 
       await connector.cleanup();
 
-      console.log(`Found ${filteredFiles.length} convertible files out of ${files.length} total`);
+      logger.info(`Found ${filteredFiles.length} convertible files out of ${files.length} total`);
 
       return {
         totalFiles: files.length,
@@ -380,7 +381,7 @@ class SourceService {
         })),
       };
     } catch (error) {
-      console.error('Error previewing Google Drive files:', error);
+      logger.error({ err: error }, 'Error previewing Google Drive files');
       throw error;
     }
   }
@@ -391,7 +392,7 @@ class SourceService {
     let errorCount = 0;
 
     try {
-      console.log(`Starting conversion processing for ${files.length} files`);
+      logger.info(`Starting conversion processing for ${files.length} files`);
 
       for (const file of files) {
         try {
@@ -411,21 +412,21 @@ class SourceService {
             }
           }
 
-          console.log(`Processing file: ${file.name}`);
+          logger.info(`Processing file: ${file.name}`);
 
           const tempPath = await connector.downloadFile(file.id, config.tempPath);
 
           const job = await conversionService.createJob(source.id, file.name, tempPath, file.size);
 
-          console.log(`Created conversion job for: ${file.name}`);
+          logger.info(`Created conversion job for: ${file.name}`);
 
           await conversionService.processJob(job.id);
 
           processedCount++;
-          console.log(`Successfully converted: ${file.name}`);
+          logger.info(`Successfully converted: ${file.name}`);
         } catch (error) {
           errorCount++;
-          console.error(`❌ Failed to process file ${file.name}:`, error);
+          logger.error({ err: error, fileName: file.name }, 'Failed to process file');
 
           await prisma.syncLog.create({
             data: {
@@ -457,11 +458,11 @@ class SourceService {
         },
       });
 
-      console.log(
+      logger.info(
         `Processing completed for source: ${source.name} (${processedCount}/${files.length} files converted)`,
       );
     } catch (error) {
-      console.error(`❌ Critical error during file processing for source ${source.name}:`, error);
+      logger.error({ err: error, source: source.name }, 'Critical error during file processing');
 
       await prisma.syncLog.update({
         where: { id: syncLogId },

--- a/backend/src/utils/configParser.js
+++ b/backend/src/utils/configParser.js
@@ -1,3 +1,5 @@
+import logger from '../config/logger.js';
+
 export function parseSourceConfig(source) {
   if (!source || !source.config) {
     throw new Error('Source configuration is missing');
@@ -11,7 +13,7 @@ export function parseSourceConfig(source) {
     try {
       return JSON.parse(source.config);
     } catch (error) {
-      console.error('Failed to parse source config JSON:', error);
+      logger.error({ err: error }, 'Failed to parse source config JSON');
       throw new Error(`Invalid source configuration JSON: ${error.message}`);
     }
   }
@@ -71,7 +73,7 @@ export function enrichSourceWithConfig(source) {
       config: parsedConfig,
     };
   } catch (error) {
-    console.error(`Failed to enrich source ${source.id || 'unknown'}:`, error);
+    logger.error({ err: error, sourceId: source.id }, 'Failed to enrich source');
     throw error;
   }
 }

--- a/backend/src/utils/encryption.js
+++ b/backend/src/utils/encryption.js
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import fs from 'fs';
 import config from '../config/env.js';
+import logger from '../config/logger.js';
 
 const ALGORITHM = 'aes-256-gcm';
 const IV_LENGTH = 12; // Pour GCM
@@ -23,7 +24,7 @@ export function encryptCredentials(data) {
 
     return result;
   } catch (error) {
-    console.error('Encryption failed:', error);
+    logger.error({ err: error }, 'Encryption failed');
     throw new Error('Failed to encrypt credentials');
   }
 }
@@ -51,7 +52,7 @@ export function decryptCredentials(encryptedData) {
       return decrypted;
     }
   } catch (error) {
-    console.error('Decryption failed:', error);
+    logger.error({ err: error }, 'Decryption failed');
     throw new Error('Failed to decrypt credentials');
   }
 }
@@ -72,7 +73,7 @@ export function verifyPassword(password, hashedPassword) {
     const verifyHash = crypto.pbkdf2Sync(password, salt, 10000, 64, 'sha512').toString('hex');
     return hash === verifyHash;
   } catch (error) {
-    console.error('Password verification failed:', error);
+    logger.error({ err: error }, 'Password verification failed');
     return false;
   }
 }


### PR DESCRIPTION
## Summary

- Replace `winston` with `pino` and `pino-http` for better performance and native structured JSON logging.
- Add centralized logger module at `backend/src/config/logger.js` that respects the `LOG_LEVEL` env variable.
- Convert all `console.log/error/warn` calls across 20 source files to Pino's structured API (`logger.error({ err, context }, 'message')`).
- Replace the inline Express request logger middleware with `pino-http`.

## Test plan

- [ ] Run `./start.sh` and verify the backend starts with JSON log output
- [ ] Confirm `LOG_LEVEL` env variable controls log verbosity
- [ ] Verify API requests produce structured pino-http logs
- [ ] Check error scenarios still log with full error details