### PR TITLE
feat: Add SSE real-time updates and fix monitoring status display

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -59,6 +59,7 @@ async function setupApp(): Promise<typeof app> {
     },
     standardHeaders: true,
     legacyHeaders: false,
+    skip: (req) => req.originalUrl.startsWith('/api/events'),
   });
   app.use('/api/', limiter);
 

--- a/backend/src/controllers/eventsController.ts
+++ b/backend/src/controllers/eventsController.ts
@@ -1,0 +1,43 @@
+import type { Request, Response } from 'express';
+import eventBus from '../services/eventBus.js';
+import logger from '../config/logger.js';
+
+const HEARTBEAT_MS = 25_000;
+
+class EventsController {
+  stream(req: Request, res: Response): void {
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache, no-transform');
+    res.setHeader('Connection', 'keep-alive');
+    // Disable response buffering on Nginx-like proxies so events flush immediately.
+    res.setHeader('X-Accel-Buffering', 'no');
+    res.flushHeaders();
+
+    res.write(': connected\n\n');
+
+    const unsubscribe = eventBus.onEvent((event) => {
+      res.write(`data: ${JSON.stringify(event)}\n\n`);
+    });
+
+    const heartbeat = setInterval(() => {
+      res.write(': ping\n\n');
+    }, HEARTBEAT_MS);
+
+    const cleanup = (): void => {
+      clearInterval(heartbeat);
+      unsubscribe();
+    };
+
+    req.on('close', cleanup);
+    req.on('error', (err: NodeJS.ErrnoException) => {
+      // ECONNRESET / aborted is the normal way a client ends an SSE stream
+      // (tab close, navigation, reload). Only surface unexpected errors.
+      if (err.code !== 'ECONNRESET' && err.message !== 'aborted') {
+        logger.warn({ err }, 'SSE connection error');
+      }
+      cleanup();
+    });
+  }
+}
+
+export default EventsController;

--- a/backend/src/routes/events.ts
+++ b/backend/src/routes/events.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+import EventsController from '../controllers/eventsController.js';
+
+const router = express.Router();
+const eventsController = new EventsController();
+
+router.get('/', eventsController.stream.bind(eventsController));
+
+export default router;

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -3,6 +3,7 @@ import sourcesRouter from './sources.js';
 import conversionsRouter from './conversions.js';
 import monitoringRouter from './monitoring.js';
 import authRouter from './auth.js';
+import eventsRouter from './events.js';
 
 const router = express.Router();
 
@@ -10,6 +11,7 @@ router.use('/sources', sourcesRouter);
 router.use('/conversions', conversionsRouter);
 router.use('/monitoring', monitoringRouter);
 router.use('/auth', authRouter);
+router.use('/events', eventsRouter);
 
 router.get('/health', (_req, res) => {
   res.json({
@@ -30,6 +32,7 @@ router.get('/', (_req, res) => {
       conversions: '/api/conversions',
       monitoring: '/api/monitoring',
       auth: '/api/auth',
+      events: '/api/events',
     },
     documentation: 'https://github.com/yourusername/doc2ai',
   });

--- a/backend/src/services/eventBus.ts
+++ b/backend/src/services/eventBus.ts
@@ -1,0 +1,30 @@
+import { EventEmitter } from 'node:events';
+
+export type AppEvent =
+  | { type: 'sync.started'; sourceId: string }
+  | { type: 'sync.completed'; sourceId: string; fileCount: number }
+  | { type: 'sync.failed'; sourceId: string; error: string }
+  | { type: 'source.created'; sourceId: string }
+  | { type: 'source.updated'; sourceId: string }
+  | { type: 'source.deleted'; sourceId: string };
+
+const CHANNEL = 'event';
+
+class EventBus extends EventEmitter {
+  emitEvent(event: AppEvent): void {
+    this.emit(CHANNEL, event);
+  }
+
+  onEvent(listener: (event: AppEvent) => void): () => void {
+    this.on(CHANNEL, listener);
+    return () => {
+      this.off(CHANNEL, listener);
+    };
+  }
+}
+
+const eventBus = new EventBus();
+// Each SSE client adds one listener; raise the cap to accommodate multiple tabs.
+eventBus.setMaxListeners(100);
+
+export default eventBus;

--- a/backend/src/services/monitoringService.ts
+++ b/backend/src/services/monitoringService.ts
@@ -4,6 +4,7 @@ import { eq, and, count, desc } from 'drizzle-orm';
 import { DriveConnectorFactory } from '../integrations/base/driveConnectorFactory.js';
 import ConversionService from './conversionService.js';
 import queueService from './queueService.js';
+import eventBus from './eventBus.js';
 import { decryptCredentials } from '../utils/encryption.js';
 import * as cron from 'node-cron';
 import type { ScheduledTask } from 'node-cron';
@@ -193,6 +194,7 @@ class MonitoringService {
     }
 
     this.syncInProgress.add(sourceId);
+    eventBus.emitEvent({ type: 'sync.started', sourceId });
 
     try {
       const monitor = this.activeMonitors.get(sourceId);
@@ -202,6 +204,7 @@ class MonitoringService {
       });
 
       if (!source) {
+        this.activeMonitors.delete(sourceId);
         throw new Error('Source not found');
       }
 
@@ -282,6 +285,12 @@ class MonitoringService {
         message: `Processed ${filteredFiles.length} files`,
         details: JSON.stringify({ fileCount: filteredFiles.length }),
       });
+
+      eventBus.emitEvent({
+        type: 'sync.completed',
+        sourceId,
+        fileCount: filteredFiles.length,
+      });
     } catch (error) {
       logger.error({ err: error, sourceId }, 'Sync failed for source');
 
@@ -296,6 +305,12 @@ class MonitoringService {
       } catch (dbError) {
         logger.error({ err: dbError }, 'Failed to log sync error');
       }
+
+      eventBus.emitEvent({
+        type: 'sync.failed',
+        sourceId,
+        error: (error as Error).message,
+      });
 
       throw error;
     } finally {

--- a/backend/src/services/sourceService.ts
+++ b/backend/src/services/sourceService.ts
@@ -4,6 +4,8 @@ import { eq, and, count, gte, desc } from 'drizzle-orm';
 import { encryptCredentials, decryptCredentials } from '../utils/encryption.js';
 import { DriveConnectorFactory } from '../integrations/base/driveConnectorFactory.js';
 import ConversionService from './conversionService.js';
+import monitoringService from './monitoringService.js';
+import eventBus from './eventBus.js';
 import config from '../config/env.js';
 import logger from '../config/logger.js';
 import type { Source, ParsedSource, SourceConfig, FileInfo } from '../types/domain.js';
@@ -109,7 +111,20 @@ class SourceService {
         .returning();
 
       logger.info(`Source created: ${name} (${platform})`);
-      return source as unknown as Source;
+
+      const createdSource = source as unknown as Source;
+      eventBus.emitEvent({ type: 'source.created', sourceId: createdSource.id });
+
+      void (async () => {
+        try {
+          await monitoringService.startSourceMonitoring(createdSource);
+          await monitoringService.syncSource(createdSource.id);
+        } catch (err) {
+          logger.error({ err, sourceId: createdSource.id }, 'Failed to auto-sync new source');
+        }
+      })();
+
+      return createdSource;
     } catch (error) {
       logger.error({ err: error }, 'Error creating source');
       throw error;
@@ -142,6 +157,7 @@ class SourceService {
         .returning();
 
       logger.info(`Source updated: ${source!.name}`);
+      eventBus.emitEvent({ type: 'source.updated', sourceId: id });
       return source as unknown as Source;
     } catch (error) {
       logger.error({ err: error }, 'Error updating source');
@@ -151,9 +167,11 @@ class SourceService {
 
   async deleteSource(id: string): Promise<{ success: boolean }> {
     try {
+      await monitoringService.stopSourceMonitoring(id);
       await db.delete(sources).where(eq(sources.id, id));
 
       logger.info(`Source deleted: ${id}`);
+      eventBus.emitEvent({ type: 'source.deleted', sourceId: id });
       return { success: true };
     } catch (error) {
       logger.error({ err: error }, 'Error deleting source');
@@ -236,7 +254,6 @@ class SourceService {
 
   async syncSource(id: string): Promise<{ success: boolean; message: string }> {
     try {
-      const monitoringService = (await import('./monitoringService.js')).default;
       await monitoringService.syncSource(id);
       return { success: true, message: 'Sync completed successfully' };
     } catch (error) {

--- a/frontend/src/components/dashboard/SourceCard.tsx
+++ b/frontend/src/components/dashboard/SourceCard.tsx
@@ -33,7 +33,7 @@ import {
   XCircle,
 } from 'lucide-react';
 import { useState } from 'react';
-import { useSources } from '../../hooks/useSources';
+import { useSourceActions } from '../../hooks/useSources';
 import type { Source } from '../../types/api';
 
 interface SourceCardProps {
@@ -51,7 +51,7 @@ export function SourceCard({ source, onSync, onDelete }: SourceCardProps) {
     message: string;
   } | null>(null);
 
-  const { testConnection, syncSource, deleteSource } = useSources();
+  const { testConnection, syncSource, deleteSource } = useSourceActions();
 
   const handleTestConnection = async () => {
     try {

--- a/frontend/src/components/forms/AddSourceDialog.tsx
+++ b/frontend/src/components/forms/AddSourceDialog.tsx
@@ -33,7 +33,7 @@ import GoogleDriveIconUrl from '../../assets/GoogleDrive.svg';
 import OneDriveIconUrl from '../../assets/OneDrive.svg';
 import SharePointIconUrl from '../../assets/Sharepoint.svg';
 import { useGoogleAuth } from '../../hooks/useGoogleAuth';
-import { useSources } from '../../hooks/useSources';
+import { useSourceActions } from '../../hooks/useSources';
 import type { CreateSourceRequest } from '../../types/api';
 import { GoogleAuthButton } from '../auth/GoogleAuthButton';
 import FilePreview from './FilePreview';
@@ -92,7 +92,7 @@ export function AddSourceDialog({ children, onSourceAdded }: AddSourceDialogProp
     path: string;
   } | null>(null);
 
-  const { createSource } = useSources();
+  const { createSource } = useSourceActions();
   const { user: googleUser, error: authError } = useGoogleAuth();
 
   const form = useForm<SourceFormData>({

--- a/frontend/src/hooks/useConversions.ts
+++ b/frontend/src/hooks/useConversions.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { conversionsApi, ApiError } from '../services/api';
 import type { ConversionJob, ConversionStats, PaginatedResponse } from '../types/api';
+import { useServerEvents } from './useServerEvents';
 
 export function useConversions(page = 1, limit = 20, status?: string) {
   const [data, setData] = useState<PaginatedResponse<ConversionJob> | null>(null);
@@ -88,6 +89,12 @@ export function useConversionStats() {
   useEffect(() => {
     fetchStats();
   }, [fetchStats]);
+
+  useServerEvents((event) => {
+    if (event.type === 'sync.completed') {
+      fetchStats();
+    }
+  });
 
   return {
     stats,

--- a/frontend/src/hooks/useMonitoring.ts
+++ b/frontend/src/hooks/useMonitoring.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { ApiError, monitoringApi } from '../services/api';
 import type { MonitoringStatus, SyncLog } from '../types/api';
+import { useServerEvents } from './useServerEvents';
 
 export function useMonitoring() {
   const [status, setStatus] = useState<MonitoringStatus | null>(null);
@@ -55,6 +56,12 @@ export function useMonitoring() {
   useEffect(() => {
     fetchStatus();
   }, [fetchStatus]);
+
+  useServerEvents((event) => {
+    if (event.type === 'source.created' || event.type === 'source.deleted') {
+      fetchStatus();
+    }
+  });
 
   return {
     status,

--- a/frontend/src/hooks/useServerEvents.ts
+++ b/frontend/src/hooks/useServerEvents.ts
@@ -1,0 +1,21 @@
+import { useEffect, useRef } from 'react';
+import { subscribeToEvents, type AppEvent } from '../services/eventStream';
+
+export type { AppEvent } from '../services/eventStream';
+export type AppEventType = AppEvent['type'];
+
+/**
+ * Subscribe to server-sent events from the backend.
+ *
+ * The handler is held in a ref so callers can pass inline closures without
+ * re-subscribing on every render. All hook instances share a single underlying
+ * EventSource — see `services/eventStream.ts`.
+ */
+export function useServerEvents(handler: (event: AppEvent) => void): void {
+  const handlerRef = useRef(handler);
+  handlerRef.current = handler;
+
+  useEffect(() => {
+    return subscribeToEvents((event) => handlerRef.current(event));
+  }, []);
+}

--- a/frontend/src/hooks/useSources.ts
+++ b/frontend/src/hooks/useSources.ts
@@ -1,32 +1,25 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { sourcesApi, ApiError } from '../services/api';
 import type { Source, CreateSourceRequest, SourceStats } from '../types/api';
+import { useServerEvents } from './useServerEvents';
 
-export function useSources() {
-  const [sources, setSources] = useState<Source[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+const SOURCE_REFRESH_EVENTS = new Set([
+  'sync.completed',
+  'sync.failed',
+  'source.created',
+  'source.updated',
+  'source.deleted',
+]);
 
-  const fetchSources = useCallback(async () => {
-    try {
-      setLoading(true);
-      setError(null);
-      const data = await sourcesApi.getAll();
-      setSources(data);
-    } catch (err) {
-      const errorMessage = err instanceof ApiError ? err.message : 'Failed to load sources';
-      setError(errorMessage);
-      console.error('Error fetching sources:', err);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
+/**
+ * Mutation-only hook for components that need to act on sources but don't
+ * render the full list. Doesn't fetch, doesn't subscribe to SSE — keep this
+ * as light as possible since it's used per-card.
+ */
+export function useSourceActions() {
   const createSource = useCallback(async (sourceData: CreateSourceRequest): Promise<Source> => {
     try {
-      const newSource = await sourcesApi.create(sourceData);
-      setSources((prev) => [...prev, newSource]);
-      return newSource;
+      return await sourcesApi.create(sourceData);
     } catch (err) {
       const errorMessage = err instanceof ApiError ? err.message : 'Failed to create source';
       throw new Error(errorMessage);
@@ -36,9 +29,7 @@ export function useSources() {
   const updateSource = useCallback(
     async (id: string, sourceData: Partial<CreateSourceRequest>): Promise<Source> => {
       try {
-        const updatedSource = await sourcesApi.update(id, sourceData);
-        setSources((prev) => prev.map((source) => (source.id === id ? updatedSource : source)));
-        return updatedSource;
+        return await sourcesApi.update(id, sourceData);
       } catch (err) {
         const errorMessage = err instanceof ApiError ? err.message : 'Failed to update source';
         throw new Error(errorMessage);
@@ -50,54 +41,72 @@ export function useSources() {
   const deleteSource = useCallback(async (id: string): Promise<void> => {
     try {
       await sourcesApi.delete(id);
-      setSources((prev) => prev.filter((source) => source.id !== id));
     } catch (err) {
       const errorMessage = err instanceof ApiError ? err.message : 'Failed to delete source';
       throw new Error(errorMessage);
     }
   }, []);
 
-  const testConnection = useCallback(
-    async (id: string) => {
-      try {
-        const result = await sourcesApi.testConnection(id);
-        await fetchSources();
-        return result;
-      } catch (err) {
-        const errorMessage = err instanceof ApiError ? err.message : 'Failed to test connection';
-        throw new Error(errorMessage);
-      }
-    },
-    [fetchSources],
-  );
+  const testConnection = useCallback(async (id: string) => {
+    try {
+      return await sourcesApi.testConnection(id);
+    } catch (err) {
+      const errorMessage = err instanceof ApiError ? err.message : 'Failed to test connection';
+      throw new Error(errorMessage);
+    }
+  }, []);
 
-  const syncSource = useCallback(
-    async (id: string): Promise<void> => {
-      try {
-        await sourcesApi.sync(id);
-        await fetchSources();
-      } catch (err) {
-        const errorMessage = err instanceof ApiError ? err.message : 'Failed to sync';
-        throw new Error(errorMessage);
-      }
-    },
-    [fetchSources],
-  );
+  const syncSource = useCallback(async (id: string): Promise<void> => {
+    try {
+      await sourcesApi.sync(id);
+    } catch (err) {
+      const errorMessage = err instanceof ApiError ? err.message : 'Failed to sync';
+      throw new Error(errorMessage);
+    }
+  }, []);
+
+  return { createSource, updateSource, deleteSource, testConnection, syncSource };
+}
+
+export function useSources() {
+  const [sources, setSources] = useState<Source[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const hasFetched = useRef(false);
+  const actions = useSourceActions();
+
+  const fetchSources = useCallback(async () => {
+    try {
+      if (!hasFetched.current) setLoading(true);
+      setError(null);
+      const data = await sourcesApi.getAll();
+      setSources(data);
+      hasFetched.current = true;
+    } catch (err) {
+      const errorMessage = err instanceof ApiError ? err.message : 'Failed to load sources';
+      setError(errorMessage);
+      console.error('Error fetching sources:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
     fetchSources();
   }, [fetchSources]);
+
+  useServerEvents((event) => {
+    if (SOURCE_REFRESH_EVENTS.has(event.type)) {
+      fetchSources();
+    }
+  });
 
   return {
     sources,
     loading,
     error,
     refetch: fetchSources,
-    createSource,
-    updateSource,
-    deleteSource,
-    testConnection,
-    syncSource,
+    ...actions,
   };
 }
 
@@ -124,6 +133,12 @@ export function useSourceStats() {
   useEffect(() => {
     fetchStats();
   }, [fetchStats]);
+
+  useServerEvents((event) => {
+    if (SOURCE_REFRESH_EVENTS.has(event.type)) {
+      fetchStats();
+    }
+  });
 
   return {
     stats,

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -100,13 +100,21 @@ export default function Dashboard() {
           <CardContent>
             {monitoringStatus ? (
               <>
-                <Badge variant={monitoringStatus.isRunning ? 'default' : 'secondary'}>
-                  {monitoringStatus.isRunning ? 'Active' : 'Inactive'}
+                <Badge
+                  variant={
+                    monitoringStatus.isRunning && monitoringStatus.totalActiveSources > 0
+                      ? 'default'
+                      : 'secondary'
+                  }
+                >
+                  {monitoringStatus.isRunning && monitoringStatus.totalActiveSources > 0
+                    ? 'Active'
+                    : 'Inactive'}
                 </Badge>
                 <p className="text-sm text-muted-foreground mt-2">
-                  {monitoringStatus.isRunning
+                  {monitoringStatus.isRunning && monitoringStatus.totalActiveSources > 0
                     ? `${monitoringStatus.totalActiveSources} sources monitored`
-                    : 'Monitoring stopped'}
+                    : 'No source monitored'}
                 </p>
               </>
             ) : (

--- a/frontend/src/services/eventStream.ts
+++ b/frontend/src/services/eventStream.ts
@@ -1,0 +1,65 @@
+const API_BASE_URL = import.meta.env.VITE_API_URL;
+
+export type AppEvent =
+  | { type: 'sync.started'; sourceId: string }
+  | { type: 'sync.completed'; sourceId: string; fileCount: number }
+  | { type: 'sync.failed'; sourceId: string; error: string }
+  | { type: 'source.created'; sourceId: string }
+  | { type: 'source.updated'; sourceId: string }
+  | { type: 'source.deleted'; sourceId: string };
+
+type Listener = (event: AppEvent) => void;
+
+const listeners = new Set<Listener>();
+let source: EventSource | null = null;
+
+function openConnection(): void {
+  if (source) return;
+
+  source = new EventSource(`${API_BASE_URL}/events`);
+
+  source.onmessage = (e) => {
+    let event: AppEvent;
+    try {
+      event = JSON.parse(e.data) as AppEvent;
+    } catch (err) {
+      console.error('Failed to parse SSE event', err, e.data);
+      return;
+    }
+    for (const listener of listeners) {
+      try {
+        listener(event);
+      } catch (err) {
+        console.error('SSE listener threw', err);
+      }
+    }
+  };
+
+  source.onerror = () => {
+    if (source?.readyState === EventSource.CLOSED) {
+      console.warn('SSE connection closed permanently');
+    }
+  };
+}
+
+function closeConnection(): void {
+  if (listeners.size > 0 || !source) return;
+  source.close();
+  source = null;
+}
+
+/**
+ * Subscribe to server-sent events from the backend.
+ *
+ * A single EventSource is shared across the whole app — opening one connection
+ * per hook would saturate the browser's per-origin HTTP/1.1 connection limit
+ * (~6) and stall regular fetch requests.
+ */
+export function subscribeToEvents(listener: Listener): () => void {
+  listeners.add(listener);
+  openConnection();
+  return () => {
+    listeners.delete(listener);
+    closeConnection();
+  };
+}


### PR DESCRIPTION
## Summary
- Add server-sent events infrastructure (EventBus, EventsController, `/api/events` endpoint) so frontend hooks auto-refresh on sync and CRUD events without polling
- Split `useSources` into `useSourceActions` (mutations only, used per-card) and `useSources` (list + SSE subscriptions) to avoid redundant state in leaf components
- Fix monitoring badge incorrectly showing "Active / 0 sources monitored" by gating the active state on `totalActiveSources > 0`

## Test plan
- [ ] Add a source and verify the source list updates without a page reload
- [ ] Trigger a sync and verify the conversion stats card refreshes automatically
- [ ] Delete a source and verify it disappears from the list via SSE (no manual refresh)
- [ ] Verify the system status badge shows "Inactive / No source monitored" when no sources exist, and "Active / N sources monitored" once sources are added