### PR TITLE
Prepare v0.1.0 release: version bump and end-user README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Automatically convert documents from Google Drive and SharePoint to Markdown, with continuous change monitoring.
 
+> **Note (v0.1.0)** &mdash; only **Google Drive** is functional in this release. SharePoint / OneDrive support is configured but not yet operational.
+
 ## Prerequisites
 
 - [Docker](https://www.docker.com/products/docker-desktop/) installed and running
@@ -17,7 +19,7 @@ cp .env.example .env
 Open `.env` and fill in your credentials:
 
 - **Google Drive** &mdash; `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` (create them in the [Google Cloud Console](https://console.cloud.google.com/apis/credentials))
-- **SharePoint / OneDrive** &mdash; `MICROSOFT_CLIENT_ID`, `MICROSOFT_CLIENT_SECRET`, and `MICROSOFT_TENANT_ID` (register an app in the [Azure portal](https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade))
+- **SharePoint / OneDrive** &mdash; `MICROSOFT_CLIENT_ID`, `MICROSOFT_CLIENT_SECRET`, and `MICROSOFT_TENANT_ID` (register an app in the [Azure portal](https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade)) &mdash; *not operational in v0.1.0, can be left blank*
 - **Security** &mdash; generate random values for `JWT_SECRET` and `ENCRYPTION_KEY`:
   ```bash
   openssl rand -base64 32
@@ -31,15 +33,13 @@ docker compose up -d
 
 This command builds (if needed) and starts all services (backend, frontend, Redis) in the background. The first run takes about 30 seconds while images are built; subsequent starts are nearly instant.
 
-> The `./start.sh` script is intended for development only — it performs a full no-cache rebuild and recreates the containers on every run.
-
 ### 3. Open the app
 
 Go to **http://localhost:5173** in your browser.
 
 From there you can:
 
-1. Connect a cloud drive (Google Drive or SharePoint) via OAuth
+1. Connect a Google Drive account via OAuth (SharePoint / OneDrive coming in a later release)
 2. Choose which folders to monitor and where to export the Markdown files
 3. Let the monitoring service automatically detect changes and convert new documents
 
@@ -51,7 +51,6 @@ From there you can:
 | `docker compose down` | Stop all services |
 | `docker compose logs -f` | Follow live logs |
 | `docker compose logs -f backend` | Follow backend logs only |
-| `./start.sh` | Dev-only: full no-cache rebuild and restart |
 
 ## Supported formats
 
@@ -60,22 +59,3 @@ From there you can:
 | DOCX / DOC | Markdown |
 | PDF | Markdown |
 | Google Docs | Markdown (exported then converted) |
-
-## Project structure
-
-```
-backend/          Node.js / Express API with Prisma ORM
-frontend/         React SPA (TypeScript, Vite, shadcn/ui)
-docker-compose.yml
-start.sh          One-command startup script
-.env.example      Template for environment variables
-```
-
-## API overview
-
-The backend exposes a REST API at `http://localhost:3000/api`:
-
-- **`/api/sources`** &mdash; manage connected cloud drives
-- **`/api/conversions`** &mdash; trigger and track document conversions
-- **`/api/monitoring`** &mdash; start/stop the automatic change watcher
-- **`/api/auth`** &mdash; OAuth callbacks for Google and Microsoft

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc2ai-backend",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "Doc2AI Backend API - Documentation to AI converter",
   "main": "dist/app.js",
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "doc2ai",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Bump `backend` (1.0.0 → 0.1.0) and `frontend` (0.0.0 → 0.1.0) `package.json` to align both packages on the upcoming v0.1.0 release.
- Refocus `README.md` on end users: drop contributor-only sections (project structure mentioning the removed Prisma ORM, API overview, `./start.sh` dev script).
- Add a clear v0.1.0 note that only Google Drive is operational; SharePoint / OneDrive credentials can be left blank until a later release.

## Test plan
- [x] CI passes (lint, test, build for backend and frontend)
- [x] README renders correctly on GitHub